### PR TITLE
Improve test types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ IDE files
 OS files
 .DS_Store
 Thumbs.db
+.php-cs-fixer.cache

--- a/src/DTO/IcapRequest.php
+++ b/src/DTO/IcapRequest.php
@@ -15,7 +15,7 @@ final readonly class IcapRequest
         array $headers = [],
         public mixed $body = ''
     ) {
-        $this->headers = array_map(fn($v) => (array)$v, $headers);
+        $this->headers = array_map(fn ($v) => (array)$v, $headers);
     }
 
     /**

--- a/src/DTO/IcapResponse.php
+++ b/src/DTO/IcapResponse.php
@@ -14,7 +14,7 @@ final readonly class IcapResponse
         array $headers = [],
         public string $body = ''
     ) {
-        $this->headers = array_map(fn($v) => (array)$v, $headers);
+        $this->headers = array_map(fn ($v) => (array)$v, $headers);
     }
 
     /**

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -14,8 +14,11 @@ uses(AsyncTestCase::class);
 it('orchestrates dependencies when calling options()', function () {
     $config = new Config('icap.example');
 
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
     $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
     $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
     $parser = m::mock(ResponseParserInterface::class);
 
     $formatter->shouldReceive('format')
@@ -32,6 +35,7 @@ it('orchestrates dependencies when calling options()', function () {
 
     $client = new IcapClient($config, $transport, $formatter, $parser);
 
+    /** @var \Ndrstmr\Icap\Tests\AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client, $responseObj) {
         $future = $client->options('/service');
         $res = \Amp\Future\await($future);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,4 +1,3 @@
 <?php
 
 // Pest initialization file
-

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -12,8 +12,11 @@ use Ndrstmr\Icap\Transport\TransportInterface;
 it('delegates calls to the async client and blocks for results', function () {
     $config = new Config('icap.example');
 
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
     $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
     $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
     $parser = m::mock(ResponseParserInterface::class);
 
     $formatter->shouldReceive('format')->once()->andReturn('RAW');

--- a/tests/Transport/AsyncAmpTransportTest.php
+++ b/tests/Transport/AsyncAmpTransportTest.php
@@ -17,6 +17,7 @@ it('throws connection exception on invalid host', function () {
     $t = new AsyncAmpTransport();
     $config = new Config('127.0.0.1', 1); // unlikely to be open
 
+    /** @var \Ndrstmr\Icap\Tests\AsyncTestCase $this */
     $this->runAsyncTest(function () use ($t, $config) {
         expect(fn () => $t->request($config, '')->await())->toThrow(IcapConnectionException::class);
     });


### PR DESCRIPTION
## Summary
- document mocks as `Interface&MockInterface`
- clarify `$this` type for async test wrappers
- run php-cs-fixer

## Testing
- `composer test` *(fails: Unhandled future)*
- `composer cs-check`
- `composer stan` *(fails: found 35 errors)*
