### PR TITLE
feat(M2): implement synchronous client logic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,10 @@
         "php": ">=8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.2",
+        "mockery/mockery": "^1.6",
         "pestphp/pest": "^3.8",
-        "phpstan/phpstan": "^1.11"
+        "phpstan/phpstan": "^1.11",
+        "phpunit/phpunit": "^11.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1a63e1d01c0e850755b5c4618421e7d",
+    "content-hash": "473735248c7e6a18e547eb48033efdab",
     "packages": [],
     "packages-dev": [
         {
@@ -281,6 +281,57 @@
             "time": "2025-06-16T00:02:10+00:00"
         },
         {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
+            },
+            "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -339,6 +390,89 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
             },
             "time": "2025-03-19T14:43:43+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.6.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "reference": "1f4efdd7d3beafe9807b08156dfcb176d18f1699",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": ">=7.3"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.6.17",
+                "symplify/easy-coding-standard": "^12.1.14"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "https://github.com/padraic",
+                    "role": "Author"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "https://davedevelopment.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nathanael Esayeas",
+                    "email": "nathanael.esayeas@protonmail.com",
+                    "homepage": "https://github.com/ghostwriter",
+                    "role": "Lead Developer"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "docs": "https://docs.mockery.io/",
+                "issues": "https://github.com/mockery/mockery/issues",
+                "rss": "https://github.com/mockery/mockery/releases.atom",
+                "security": "https://github.com/mockery/mockery/security/advisories",
+                "source": "https://github.com/mockery/mockery"
+            },
+            "time": "2024-05-16T03:13:13+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/DTO/IcapRequest.php
+++ b/src/DTO/IcapRequest.php
@@ -11,8 +11,9 @@ final readonly class IcapRequest
 
     public function __construct(
         public string $method,
+        public string $uri = '/',
         array $headers = [],
-        public string $body = ''
+        public mixed $body = ''
     ) {
         $this->headers = array_map(fn($v) => (array)$v, $headers);
     }
@@ -27,6 +28,7 @@ final readonly class IcapRequest
 
         return new self(
             $this->method,
+            $this->uri,
             $headers,
             $this->body,
         );

--- a/src/Exception/IcapConnectionException.php
+++ b/src/Exception/IcapConnectionException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+use RuntimeException;
+
+class IcapConnectionException extends RuntimeException
+{
+}

--- a/src/Exception/IcapResponseException.php
+++ b/src/Exception/IcapResponseException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+use RuntimeException;
+
+class IcapResponseException extends RuntimeException
+{
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\Transport\TransportInterface;
+use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+
+class IcapClient
+{
+    public function __construct(
+        private Config $config,
+        private TransportInterface $transport,
+        private RequestFormatterInterface $formatter,
+        private ResponseParserInterface $parser
+    ) {
+    }
+
+    public static function forServer(string $host, int $port = 1344): self
+    {
+        return new self(new Config($host, $port), new SynchronousStreamTransport(), new RequestFormatter(), new ResponseParser());
+    }
+
+    public function request(IcapRequest $request): IcapResponse
+    {
+        $raw = $this->formatter->format($request);
+        $responseString = $this->transport->request($this->config, $raw);
+        return $this->parser->parse($responseString);
+    }
+
+    public function options(string $service): IcapResponse
+    {
+        $uri = sprintf('icap://%s%s', $this->config->host, $service);
+        $request = new IcapRequest('OPTIONS', $uri);
+        return $this->request($request);
+    }
+
+    public function scanFile(string $service, string $filePath): IcapResponse
+    {
+        $stream = fopen($filePath, 'r');
+        if ($stream === false) {
+            throw new \RuntimeException('Unable to open file');
+        }
+        $uri = sprintf('icap://%s%s', $this->config->host, $service);
+        $request = new IcapRequest('RESPMOD', $uri, [], $stream);
+        return $this->request($request);
+    }
+}

--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\DTO\IcapRequest;
+
+class RequestFormatter implements RequestFormatterInterface
+{
+    public function format(IcapRequest $request): string
+    {
+        $parts = parse_url($request->uri);
+        $host = $parts['host'] ?? '';
+
+        $requestLine = sprintf('%s %s ICAP/1.0', $request->method, $request->uri);
+
+        $headers = $request->headers;
+        if (!isset($headers['Host'])) {
+            $headers['Host'] = [$host];
+        }
+        if (!isset($headers['Encapsulated'])) {
+            $headers['Encapsulated'] = ['null-body=0'];
+        }
+
+        $headerLines = '';
+        foreach ($headers as $name => $values) {
+            foreach ($values as $value) {
+                $headerLines .= $name . ': ' . $value . "\r\n";
+            }
+        }
+
+        $body = '';
+        if (is_resource($request->body)) {
+            rewind($request->body);
+            while (!feof($request->body)) {
+                $chunk = fread($request->body, 8192);
+                if ($chunk === false) {
+                    break;
+                }
+                $len = dechex(strlen($chunk));
+                $body .= $len . "\r\n" . $chunk . "\r\n";
+            }
+            $body .= "0\r\n\r\n";
+        } elseif ($request->body !== '') {
+            $body = $request->body;
+        }
+
+        return $requestLine . "\r\n" . $headerLines . "\r\n" . $body;
+    }
+}

--- a/src/RequestFormatterInterface.php
+++ b/src/RequestFormatterInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\DTO\IcapRequest;
+
+interface RequestFormatterInterface
+{
+    public function format(IcapRequest $request): string;
+}

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\Exception\IcapResponseException;
+
+class ResponseParser implements ResponseParserInterface
+{
+    public function parse(string $rawResponse): IcapResponse
+    {
+        $parts = preg_split("/\r?\n\r?\n/", $rawResponse, 2);
+        if ($parts === false || count($parts) < 1) {
+            throw new IcapResponseException('Invalid ICAP response');
+        }
+        [$head, $body] = $parts + ['', ''];
+
+        $lines = preg_split('/\r?\n/', $head);
+        if ($lines === false || count($lines) === 0) {
+            throw new IcapResponseException('Invalid ICAP response');
+        }
+
+        $statusLine = array_shift($lines);
+        if (!preg_match('/ICAP\/1\.0\s+(\d+)/', (string)$statusLine, $m)) {
+            throw new IcapResponseException('Invalid status line');
+        }
+        $statusCode = (int)$m[1];
+
+        $headers = [];
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
+            }
+            [$name, $value] = explode(':', $line, 2);
+            $name = trim($name);
+            $value = trim($value);
+            $headers[$name][] = $value;
+        }
+
+        // decode chunked body if applicable
+        if ($body !== '' && preg_match('/^[0-9a-fA-F]+\r\n/i', $body)) {
+            $decoded = '';
+            while (preg_match('/^([0-9a-fA-F]+)\r\n/', $body, $mm)) {
+                $len = hexdec($mm[1]);
+                $body = substr($body, strlen($mm[0]));
+                if ($len === 0) {
+                    break;
+                }
+                $decoded .= substr($body, 0, $len);
+                $body = substr($body, $len + 2); // skip chunk and CRLF
+            }
+            $body = $decoded;
+        }
+
+        return new IcapResponse($statusCode, $headers, $body);
+    }
+}

--- a/src/ResponseParserInterface.php
+++ b/src/ResponseParserInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+
+interface ResponseParserInterface
+{
+    public function parse(string $rawResponse): IcapResponse;
+}

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Exception\IcapConnectionException;
+
+class SynchronousStreamTransport implements TransportInterface
+{
+    public function request(Config $config, string $rawRequest): string
+    {
+        $errno = 0;
+        $errstr = '';
+        $address = sprintf('tcp://%s:%d', $config->host, $config->port);
+        $stream = @stream_socket_client($address, $errno, $errstr, 5);
+        if ($stream === false) {
+            throw new IcapConnectionException($errstr ?: 'Connection failed');
+        }
+
+        fwrite($stream, $rawRequest);
+        $response = stream_get_contents($stream);
+        fclose($stream);
+
+        return $response !== false ? $response : '';
+    }
+}

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;
 
-use Ndrstmr\Icap\DTO\IcapRequest;
-use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\Config;
 
 interface TransportInterface
 {
-    public function request(IcapRequest $request): IcapResponse;
+    public function request(Config $config, string $rawRequest): string;
 }

--- a/tests/DTO/IcapRequestTest.php
+++ b/tests/DTO/IcapRequestTest.php
@@ -3,8 +3,9 @@
 use Ndrstmr\Icap\DTO\IcapRequest;
 
 it('can be instantiated and mutated immutably', function () {
-    $req = new IcapRequest('REQMOD');
-    expect($req->method)->toBe('REQMOD');
+    $req = new IcapRequest('REQMOD', 'icap://icap.example/');
+    expect($req->method)->toBe('REQMOD')
+        ->and($req->uri)->toBe('icap://icap.example/');
     $req2 = $req->withHeader('X-Test', '1');
     expect($req2)->not->toBe($req)
         ->and($req2->headers['X-Test'])->toEqual(['1']);

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+it('orchestrates dependencies when calling options()', function () {
+    $config = new Config('icap.example');
+
+    $formatter = m::mock(RequestFormatterInterface::class);
+    $transport = m::mock(TransportInterface::class);
+    $parser = m::mock(ResponseParserInterface::class);
+
+    $formatter->shouldReceive('format')
+        ->once()
+        ->withArgs(function ($req) {
+            return $req instanceof \Ndrstmr\Icap\DTO\IcapRequest && $req->method === 'OPTIONS' && str_contains($req->uri, '/service');
+        })
+        ->andReturn('RAW');
+
+    $transport->shouldReceive('request')->once()->with($config, 'RAW')->andReturn('RESP');
+    $responseObj = new IcapResponse(200);
+    $parser->shouldReceive('parse')->once()->with('RESP')->andReturn($responseObj);
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    $res = $client->options('/service');
+
+    expect($res)->toBe($responseObj);
+
+    m::close();
+});

--- a/tests/RequestFormatterTest.php
+++ b/tests/RequestFormatterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\RequestFormatter;
+
+it('formats a basic OPTIONS request', function () {
+    $req = new IcapRequest('OPTIONS', 'icap://icap.example.net/service');
+    $req = $req->withHeader('User-Agent', 'icap-flow');
+
+    $formatter = new RequestFormatter();
+
+    $expected = "OPTIONS icap://icap.example.net/service ICAP/1.0\r\n" .
+        "User-Agent: icap-flow\r\n" .
+        "Host: icap.example.net\r\n" .
+        "Encapsulated: null-body=0\r\n" .
+        "\r\n";
+
+    expect($formatter->format($req))->toBe($expected);
+});
+
+it('formats a request with stream body using chunked encoding', function () {
+    $stream = fopen('php://temp', 'r+');
+    fwrite($stream, 'hello world');
+    rewind($stream);
+
+    $req = new IcapRequest('RESPMOD', 'icap://icap.example.net/service', [], $stream);
+
+    $formatter = new RequestFormatter();
+
+    $expectedStart = "RESPMOD icap://icap.example.net/service ICAP/1.0\r\n" .
+        "Host: icap.example.net\r\n" .
+        "Encapsulated: null-body=0\r\n" .
+        "\r\n";
+    $result = $formatter->format($req);
+
+    expect($result)->toStartWith($expectedStart)
+        ->and($result)->toContain("b\r\nhello world\r\n0\r\n\r\n");
+});

--- a/tests/ResponseParserTest.php
+++ b/tests/ResponseParserTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\DTO\IcapResponse;
+
+it('parses a basic ICAP response', function () {
+    $raw = "ICAP/1.0 200 OK\r\n" .
+        "Encapsulated: null-body=0\r\n" .
+        "\r\n" .
+        "b\r\nhello world\r\n0\r\n\r\n";
+
+    $parser = new ResponseParser();
+    $res = $parser->parse($raw);
+
+    expect($res)->toBeInstanceOf(IcapResponse::class)
+        ->and($res->statusCode)->toBe(200)
+        ->and($res->headers['Encapsulated'])->toEqual(['null-body=0'])
+        ->and($res->body)->toBe('hello world');
+});

--- a/tests/Transport/SynchronousStreamTransportTest.php
+++ b/tests/Transport/SynchronousStreamTransportTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Exception\IcapConnectionException;
+use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+it('implements TransportInterface', function () {
+    $t = new SynchronousStreamTransport();
+    expect($t)->toBeInstanceOf(TransportInterface::class);
+});
+
+it('throws connection exception on failure', function () {
+    $t = new SynchronousStreamTransport();
+    $config = new Config('256.256.256.256', 9999); // invalid host
+
+    expect(fn() => $t->request($config, ""))->toThrow(IcapConnectionException::class);
+});


### PR DESCRIPTION
## Summary
- add RequestFormatter & ResponseParser with interfaces
- implement SynchronousStreamTransport
- wire everything through new IcapClient
- extend DTOs for URI handling and streaming
- add comprehensive unit tests

## Testing
- `composer test`
- `composer stan` *(fails: At least one path must be specified to analyse)*

------
https://chatgpt.com/codex/tasks/task_e_68517a291d9c832e95084f8614f8a720