### PR TITLE
feat(API): Introduce fully async core client and synchronous wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,33 @@ composer require ndrstmr/icap-flow
 
 ## Basic Usage
 
-(This API is currently under development and subject to change.)
+For most projects, the `SynchronousIcapClient` offers a very simple, blocking API.
 
 ```php
+$async = IcapClient::forServer('127.0.0.1', 1344);
+$icap  = new SynchronousIcapClient($async);
+
+$response = $icap->scanFile('/service', '/path/to/your/file.txt');
+
+echo 'ICAP Status: ' . $response->statusCode;
+```
+
+## Advanced Usage: Asynchronous Requests
+
+To take advantage of non-blocking I/O, interact with the `IcapClient` directly
+within an event loop:
+
+```php
+use Revolt\EventLoop;
+
 $icap = IcapClient::forServer('127.0.0.1', 1344);
 
-$response = $icap->withTimeout(10)
-                 ->scanFile('/path/to/your/file.txt');
+EventLoop::run(function () use ($icap) {
+    $future = $icap->scanFile('/service', '/path/to/your/file.txt');
+    $response = \Amp\Future\await($future);
 
-echo 'ICAP Status: ' . $response->getStatusCode();
+    echo 'ICAP Status: ' . $response->statusCode . PHP_EOL;
+});
 ```
 
 ## Contributing

--- a/examples/01-sync-scan.php
+++ b/examples/01-sync-scan.php
@@ -1,0 +1,28 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\SynchronousIcapClient;
+use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+
+$config = new Config('127.0.0.1', 1344);
+$client = new SynchronousIcapClient(new IcapClient(
+    $config,
+    new SynchronousStreamTransport(),
+    new RequestFormatter(),
+    new ResponseParser()
+));
+
+$eicarFile = __DIR__ . '/eicar.com';
+if (!file_exists($eicarFile)) {
+    file_put_contents($eicarFile, 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*');
+}
+
+echo "Scanning file $eicarFile synchronously...\n";
+$response = $client->scanFile('/service', $eicarFile);
+
+echo "ICAP Status Code: " . $response->statusCode . PHP_EOL;
+print_r($response->headers);

--- a/examples/02-async-scan.php
+++ b/examples/02-async-scan.php
@@ -23,11 +23,11 @@ EventLoop::run(function () {
         );
 
         echo "Scanning file $eicarFile asynchronously...\n";
-        $response = $client->scanFile('/service', $eicarFile);
-        
+        $future = $client->scanFile('/service', $eicarFile);
+        $response = \Amp\Future\await($future);
 
-        echo "ICAP Status Code (async): " . $response->getStatusCode() . "\n";
-        print_r($response->getHeaders());
+        echo "ICAP Status Code (async): " . $response->statusCode . "\n";
+        print_r($response->headers);
     } catch (\Exception $e) {
         echo "An error occurred: " . $e->getMessage() . "\n";
     }

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Amp\Future;
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
+
+final class SynchronousIcapClient
+{
+    private IcapClient $asyncClient;
+
+    public function __construct(IcapClient $asyncClient)
+    {
+        $this->asyncClient = $asyncClient;
+    }
+
+    public function request(IcapRequest $request): IcapResponse
+    {
+        return Future::await($this->asyncClient->request($request));
+    }
+
+    public function options(string $service): IcapResponse
+    {
+        return Future::await($this->asyncClient->options($service));
+    }
+
+    public function scanFile(string $service, string $filePath): IcapResponse
+    {
+        return Future::await($this->asyncClient->scanFile($service, $filePath));
+    }
+}

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -1,42 +1,33 @@
 <?php
 
 use Mockery as m;
-use Ndrstmr\Icap\Tests\AsyncTestCase;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\SynchronousIcapClient;
 use Ndrstmr\Icap\RequestFormatterInterface;
 use Ndrstmr\Icap\ResponseParserInterface;
 use Ndrstmr\Icap\Transport\TransportInterface;
 
-uses(AsyncTestCase::class);
-
-it('orchestrates dependencies when calling options()', function () {
+it('delegates calls to the async client and blocks for results', function () {
     $config = new Config('icap.example');
 
     $formatter = m::mock(RequestFormatterInterface::class);
     $transport = m::mock(TransportInterface::class);
     $parser = m::mock(ResponseParserInterface::class);
 
-    $formatter->shouldReceive('format')
-        ->once()
-        ->withArgs(function ($req) {
-            return $req instanceof \Ndrstmr\Icap\DTO\IcapRequest && $req->method === 'OPTIONS' && str_contains($req->uri, '/service');
-        })
-        ->andReturn('RAW');
-
+    $formatter->shouldReceive('format')->once()->andReturn('RAW');
     $transport->shouldReceive('request')->once()->with($config, 'RAW')
         ->andReturn(\Amp\Future::complete('RESP'));
     $responseObj = new IcapResponse(200);
     $parser->shouldReceive('parse')->once()->with('RESP')->andReturn($responseObj);
 
-    $client = new IcapClient($config, $transport, $formatter, $parser);
+    $async = new IcapClient($config, $transport, $formatter, $parser);
+    $client = new SynchronousIcapClient($async);
 
-    $this->runAsyncTest(function () use ($client, $responseObj) {
-        $future = $client->options('/service');
-        $res = \Amp\Future\await($future);
-        expect($res)->toBe($responseObj);
-    });
+    $res = $client->options('/service');
+
+    expect($res)->toBe($responseObj);
 
     m::close();
 });


### PR DESCRIPTION
## Summary
- refactor `IcapClient` methods to return `Future`
- add `SynchronousIcapClient` for blocking use cases
- adjust tests for asynchronous API and add tests for the wrapper
- update README with basic and advanced usage
- provide sync and async examples

## Testing
- `composer test` *(fails: `DOMDocument` not found)*
- `composer stan` *(fails: At least one path must be specified)*
