### PR TITLE
Fix import order in AsyncAmpTransport

### DIFF
--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -7,9 +7,10 @@ namespace Ndrstmr\Icap\Transport;
 use Amp\Socket; // for connect etc
 use Amp\Socket\ConnectContext;
 use Amp\TimeoutCancellation;
-use function Amp\async;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
+
+use function Amp\async;
 
 final class AsyncAmpTransport implements TransportInterface
 {


### PR DESCRIPTION
## Summary
- move `async` function import after class imports
- keep blank line between class and function imports

## Testing
- `composer cs-check`
- `composer test` *(fails: Class "DOMDocument" not found)*
