### PR TITLE
feat(API): Introduce ScanResult DTO and configurable result interpretation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ For most projects, the `SynchronousIcapClient` offers a very simple, blocking AP
 ```php
 $icap = SynchronousIcapClient::create();
 
-$response = $icap->scanFile('/service', '/path/to/your/file.txt');
+$result = $icap->scanFile('/service', '/path/to/your/file.txt');
 
-echo 'ICAP Status: ' . $response->statusCode;
+echo $result->isInfected()
+    ? 'Virus found: ' . $result->getVirusName()
+    : 'File is clean';
 ```
 
 ## Advanced Usage: Asynchronous Requests
@@ -44,9 +46,11 @@ $icap = IcapClient::create();
 
 EventLoop::run(function () use ($icap) {
     $future = $icap->scanFile('/service', '/path/to/your/file.txt');
-    $response = $future->await();
+    $result = $future->await();
 
-    echo 'ICAP Status: ' . $response->statusCode . PHP_EOL;
+    echo $result->isInfected()
+        ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+        : 'File is clean' . PHP_EOL;
 });
 ```
 
@@ -62,6 +66,8 @@ $config = new Config(
     port: 1344,
     socketTimeout: 5.0,
     streamTimeout: 30.0,
+    // Header used by the ICAP server to report infections
+    virusFoundHeader: 'X-Virus-Name',
 );
 ```
 

--- a/examples/01-sync-scan.php
+++ b/examples/01-sync-scan.php
@@ -22,7 +22,8 @@ if (!file_exists($eicarFile)) {
 }
 
 echo "Scanning file $eicarFile synchronously...\n";
-$response = $client->scanFile('/service', $eicarFile);
+$result = $client->scanFile('/service', $eicarFile);
 
-echo "ICAP Status Code: " . $response->statusCode . PHP_EOL;
-print_r($response->headers);
+echo $result->isInfected()
+    ? 'Virus found: ' . $result->getVirusName() . PHP_EOL
+    : "File is clean\n";

--- a/examples/02-async-scan.php
+++ b/examples/02-async-scan.php
@@ -24,10 +24,11 @@ EventLoop::run(function () {
 
         echo "Scanning file $eicarFile asynchronously...\n";
         $future = $client->scanFile('/service', $eicarFile);
-        $response = $future->await();
+        $result = $future->await();
 
-        echo "ICAP Status Code (async): " . $response->statusCode . "\n";
-        print_r($response->headers);
+        echo $result->isInfected()
+            ? 'Virus: ' . $result->getVirusName() . "\n"
+            : "File is clean\n";
     } catch (\Exception $e) {
         echo "An error occurred: " . $e->getMessage() . "\n";
     }

--- a/examples/cookbook/01-custom-headers.php
+++ b/examples/cookbook/01-custom-headers.php
@@ -10,6 +10,6 @@ $icap = SynchronousIcapClient::create();
 $request = (new IcapRequest('RESPMOD', 'icap://127.0.0.1/service'))
     ->withHeader('X-Client-IP', '203.0.113.5');
 
-$response = $icap->request($request);
+$result = $icap->request($request);
 
-print_r($response->headers);
+print_r($result->getOriginalResponse()->headers);

--- a/examples/cookbook/02-custom-preview-strategy.php
+++ b/examples/cookbook/02-custom-preview-strategy.php
@@ -28,6 +28,8 @@ $client = new IcapClient(
 );
 
 $future = $client->scanFileWithPreview('/service', __DIR__ . '/../eicar.com');
-$response = $future->await();
+$result = $future->await();
 
-echo 'ICAP Status: ' . $response->statusCode . PHP_EOL;
+echo $result->isInfected()
+    ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+    : 'Clean' . PHP_EOL;

--- a/examples/cookbook/03-options-request.php
+++ b/examples/cookbook/03-options-request.php
@@ -7,11 +7,14 @@ use Ndrstmr\Icap\SynchronousIcapClient;
 $icap = SynchronousIcapClient::create();
 
 // Retrieve server options to determine preview size
+
 $options = $icap->options('/service');
-$previewSize = (int)($options->headers['Preview'][0] ?? 1024);
+$previewSize = (int)($options->getOriginalResponse()->headers['Preview'][0] ?? 1024);
 
 echo "Server preview size: $previewSize\n";
 
-$response = $icap->scanFileWithPreview('/service', __DIR__ . '/../eicar.com', $previewSize);
+$result = $icap->scanFileWithPreview('/service', __DIR__ . '/../eicar.com', $previewSize);
 
-echo 'ICAP Status: ' . $response->statusCode . PHP_EOL;
+echo $result->isInfected()
+    ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+    : 'Clean' . PHP_EOL;

--- a/src/Config.php
+++ b/src/Config.php
@@ -20,6 +20,7 @@ final readonly class Config
         public int $port = 1344,
         private float $socketTimeout = 10.0,
         private float $streamTimeout = 10.0,
+        private string $virusFoundHeader = 'X-Virus-Name',
     ) {
     }
 
@@ -37,5 +38,21 @@ final readonly class Config
     public function getStreamTimeout(): float
     {
         return $this->streamTimeout;
+    }
+
+    public function withVirusFoundHeader(string $headerName): self
+    {
+        return new self(
+            $this->host,
+            $this->port,
+            $this->socketTimeout,
+            $this->streamTimeout,
+            $headerName,
+        );
+    }
+
+    public function getVirusFoundHeader(): string
+    {
+        return $this->virusFoundHeader;
     }
 }

--- a/src/DTO/ScanResult.php
+++ b/src/DTO/ScanResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\DTO;
+
+final readonly class ScanResult
+{
+    public function __construct(
+        private bool $isInfected,
+        private ?string $virusName,
+        private IcapResponse $originalResponse,
+    ) {
+    }
+
+    public function isInfected(): bool
+    {
+        return $this->isInfected;
+    }
+
+    public function getVirusName(): ?string
+    {
+        return $this->virusName;
+    }
+
+    public function getOriginalResponse(): IcapResponse
+    {
+        return $this->originalResponse;
+    }
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -172,6 +172,10 @@ class IcapClient
             return new ScanResult(false, null, $response);
         }
 
+        if ($response->statusCode === 100) {
+            return new ScanResult(false, null, $response);
+        }
+
         throw new IcapResponseException('Unexpected ICAP status: ' . $response->statusCode, $response->statusCode);
     }
 }

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -7,6 +7,8 @@ namespace Ndrstmr\Icap;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
+use Ndrstmr\Icap\Exception\IcapResponseException;
 use Ndrstmr\Icap\Transport\TransportInterface;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\Transport\AsyncAmpTransport;
@@ -67,16 +69,18 @@ class IcapClient
      * Send a raw ICAP request.
      *
      * @param IcapRequest $request
-     * @return Future<IcapResponse>
+     * @return Future<ScanResult>
      */
     public function request(IcapRequest $request): Future
     {
-        /** @var Future<IcapResponse> $future */
-        $future = \Amp\async(function () use ($request): IcapResponse {
+        /** @var Future<ScanResult> $future */
+        $future = \Amp\async(function () use ($request): ScanResult {
             $raw = $this->formatter->format($request);
             $responseString = $this->transport->request($this->config, $raw)->await();
 
-            return $this->parser->parse($responseString);
+            $response = $this->parser->parse($responseString);
+
+            return $this->interpretResponse($response, $this->config);
         });
 
         return $future;
@@ -86,7 +90,7 @@ class IcapClient
      * Issue an OPTIONS request to the given service.
      *
      * @param string $service
-     * @return Future<IcapResponse>
+     * @return Future<ScanResult>
      */
     public function options(string $service): Future
     {
@@ -100,7 +104,7 @@ class IcapClient
      *
      * @param string $service
      * @param string $filePath
-     * @return Future<IcapResponse>
+     * @return Future<ScanResult>
      * @throws \RuntimeException When the file cannot be opened
      */
     public function scanFile(string $service, string $filePath): Future
@@ -120,13 +124,13 @@ class IcapClient
      * @param string $service
      * @param string $filePath
      * @param int    $previewSize
-     * @return Future<IcapResponse>
+     * @return Future<ScanResult>
      * @throws \RuntimeException When the file cannot be read
      */
     public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future
     {
-        /** @var Future<IcapResponse> $future */
-        $future = \Amp\async(function () use ($service, $filePath, $previewSize): IcapResponse {
+        /** @var Future<ScanResult> $future */
+        $future = \Amp\async(function () use ($service, $filePath, $previewSize): ScanResult {
             $content = file_get_contents($filePath);
             if ($content === false) {
                 throw new \RuntimeException('Unable to read file');
@@ -136,9 +140,8 @@ class IcapClient
 
             $previewBody = substr($content, 0, $previewSize);
             $previewReq = new IcapRequest('RESPMOD', $uri, ['Preview' => [(string) $previewSize]], $previewBody);
-            $previewResponse = $this->request($previewReq)->await();
-
-            $decision = $this->previewStrategy->handlePreviewResponse($previewResponse);
+            $previewResult = $this->request($previewReq)->await();
+            $decision = $this->previewStrategy->handlePreviewResponse($previewResult->getOriginalResponse());
 
             if ($decision === PreviewDecision::CONTINUE_SENDING) {
                 $remaining = substr($content, $previewSize);
@@ -146,9 +149,29 @@ class IcapClient
                 return $this->request($finalReq)->await();
             }
 
-            return $previewResponse;
+            return $previewResult;
         });
 
         return $future;
+    }
+
+    private function interpretResponse(IcapResponse $response, Config $config): ScanResult
+    {
+        if ($response->statusCode === 204) {
+            return new ScanResult(false, null, $response);
+        }
+
+        if ($response->statusCode === 200) {
+            $header = $config->getVirusFoundHeader();
+            $virus = $response->headers[$header][0] ?? null;
+
+            if ($virus !== null) {
+                return new ScanResult(true, $virus, $response);
+            }
+
+            return new ScanResult(false, null, $response);
+        }
+
+        throw new IcapResponseException('Unexpected ICAP status: ' . $response->statusCode, $response->statusCode);
     }
 }

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -6,7 +6,7 @@ namespace Ndrstmr\Icap;
 
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
-use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\RequestFormatter;
@@ -47,7 +47,7 @@ final class SynchronousIcapClient
     /**
      * @param IcapRequest $request
      */
-    public function request(IcapRequest $request): IcapResponse
+    public function request(IcapRequest $request): ScanResult
     {
         return $this->asyncClient->request($request)->await();
     }
@@ -55,7 +55,7 @@ final class SynchronousIcapClient
     /**
      * @param string $service
      */
-    public function options(string $service): IcapResponse
+    public function options(string $service): ScanResult
     {
         return $this->asyncClient->options($service)->await();
     }
@@ -63,7 +63,7 @@ final class SynchronousIcapClient
     /**
      * @throws \RuntimeException
      */
-    public function scanFile(string $service, string $filePath): IcapResponse
+    public function scanFile(string $service, string $filePath): ScanResult
     {
         return $this->asyncClient->scanFile($service, $filePath)->await();
     }
@@ -71,7 +71,7 @@ final class SynchronousIcapClient
     /**
      * @throws \RuntimeException
      */
-    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): IcapResponse
+    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): ScanResult
     {
         return $this->asyncClient->scanFileWithPreview($service, $filePath, $previewSize)->await();
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,3 +10,12 @@ test('Config can be instantiated', function () {
         ->and($config->getSocketTimeout())->toBe(10.0)
         ->and($config->getStreamTimeout())->toBe(10.0);
 });
+
+test('virus header can be customized', function () {
+    $config = new Config('icap.example');
+    $new = $config->withVirusFoundHeader('X-Infection-Found');
+
+    expect($new)->not->toBe($config)
+        ->and($new->getVirusFoundHeader())->toBe('X-Infection-Found')
+        ->and($config->getVirusFoundHeader())->toBe('X-Virus-Name');
+});

--- a/tests/DTO/ScanResultTest.php
+++ b/tests/DTO/ScanResultTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
+
+it('stores infection state and original response', function () {
+    $resp = new IcapResponse(204);
+    $result = new ScanResult(false, null, $resp);
+
+    expect($result->isInfected())->toBeFalse()
+        ->and($result->getVirusName())->toBeNull()
+        ->and($result->getOriginalResponse())->toBe($resp);
+});
+
+it('can store virus name', function () {
+    $resp = new IcapResponse(200, ['X-Virus-Name' => ['EICAR']]);
+    $result = new ScanResult(true, 'EICAR', $resp);
+
+    expect($result->isInfected())->toBeTrue()
+        ->and($result->getVirusName())->toBe('EICAR')
+        ->and($result->getOriginalResponse())->toBe($resp);
+});

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -4,6 +4,7 @@ use Mockery as m;
 use Ndrstmr\Icap\Tests\AsyncTestCase;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\RequestFormatterInterface;
 use Ndrstmr\Icap\ResponseParserInterface;
@@ -49,7 +50,9 @@ it('orchestrates dependencies when calling options()', function () {
     $this->runAsyncTest(function () use ($client, $responseObj) {
         $future = $client->options('/service');
         $res = $future->await();
-        expect($res)->toBe($responseObj);
+        expect($res)->toBeInstanceOf(ScanResult::class)
+            ->and($res->getOriginalResponse())->toBe($responseObj)
+            ->and($res->isInfected())->toBeFalse();
     });
 
     m::close();
@@ -95,7 +98,9 @@ it('invokes custom preview strategy when scanning with preview', function () {
     $this->runAsyncTest(function () use ($client, $tmp, $previewResponse) {
         $future = $client->scanFileWithPreview('/service', $tmp, 1);
         $res = $future->await();
-        expect($res)->toBe($previewResponse);
+        expect($res)->toBeInstanceOf(ScanResult::class)
+            ->and($res->getOriginalResponse())->toBe($previewResponse)
+            ->and($res->isInfected())->toBeFalse();
     });
 
     unlink($tmp);
@@ -166,7 +171,8 @@ it('correctly handles abort infected preview decision', function () {
     $this->runAsyncTest(function () use ($client, $tmp, $previewResponse) {
         $future = $client->scanFileWithPreview('/service', $tmp, 1);
         $res = $future->await();
-        expect($res)->toBe($previewResponse);
+        expect($res)->toBeInstanceOf(ScanResult::class)
+            ->and($res->getOriginalResponse())->toBe($previewResponse);
     });
 
     unlink($tmp);
@@ -241,7 +247,8 @@ it('correctly handles file size equal to preview size', function () {
     $this->runAsyncTest(function () use ($client, $tmp, $previewSize, $finalRes) {
         $future = $client->scanFileWithPreview('/service', $tmp, $previewSize);
         $res = $future->await();
-        expect($res)->toBe($finalRes);
+        expect($res)->toBeInstanceOf(ScanResult::class)
+            ->and($res->getOriginalResponse())->toBe($finalRes);
     });
 
     unlink($tmp);

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -3,6 +3,7 @@
 use Mockery as m;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\SynchronousIcapClient;
 use Ndrstmr\Icap\RequestFormatterInterface;
@@ -46,7 +47,8 @@ it('delegates calls to the async client and blocks for results', function () {
 
     $res = $client->options('/service');
 
-    expect($res)->toBe($responseObj);
+    expect($res)->toBeInstanceOf(ScanResult::class)
+        ->and($res->getOriginalResponse())->toBe($responseObj);
 
     m::close();
 });
@@ -65,7 +67,8 @@ it('scanFile delegates correctly to async client', function () {
 
     $res = $client->scanFile('/service', '/tmp/file');
 
-    expect($res)->toBe($response);
+    expect($res)->toBeInstanceOf(ScanResult::class)
+        ->and($res->getOriginalResponse())->toBe($response);
 
     m::close();
 });
@@ -85,7 +88,8 @@ it('request delegates correctly to async client', function () {
 
     $res = $client->request($req);
 
-    expect($res)->toBe($response);
+    expect($res)->toBeInstanceOf(ScanResult::class)
+        ->and($res->getOriginalResponse())->toBe($response);
 
     m::close();
 });

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -57,18 +57,18 @@ it('scanFile delegates correctly to async client', function () {
     /** @var IcapClient&\Mockery\MockInterface $async */
     $async = m::mock(IcapClient::class);
     $response = new IcapResponse(201);
+    $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');
     $exp->with('/service', '/tmp/file');
     $exp->once();
-    $exp->andReturn(\Amp\Future::complete($response));
+    $exp->andReturn(\Amp\Future::complete($result));
 
     $client = new SynchronousIcapClient($async);
 
     $res = $client->scanFile('/service', '/tmp/file');
 
-    expect($res)->toBeInstanceOf(ScanResult::class)
-        ->and($res->getOriginalResponse())->toBe($response);
+    expect($res)->toBe($result);
 
     m::close();
 });
@@ -78,18 +78,18 @@ it('request delegates correctly to async client', function () {
     $async = m::mock(IcapClient::class);
     $req = new \Ndrstmr\Icap\DTO\IcapRequest('OPTIONS', 'icap://icap.example');
     $response = new IcapResponse(200);
+    $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('request');
     $exp->with($req);
     $exp->once();
-    $exp->andReturn(\Amp\Future::complete($response));
+    $exp->andReturn(\Amp\Future::complete($result));
 
     $client = new SynchronousIcapClient($async);
 
     $res = $client->request($req);
 
-    expect($res)->toBeInstanceOf(ScanResult::class)
-        ->and($res->getOriginalResponse())->toBe($response);
+    expect($res)->toBe($result);
 
     m::close();
 });


### PR DESCRIPTION
## Summary
- add `ScanResult` DTO representing final virus scan result
- make the virus-result header configurable in `Config`
- interpret ICAP responses in `IcapClient` to return `ScanResult`
- adapt `SynchronousIcapClient` and tests to new result type
- update examples and README

## Testing
- `composer stan`
- `composer cs-fix`
- `composer test` *(fails: Class "DOMDocument" not found)*
