### PR TITLE
Add PHP 8.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Compatibility with PHP 8.2. No functional changes were made.
+
 ## [1.0.0] - 2025-06-18
 ### Added
 - Initial release of the IcapFlow library.


### PR DESCRIPTION
## Summary
- note PHP 8.2 compatibility in the changelog

## Testing
- `composer test` *(fails: Class `DOMDocument` not found)*
- `composer stan`
- `composer cs-check`


