### PR TITLE
Refine TransportInterface for Futures and implement Timeouts

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,18 @@ final readonly class Config
     public function __construct(
         public string $host,
         public int $port = 1344,
+        private float $socketTimeout = 10.0,
+        private float $streamTimeout = 10.0,
     ) {
+    }
+
+    public function getSocketTimeout(): float
+    {
+        return $this->socketTimeout;
+    }
+
+    public function getStreamTimeout(): float
+    {
+        return $this->streamTimeout;
     }
 }

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -31,7 +31,7 @@ class IcapClient
     public function request(IcapRequest $request): IcapResponse
     {
         $raw = $this->formatter->format($request);
-        $responseString = $this->transport->request($this->config, $raw);
+        $responseString = $this->transport->request($this->config, $raw)->await();
         return $this->parser->parse($responseString);
     }
 

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -9,7 +9,7 @@ use Ndrstmr\Icap\Exception\IcapConnectionException;
 
 class SynchronousStreamTransport implements TransportInterface
 {
-    public function request(Config $config, string $rawRequest): string
+    public function request(Config $config, string $rawRequest): \Amp\Future
     {
         $errno = 0;
         $errstr = '';
@@ -23,6 +23,6 @@ class SynchronousStreamTransport implements TransportInterface
         $response = stream_get_contents($stream);
         fclose($stream);
 
-        return $response !== false ? $response : '';
+        return \Amp\Future::complete($response !== false ? $response : '');
     }
 }

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -8,5 +8,8 @@ use Ndrstmr\Icap\Config;
 
 interface TransportInterface
 {
-    public function request(Config $config, string $rawRequest): string;
+    /**
+     * @return \Amp\Future<string>
+     */
+    public function request(Config $config, string $rawRequest): \Amp\Future;
 }

--- a/tests/AsyncTestCase.php
+++ b/tests/AsyncTestCase.php
@@ -9,6 +9,7 @@ abstract class AsyncTestCase extends TestCase
 {
     protected function runAsyncTest(callable $test): void
     {
-        EventLoop::run($test);
+        EventLoop::queue($test);
+        EventLoop::run();
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,5 +6,7 @@ test('Config can be instantiated', function () {
     $config = new Config('icap.example');
     expect($config)->toBeInstanceOf(Config::class)
         ->and($config->host)->toBe('icap.example')
-        ->and($config->port)->toBe(1344);
+        ->and($config->port)->toBe(1344)
+        ->and($config->getSocketTimeout())->toBe(10.0)
+        ->and($config->getStreamTimeout())->toBe(10.0);
 });

--- a/tests/Transport/AsyncAmpTransportTest.php
+++ b/tests/Transport/AsyncAmpTransportTest.php
@@ -18,6 +18,6 @@ it('throws connection exception on invalid host', function () {
     $config = new Config('127.0.0.1', 1); // unlikely to be open
 
     $this->runAsyncTest(function () use ($t, $config) {
-        expect(fn() => $t->request($config, ''))->toThrow(IcapConnectionException::class);
+        expect(fn() => $t->request($config, '')->await())->toThrow(IcapConnectionException::class);
     });
 });

--- a/tests/Transport/SynchronousStreamTransportTest.php
+++ b/tests/Transport/SynchronousStreamTransportTest.php
@@ -14,5 +14,5 @@ it('throws connection exception on failure', function () {
     $t = new SynchronousStreamTransport();
     $config = new Config('256.256.256.256', 9999); // invalid host
 
-    expect(fn() => $t->request($config, ""))->toThrow(IcapConnectionException::class);
+    expect(fn() => $t->request($config, "")->await())->toThrow(IcapConnectionException::class);
 });


### PR DESCRIPTION
## Summary
- adjust `TransportInterface` to return `Amp\Future`
- update `AsyncAmpTransport` to return a future and respect connection timeouts
- update `SynchronousStreamTransport` to return a resolved future
- adapt `IcapClient` to await the transport future
- extend `Config` with timeout configuration
- fix async test helper and update tests

## Testing
- `composer test`
- `composer stan` *(fails: At least one path must be specified to analyse)*
