### PR TITLE
Add phpstan default configuration

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    paths:
+        - src
+        - tests


### PR DESCRIPTION
## Summary
- add `phpstan.neon.dist` with basic paths
- include phpstan in composer and keep `composer stan`
- ensure CI still runs `composer stan`

## Testing
- `composer install --no-interaction --prefer-dist --no-progress --ignore-platform-reqs`
- `composer stan` *(fails: No rules detected)*
- `composer test` *(fails: DOMDocument not found)*
