### PR TITLE
Fix arrow function spacing in tests

### DIFF
--- a/tests/Transport/AsyncAmpTransportTest.php
+++ b/tests/Transport/AsyncAmpTransportTest.php
@@ -18,6 +18,6 @@ it('throws connection exception on invalid host', function () {
     $config = new Config('127.0.0.1', 1); // unlikely to be open
 
     $this->runAsyncTest(function () use ($t, $config) {
-        expect(fn() => $t->request($config, '')->await())->toThrow(IcapConnectionException::class);
+        expect(fn () => $t->request($config, '')->await())->toThrow(IcapConnectionException::class);
     });
 });

--- a/tests/Transport/SynchronousStreamTransportTest.php
+++ b/tests/Transport/SynchronousStreamTransportTest.php
@@ -14,5 +14,5 @@ it('throws connection exception on failure', function () {
     $t = new SynchronousStreamTransport();
     $config = new Config('256.256.256.256', 9999); // invalid host
 
-    expect(fn() => $t->request($config, "")->await())->toThrow(IcapConnectionException::class);
+    expect(fn () => $t->request($config, "")->await())->toThrow(IcapConnectionException::class);
 });


### PR DESCRIPTION
## Summary
- fix arrow function spacing in tests for PSR-12 compliance
- run php-cs-fixer to verify files are clean

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.dist.php tests/Transport/AsyncAmpTransportTest.php tests/Transport/SynchronousStreamTransportTest.php`
