### PR TITLE
Fix chunk decoding length cast

### DIFF
--- a/src/DTO/IcapRequest.php
+++ b/src/DTO/IcapRequest.php
@@ -15,7 +15,7 @@ final readonly class IcapRequest
         array $headers = [],
         public mixed $body = ''
     ) {
-        $this->headers = array_map(fn($v) => (array)$v, $headers);
+        $this->headers = array_map(fn ($v) => (array)$v, $headers);
     }
 
     /**

--- a/src/DTO/IcapResponse.php
+++ b/src/DTO/IcapResponse.php
@@ -14,7 +14,7 @@ final readonly class IcapResponse
         array $headers = [],
         public string $body = ''
     ) {
-        $this->headers = array_map(fn($v) => (array)$v, $headers);
+        $this->headers = array_map(fn ($v) => (array)$v, $headers);
     }
 
     /**

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -48,8 +48,8 @@ class ResponseParser implements ResponseParserInterface
                 if ($len === 0) {
                     break;
                 }
-                $decoded .= substr($body, 0, $len);
-                $body = substr($body, $len + 2); // skip chunk and CRLF
+                $decoded .= substr($body, 0, (int)$len);
+                $body = substr($body, (int)$len + 2); // skip chunk and CRLF
             }
             $body = $decoded;
         }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,3 @@
 <?php
 
 // Pest initialization file
-


### PR DESCRIPTION
## Summary
- fix style issues via cs-fix
- cast chunk length to `int` before using `substr`

## Testing
- `composer install --no-interaction`
- `composer test` *(fails: UncaughtThrowable in `IcapClientTest`)*
- `composer cs-check`
- `composer stan` *(fails: Found 39 errors)*
