### PR TITLE
Add Future generic annotations and update await usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $icap = IcapClient::forServer('127.0.0.1', 1344);
 
 EventLoop::run(function () use ($icap) {
     $future = $icap->scanFile('/service', '/path/to/your/file.txt');
-    $response = \Amp\Future\await($future);
+    $response = $future->await();
 
     echo 'ICAP Status: ' . $response->statusCode . PHP_EOL;
 });

--- a/examples/02-async-scan.php
+++ b/examples/02-async-scan.php
@@ -24,7 +24,7 @@ EventLoop::run(function () {
 
         echo "Scanning file $eicarFile asynchronously...\n";
         $future = $client->scanFile('/service', $eicarFile);
-        $response = \Amp\Future\await($future);
+        $response = $future->await();
 
         echo "ICAP Status Code (async): " . $response->statusCode . "\n";
         print_r($response->headers);

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -29,18 +29,22 @@ class IcapClient
         return new self(new Config($host, $port), new SynchronousStreamTransport(), new RequestFormatter(), new ResponseParser());
     }
 
+    /**
+     * @return Future<IcapResponse>
+     */
     public function request(IcapRequest $request): Future
     {
         return \Amp\async(function () use ($request) {
             $raw = $this->formatter->format($request);
-            $responseString = \Amp\Future\await(
-                $this->transport->request($this->config, $raw)
-            );
+            $responseString = $this->transport->request($this->config, $raw)->await();
 
             return $this->parser->parse($responseString);
         });
     }
 
+    /**
+     * @return Future<IcapResponse>
+     */
     public function options(string $service): Future
     {
         $uri = sprintf('icap://%s%s', $this->config->host, $service);
@@ -48,6 +52,9 @@ class IcapClient
         return $this->request($request);
     }
 
+    /**
+     * @return Future<IcapResponse>
+     */
     public function scanFile(string $service, string $filePath): Future
     {
         $stream = fopen($filePath, 'r');

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -19,16 +19,16 @@ final class SynchronousIcapClient
 
     public function request(IcapRequest $request): IcapResponse
     {
-        return Future::await($this->asyncClient->request($request));
+        return $this->asyncClient->request($request)->await();
     }
 
     public function options(string $service): IcapResponse
     {
-        return Future::await($this->asyncClient->options($service));
+        return $this->asyncClient->options($service)->await();
     }
 
     public function scanFile(string $service, string $filePath): IcapResponse
     {
-        return Future::await($this->asyncClient->scanFile($service, $filePath));
+        return $this->asyncClient->scanFile($service, $filePath)->await();
     }
 }

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -14,6 +14,9 @@ use function Amp\async;
 
 final class AsyncAmpTransport implements TransportInterface
 {
+    /**
+     * @return \Amp\Future<string>
+     */
     public function request(Config $config, string $rawRequest): \Amp\Future
     {
         return async(function () use ($config, $rawRequest) {

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -9,6 +9,9 @@ use Ndrstmr\Icap\Exception\IcapConnectionException;
 
 class SynchronousStreamTransport implements TransportInterface
 {
+    /**
+     * @return \Amp\Future<string>
+     */
     public function request(Config $config, string $rawRequest): \Amp\Future
     {
         $errno = 0;

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -34,7 +34,7 @@ it('orchestrates dependencies when calling options()', function () {
 
     $this->runAsyncTest(function () use ($client, $responseObj) {
         $future = $client->options('/service');
-        $res = \Amp\Future\await($future);
+        $res = $future->await();
         expect($res)->toBe($responseObj);
     });
 


### PR DESCRIPTION
## Summary
- document returned `Future` types on Icap client and transports
- switch to `->await()` instead of `Future::await()`
- adjust synchronous client, example, README and tests

## Testing
- `composer test` *(fails: `pest` not found)*
- `composer stan` *(fails: `phpstan` not found)*
- `composer cs-check` *(fails: `php-cs-fixer` not found)*
