### PR TITLE
Fix stream check in tests

### DIFF
--- a/tests/RequestFormatterTest.php
+++ b/tests/RequestFormatterTest.php
@@ -20,6 +20,8 @@ it('formats a basic OPTIONS request', function () {
 
 it('formats a request with stream body using chunked encoding', function () {
     $stream = fopen('php://temp', 'r+');
+    expect($stream)->not->toBeFalse();
+
     fwrite($stream, 'hello world');
     rewind($stream);
 


### PR DESCRIPTION
## Summary
- ensure `fopen()` succeeded in `RequestFormatterTest`

## Testing
- `composer test` *(fails: UnhandledFutureError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851ed601918832eafa37477c8e812ad