### PR TITLE
feat(v2)!: M0 foundation — exceptions, IcapClientInterface, final, PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       # Teste immer gegen mehrere PHP-Versionen
       matrix:
-        php-version: ['8.3']
+        php-version: ['8.4', '8.5']
 
     steps:
       - name: Checkout code
@@ -72,7 +72,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Wir nehmen nur den Report von der neuesten PHP-Version, da sie identisch sein sollten
-          name: coverage-report-php-8.3
+          name: coverage-report-php-8.5
 
       # Deploye den heruntergeladenen Ordner nach GitHub Pages
       - name: Deploy to GitHub Pages

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
     }
   ],
   "require": {
-    "php": ">=8.3",
-    "amphp/socket": "^2.3"
+    "php": "^8.4",
+    "amphp/socket": "^2.3",
+    "revolt/event-loop": "^1.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.75",
@@ -40,7 +41,7 @@
   "config": {
     "sort-packages": true,
     "platform": {
-      "php": "8.3.0"
+      "php": "8.4.0"
     },
     "allow-plugins": {
       "pestphp/pest-plugin": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "067529451a1200d3c978d76141552a3f",
+    "content-hash": "1b4d9f324cdba99656467f0ad06b349b",
     "packages": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9"
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
-                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
                 "shasum": ""
             },
             "require": {
@@ -77,7 +77,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.0"
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -85,7 +85,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-26T16:07:39+00:00"
+            "time": "2025-08-27T21:42:00+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -515,24 +515,27 @@
         },
         {
             "name": "amphp/serialization",
-            "version": "v1.0.0",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/serialization.git",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
-                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/fdf2834d78cebb0205fb2672676c1b1eb84371f0",
+                "reference": "fdf2834d78cebb0205fb2672676c1b1eb84371f0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^9 || ^8 || ^7"
+                "amphp/php-cs-fixer-config": "^2",
+                "ext-json": "*",
+                "ext-zlib": "*",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -567,22 +570,28 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/serialization/issues",
-                "source": "https://github.com/amphp/serialization/tree/master"
+                "source": "https://github.com/amphp/serialization/tree/v1.1.0"
             },
-            "time": "2020-03-25T21:39:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-05T15:59:53+00:00"
         },
         {
             "name": "amphp/socket",
-            "version": "v2.3.1",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/socket.git",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1"
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/socket/zipball/58e0422221825b79681b72c50c47a930be7bf1e1",
-                "reference": "58e0422221825b79681b72c50c47a930be7bf1e1",
+                "url": "https://api.github.com/repos/amphp/socket/zipball/dadb63c5d3179fd83803e29dfeac27350e619314",
+                "reference": "dadb63c5d3179fd83803e29dfeac27350e619314",
                 "shasum": ""
             },
             "require": {
@@ -591,17 +600,17 @@
                 "amphp/dns": "^2",
                 "ext-openssl": "*",
                 "kelunik/certificate": "^1.1",
-                "league/uri": "^6.5 | ^7",
-                "league/uri-interfaces": "^2.3 | ^7",
+                "league/uri": "^7",
+                "league/uri-interfaces": "^7",
                 "php": ">=8.1",
-                "revolt/event-loop": "^1 || ^0.2"
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
                 "amphp/php-cs-fixer-config": "^2",
                 "amphp/phpunit-util": "^3",
                 "amphp/process": "^2",
                 "phpunit/phpunit": "^9",
-                "psalm/phar": "5.20"
+                "psalm/phar": "6.16.1"
             },
             "type": "library",
             "autoload": {
@@ -645,7 +654,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/socket/issues",
-                "source": "https://github.com/amphp/socket/tree/v2.3.1"
+                "source": "https://github.com/amphp/socket/tree/v2.4.0"
             },
             "funding": [
                 {
@@ -653,7 +662,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-21T14:33:03+00:00"
+            "time": "2026-04-19T15:09:56+00:00"
         },
         {
             "name": "amphp/sync",
@@ -834,33 +843,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/08cf38e3924d4f56238125547b5720496fac8fd4",
+                "reference": "08cf38e3924d4f56238125547b5720496fac8fd4",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.8.1",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
+                "ext-uri": "to use the PHP native URI class",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -888,6 +902,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -900,9 +915,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -912,7 +929,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.1"
             },
             "funding": [
                 {
@@ -920,26 +937,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2026-03-15T20:22:25+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/85d5c77c5d6d3af6c54db4a78246364908f3c928",
+                "reference": "85d5c77c5d6d3af6c54db4a78246364908f3c928",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -947,6 +963,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -971,7 +988,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -996,7 +1013,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.1"
             },
             "funding": [
                 {
@@ -1004,7 +1021,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2026-03-08T20:05:35+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -1116,16 +1133,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.7",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3"
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/09bf1bf7f7f574453efe43044b06fafe12216eb3",
-                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
                 "shasum": ""
             },
             "require": {
@@ -1182,9 +1199,9 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.7"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
-            "time": "2025-01-25T19:27:39+00:00"
+            "time": "2025-08-27T21:33:23+00:00"
         }
     ],
     "packages-dev": [
@@ -1426,16 +1443,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -1487,7 +1504,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -1497,13 +1514,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1618,6 +1631,75 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
             },
             "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "ergebnis/agent-detector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/agent-detector.git",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/agent-detector/zipball/5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "reference": "5b654a9f1ff8a5d2ce6a57568df5ae8801c87f64",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0 || ~8.6.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
+                "infection/infection": "^0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a detector for detecting the presence of an agent.",
+            "homepage": "https://github.com/ergebnis/agent-detector",
+            "support": {
+                "issues": "https://github.com/ergebnis/agent-detector/issues",
+                "security": "https://github.com/ergebnis/agent-detector/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/agent-detector"
+            },
+            "time": "2026-04-10T13:45:13+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -1800,58 +1882,59 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.75.0",
+            "version": "v3.95.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c"
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/399a128ff2fdaf4281e4e79b755693286cdf325c",
-                "reference": "399a128ff2fdaf4281e4e79b755693286cdf325c",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
                 "shasum": ""
             },
             "require": {
-                "clue/ndjson-react": "^1.0",
+                "clue/ndjson-react": "^1.3",
                 "composer/semver": "^3.4",
-                "composer/xdebug-handler": "^3.0.3",
+                "composer/xdebug-handler": "^3.0.5",
+                "ergebnis/agent-detector": "^1.1.1",
                 "ext-filter": "*",
                 "ext-hash": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "fidry/cpu-core-counter": "^1.2",
+                "fidry/cpu-core-counter": "^1.3",
                 "php": "^7.4 || ^8.0",
-                "react/child-process": "^0.6.5",
-                "react/event-loop": "^1.0",
-                "react/promise": "^2.0 || ^3.0",
-                "react/socket": "^1.0",
-                "react/stream": "^1.0",
-                "sebastian/diff": "^4.0 || ^5.1 || ^6.0 || ^7.0",
-                "symfony/console": "^5.4 || ^6.4 || ^7.0",
-                "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
-                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
-                "symfony/finder": "^5.4 || ^6.4 || ^7.0",
-                "symfony/options-resolver": "^5.4 || ^6.4 || ^7.0",
-                "symfony/polyfill-mbstring": "^1.31",
-                "symfony/polyfill-php80": "^1.31",
-                "symfony/polyfill-php81": "^1.31",
-                "symfony/process": "^5.4 || ^6.4 || ^7.2",
-                "symfony/stopwatch": "^5.4 || ^6.4 || ^7.0"
+                "react/child-process": "^0.6.6",
+                "react/event-loop": "^1.5",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4",
+                "sebastian/diff": "^4.0.6 || ^5.1.1 || ^6.0.2 || ^7.0 || ^8.0",
+                "symfony/console": "^5.4.47 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/filesystem": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/finder": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/options-resolver": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.33",
+                "symfony/polyfill-php80": "^1.33",
+                "symfony/polyfill-php81": "^1.33",
+                "symfony/polyfill-php84": "^1.33",
+                "symfony/process": "^5.4.47 || ^6.4.24 || ^7.2 || ^8.0",
+                "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.6",
-                "infection/infection": "^0.29.14",
-                "justinrainbow/json-schema": "^5.3 || ^6.2",
-                "keradus/cli-executor": "^2.1",
+                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
+                "infection/infection": "^0.32.6",
+                "justinrainbow/json-schema": "^6.8.0",
+                "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
-                "php-coveralls/php-coveralls": "^2.7",
-                "php-cs-fixer/accessible-object": "^1.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.6",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.6",
-                "phpunit/phpunit": "^9.6.22 || ^10.5.45 || ^11.5.12",
-                "symfony/var-dumper": "^5.4.48 || ^6.4.18 || ^7.2.3",
-                "symfony/yaml": "^5.4.45 || ^6.4.18 || ^7.2.3"
+                "php-coveralls/php-coveralls": "^2.9.1",
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
+                "phpunit/phpunit": "^9.6.34 || ^10.5.63 || ^11.5.55",
+                "symfony/polyfill-php85": "^1.33",
+                "symfony/var-dumper": "^5.4.48 || ^6.4.32 || ^7.4.4 || ^8.0.8",
+                "symfony/yaml": "^5.4.45 || ^6.4.30 || ^7.4.1 || ^8.0.8"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -1866,7 +1949,7 @@
                     "PhpCsFixer\\": "src/"
                 },
                 "exclude-from-classmap": [
-                    "src/Fixer/Internal/*"
+                    "src/**/Internal/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1892,7 +1975,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.75.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
             },
             "funding": [
                 {
@@ -1900,7 +1983,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-31T18:40:42+00:00"
+            "time": "2026-04-12T17:00:09+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -3064,16 +3147,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.27",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162"
-            },
+            "version": "1.12.33",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/3a6e423c076ab39dfedc307e2ac627ef579db162",
-                "reference": "3a6e423c076ab39dfedc307e2ac627ef579db162",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
                 "shasum": ""
             },
             "require": {
@@ -3118,7 +3196,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-05-21T20:51:45+00:00"
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3854,16 +3932,16 @@
         },
         {
             "name": "react/child-process",
-            "version": "v0.6.6",
+            "version": "v0.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/child-process.git",
-                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159"
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/child-process/zipball/1721e2b93d89b745664353b9cfc8f155ba8a6159",
-                "reference": "1721e2b93d89b745664353b9cfc8f155ba8a6159",
+                "url": "https://api.github.com/repos/reactphp/child-process/zipball/970f0e71945556422ee4570ccbabaedc3cf04ad3",
+                "reference": "970f0e71945556422ee4570ccbabaedc3cf04ad3",
                 "shasum": ""
             },
             "require": {
@@ -3917,7 +3995,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/child-process/issues",
-                "source": "https://github.com/reactphp/child-process/tree/v0.6.6"
+                "source": "https://github.com/reactphp/child-process/tree/v0.6.7"
             },
             "funding": [
                 {
@@ -3925,20 +4003,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-01-01T16:37:48+00:00"
+            "time": "2025-12-23T15:25:20+00:00"
         },
         {
             "name": "react/dns",
-            "version": "v1.13.0",
+            "version": "v1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/dns.git",
-                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5"
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/dns/zipball/eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
-                "reference": "eb8ae001b5a455665c89c1df97f6fb682f8fb0f5",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
                 "shasum": ""
             },
             "require": {
@@ -3993,7 +4071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/dns/issues",
-                "source": "https://github.com/reactphp/dns/tree/v1.13.0"
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
             },
             "funding": [
                 {
@@ -4001,20 +4079,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-06-13T14:18:03+00:00"
+            "time": "2025-11-18T19:34:28+00:00"
         },
         {
             "name": "react/event-loop",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354"
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
-                "reference": "bbe0bd8c51ffc05ee43f1729087ed3bdf7d53354",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
                 "shasum": ""
             },
             "require": {
@@ -4065,7 +4143,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/event-loop/issues",
-                "source": "https://github.com/reactphp/event-loop/tree/v1.5.0"
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
             },
             "funding": [
                 {
@@ -4073,27 +4151,27 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-11-13T13:48:05+00:00"
+            "time": "2025-11-17T20:46:25+00:00"
         },
         {
             "name": "react/promise",
-            "version": "v3.2.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise.git",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63"
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/8a164643313c71354582dc850b42b33fa12a4b63",
-                "reference": "8a164643313c71354582dc850b42b33fa12a4b63",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "1.10.39 || 1.4.10",
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
                 "phpunit/phpunit": "^9.6 || ^7.5"
             },
             "type": "library",
@@ -4138,7 +4216,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v3.2.0"
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4146,20 +4224,20 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-05-24T10:39:05+00:00"
+            "time": "2025-08-19T18:57:03+00:00"
         },
         {
             "name": "react/socket",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/socket.git",
-                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1"
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket/zipball/23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
-                "reference": "23e4ff33ea3e160d2d1f59a0e6050e4b0fb0eac1",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
                 "shasum": ""
             },
             "require": {
@@ -4218,7 +4296,7 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/socket/issues",
-                "source": "https://github.com/reactphp/socket/tree/v1.16.0"
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
             },
             "funding": [
                 {
@@ -4226,7 +4304,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-07-26T10:38:09+00:00"
+            "time": "2025-11-19T20:47:34+00:00"
         },
         {
             "name": "react/stream",
@@ -5346,47 +5424,39 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707"
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
-                "reference": "1e92e39c51f95b88e3d66fa2d9f06d1fb45dd707",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5b66d385dc58f69652e56f78a4184615e3f2b7f7",
+                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5420,7 +5490,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.8"
+                "source": "https://github.com/symfony/console/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5440,7 +5510,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T13:54:39+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5511,24 +5581,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.3.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
+                "reference": "f662acc6ab22a3d6d716dcb44c381c6002940df6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
-                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f662acc6ab22a3d6d716dcb44c381c6002940df6",
+                "reference": "f662acc6ab22a3d6d716dcb44c381c6002940df6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -5537,13 +5607,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/error-handler": "^6.4|^7.0",
-                "symfony/expression-language": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5571,7 +5642,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5583,11 +5654,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-22T09:11:45+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5667,25 +5742,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.3.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^6.4|^7.0"
+                "symfony/process": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5713,7 +5788,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5725,31 +5800,35 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:15:23+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "8da41214757b87d97f181e3d14a4179286151007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
+                "reference": "8da41214757b87d97f181e3d14a4179286151007",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -5777,7 +5856,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5797,24 +5876,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.3.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "afb9a8038025e5dbc657378bfab9198d75f10fca"
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/afb9a8038025e5dbc657378bfab9198d75f10fca",
-                "reference": "afb9a8038025e5dbc657378bfab9198d75f10fca",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b48bce0a70b914f6953dafbd10474df232ed4de8",
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -5848,7 +5927,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.3.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -5860,11 +5939,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-04T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -6287,7 +6370,7 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.32.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -6343,7 +6426,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -6355,6 +6438,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -6362,21 +6449,101 @@
             "time": "2024-09-09T11:45:10+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v7.4.8",
+            "name": "symfony/polyfill-php84",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "reference": "cb8939aff03470d1a9d1d1b66d08c6fa71b3bbdc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -6404,7 +6571,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6424,7 +6591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6515,20 +6682,20 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.3.0",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd"
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
-                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -6557,7 +6724,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.3.0"
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6569,43 +6736,46 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-24T10:49:57+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6644,7 +6814,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -6664,7 +6834,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -6844,11 +7014,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3"
+        "php": "^8.4"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3.0"
+        "php": "8.4.0"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/docs/review/consolidated_task-list.md
+++ b/docs/review/consolidated_task-list.md
@@ -1,0 +1,177 @@
+# Konsolidierte Task-Liste — v2.0.0 RFC-Compliance & Hardening
+
+**Ziel:** `ndrstmr/icap-flow` zum quasi-Standard PHP-ICAP-Client ausbauen — RFC-3507-konform, fail-secure, streaming-sicher, Symfony-ready.
+
+**Basis:** Synthese der drei unabhängigen Due-Diligence-Reviews in `docs/review/` (Claude, Codex, Jules), verifiziert am aktuellen `src/`-Stand bei commit `ec16785`.
+
+**Strategie:** v1.0.0 wird **deprecated**. Die erforderlichen Wire-Format-Fixes sind per Definition breaking → **v2.0.0** direkt.
+
+**Vorgehen:** Test-driven. Pro Finding ein roter Test (Regression-Dokument), dann Minimal-Implementation, dann Refactor. Ein PR pro Milestone.
+
+**Reihenfolge:** M0 → M1 → M2 → M3 → M4 → M5 → (danach: separates Repo `icap-flow-bundle`).
+
+---
+
+## Verifizierte Findings
+
+| ID | Finding | Schweregrad | Code-Nachweis | Quelle |
+|---|---|---|---|---|
+| A | `Encapsulated`-Header hardcoded `null-body=0` | RFC-Blocker | `RequestFormatter.php:28-30` | Claude, Codex, Jules |
+| B | Keine HTTP-in-ICAP-Kapselung (`req-hdr`/`res-hdr` fehlen) | RFC-Blocker | `RequestFormatter.php:17-55` | Claude, Jules |
+| C | String-Body nicht chunked encoded | RFC-Blocker | `RequestFormatter.php:51-53` | Claude, Jules |
+| D | Kein `; ieof`-Terminator im Preview-Flow | RFC-Blocker | `RequestFormatter.php:50` | Claude, Codex, Jules |
+| E | `scanFileWithPreview` lädt komplette Datei in RAM | OOM / Streaming-Regression | `IcapClient.php:134` | alle |
+| F | `ResponseParser` wertet `Encapsulated`-Header nicht aus | RFC-Blocker | `ResponseParser.php:40-49` | Claude, Codex |
+| **G** | **Fail-Open: Status 100 → `ScanResult(isInfected=false)`** | **Security-Critical** | `IcapClient.php:175-177` | Claude |
+| H | CRLF-Injection via `$service` | Security | `IcapClient.php:97,116,139` | Claude |
+| I | `SynchronousStreamTransport`: hardcoded 5s, kein `finally`, kein Length-Limit | Resource-Leak / DoS | `SynchronousStreamTransport.php:23-30` | Claude, Codex |
+| J | Kein TLS (`icaps://`) | Security | `AsyncAmpTransport.php:28` | alle |
+| K | Test zementiert Bug A | Test-Qualität | `tests/RequestFormatterTest.php:35-43` | Claude |
+| L | Kein `Allow: 204`-Header | RFC-Optimierung | grep leer | Codex, Jules |
+| M | Status-Code-Matrix lückenhaft (206, 400, 403, 500, 503) | RFC / Security | `IcapClient.php:158-180` | alle |
+| N | Parser ohne Max-Header-Size/Count | DoS | `ResponseParser.php:40-49` | Claude, Codex |
+
+---
+
+## Milestone M0 — Fundament
+
+**Aufwand:** 1–2 PT
+**PR:** `chore(v2): exception hierarchy, interfaces, final`
+
+- [ ] **M0.1** Exception-Hierarchie
+  - `IcapExceptionInterface` (Marker)
+  - `IcapProtocolException extends RuntimeException implements IcapExceptionInterface`
+  - `IcapTimeoutException`
+  - `IcapClientException` (4xx)
+  - `IcapServerException` (5xx)
+  - `IcapMalformedResponseException extends IcapProtocolException`
+  - Bestehende `IcapConnectionException`, `IcapResponseException` implementieren das Marker-Interface
+- [ ] **M0.2** `IcapClientInterface` extrahieren, `IcapClient` implementiert sie
+- [ ] **M0.3** `final` setzen: `IcapClient`, `RequestFormatter`, `ResponseParser`, `DefaultPreviewStrategy`, `SynchronousStreamTransport`
+- [ ] **M0.4** `#[\Override]`-Attribute an Interface-Implementierungen
+- [ ] **M0.5** `revolt/event-loop` explizit in `composer.json:require`
+- [ ] **M0.6** Baseline-Tests grün halten, PHPStan L9 clean
+
+---
+
+## Milestone M1 — RFC-3507-Korrektheit
+
+**Aufwand:** 3–4 PT
+**PR:** `feat(v2): RFC 3507 wire format (encapsulated, chunked, ieof)`
+**Findings:** A, B, C, D, E, F, K, L
+
+- [ ] **M1.1** Neue DTOs `HttpRequest` / `HttpResponse` (method/uri/headers/body) als Encapsulated-Payload-Träger
+- [ ] **M1.2** `IcapRequest` erweitern: `?HttpRequest $encapsulatedRequest`, `?HttpResponse $encapsulatedResponse` — `mixed $body` entfernen
+- [ ] **M1.3** `RequestFormatter` neu schreiben:
+  - Encapsulated-Offsets **berechnen** (`req-hdr=0, req-body=N` usw.)
+  - String-UND-Stream-Body chunked encoden
+  - `; ieof` bei Preview-Complete-Szenario (Dateigröße ≤ Preview)
+  - Streaming-Interface: gibt Iterable/Generator (Chunks) zurück — kein großer String mehr
+- [ ] **M1.4** `TransportInterface` erweitern: akzeptiert Iterable<string> für Request, streamt auf Socket
+- [ ] **M1.5** `Allow: 204` default im Preview-Flow
+- [ ] **M1.6** `ResponseParser` Encapsulated-aware: trennt ICAP-Header / HTTP-Header / HTTP-Body
+- [ ] **M1.7** `scanFileWithPreview` streaming-basiert (OOM-Fix, E)
+- [ ] **M1.8** Tests komplett neu: `tests/RequestFormatterTest.php` ersetzen; neue Fixtures aus echten c-icap-Wire-Bytes (EICAR, saubere Dateien, Preview-Continue, Preview-Complete-mit-`ieof`)
+- [ ] **M1.9** Bug-zementierender Test K zuerst red → dann green mit korrektem Wire-Format
+
+---
+
+## Milestone M2 — Security-Härtung
+
+**Aufwand:** 2 PT
+**PR:** `feat(v2): fail-secure, TLS, DoS limits, status matrix`
+**Findings:** G, H, I, J, M, N
+
+- [ ] **M2.1** **Fix Fail-Open G:** Status 100 außerhalb Preview-Flow ist `IcapProtocolException`, nicht "clean". Expliziter Regression-Test (Security-Gate).
+- [ ] **M2.2** URI-/Service-Validation gegen CRLF-Injection (RFC 3507 §7.3)
+- [ ] **M2.3** `Config` erweitern: `tlsContext`, `maxResponseSize` (default 10 MB), `maxHeaderCount` (100), `maxHeaderLineLength` (8 KB)
+- [ ] **M2.4** `AsyncAmpTransport` TLS via `Socket\connectTls()` bei `icaps://`-Schema (RFC 3507 verwendet Port 11344 für TLS de-facto)
+- [ ] **M2.5** `SynchronousStreamTransport` fix: `$config->getSocketTimeout()`/`getStreamTimeout()` nutzen, `finally { fclose() }`, `stream_set_timeout()`, Read-Length-Limit
+- [ ] **M2.6** Parser-Limits durchsetzen (N)
+- [ ] **M2.7** Status-Code-Matrix:
+  - 100 nur im Preview-Context legitim
+  - 204 clean
+  - 200 mit `X-Virus-Name`/Vendor-Header prüfen
+  - 206 Partial Content
+  - 403 → je nach Vendor-Profil als "virus found" interpretierbar
+  - 4xx → `IcapClientException` mit vollem Response-Kontext
+  - 5xx → `IcapServerException` (503-Retry-fähig)
+
+---
+
+## Milestone M3 — Ökosystem-Fit
+
+**Aufwand:** 2 PT
+**PR:** `feat(v2): logger, cancellation, OPTIONS cache, pooling, multi-vendor`
+
+- [ ] **M3.1** PSR-3 `LoggerInterface` optional injizierbar (Connect, Scan-Start, Scan-Result, Timeout als strukturierte Log-Events)
+- [ ] **M3.2** `Cancellation` in Public-API von `IcapClient::scanFile` / `request` durchreichen
+- [ ] **M3.3** OPTIONS-Response-Cache (PSR-16 optional, TTL aus `Options-TTL`, Key host:port/service)
+- [ ] **M3.4** `Config::maxConnections` + einfaches Keep-Alive-Pooling in `AsyncAmpTransport`
+- [ ] **M3.5** `Config::virusFoundHeaders: array<string>` (Multi-Vendor: `X-Virus-Name`, `X-Infection-Found`, `X-Violations-Found`)
+- [ ] **M3.6** Custom-Request-Header-Support (`X-Client-IP`, `X-Authenticated-User`) über `IcapRequest`
+- [ ] **M3.7** Retry-Policy mit Exponential-Backoff für 503
+
+---
+
+## Milestone M4 — Test-Infrastruktur
+
+**Aufwand:** 2 PT
+**PR:** `test(v2): integration suite, coverage/mutation gates, PHP 8.4 matrix`
+
+- [ ] **M4.1** `docker-compose.yml` (Projektroot): c-icap + ClamAV-Service + optional Squid
+- [ ] **M4.2** `tests/Integration/`: EICAR-Testfile, clean file, preview-continue, preview-complete, 200-with-virus, 503-retry
+- [ ] **M4.3** CI-Workflow erweitern: Integration-Job mit Docker-Compose-Services, Matrix `['8.3', '8.4']`
+- [ ] **M4.4** `phpunit.xml.dist`: Coverage-Threshold (`enforceCheckCoverage`, `min-lines=90`, `min-branches=85`)
+- [ ] **M4.5** `infection/infection` installieren, MSI-Gate ≥ 70 %
+- [ ] **M4.6** PHPStan `^1.11` → `^2.1`
+- [ ] **M4.7** `roave/security-advisories` in dev-deps (dev-master)
+- [ ] **M4.8** `phpbench/phpbench` für Throughput-Benchmarks (Baseline für zukünftige Regressionen)
+
+---
+
+## Milestone M5 — Governance & Doku
+
+**Aufwand:** 1 PT
+**PR:** `docs(v2): SECURITY.md, SPDX headers, migration guide, DE README`
+
+- [ ] **M5.1** `SECURITY.md` (Disclosure-Prozess, contact)
+- [ ] **M5.2** SPDX-Header (`SPDX-License-Identifier: EUPL-1.2`) via `.php-cs-fixer.dist.php`-Regel in allen `src/`- und `tests/`-Dateien
+- [ ] **M5.3** `README.md` ehrlich machen: Versprechen aus `docs/agent.md` entweder einlösen oder dort streichen
+- [ ] **M5.4** `README.de.md` — deutsche Fassung für Public-Sector-Adoption
+- [ ] **M5.5** `docs/migration-v1-to-v2.md` — Breaking-Change-Guide
+- [ ] **M5.6** `CHANGELOG.md` v2.0.0-Entry
+- [ ] **M5.7** Cookbook-Fix: `examples/cookbook/02-custom-preview-strategy.php:16` — 304 ist kein ICAP-Status
+- [ ] **M5.8** v2.0.0-Tag
+
+---
+
+## Post-v2.0.0 — Separates Repo `icap-flow-bundle`
+
+**Nicht Teil dieser PR-Serie. Start nach Release v2.0.0.**
+
+- Symfony DI-Extension, Autowiring
+- Monolog-Channel `icap`
+- Console-Commands `icap:options`, `icap:scan`, `icap:health`
+- Symfony Profiler DataCollector
+- Messenger-Handler für async Upload-Scanning
+- Validator-Constraint `#[IcapClean]`
+- VichUploader-/OneupUploader-Adapter
+
+---
+
+## Gesamt-Aufwand v2.0.0 Core
+
+**~10–12 PT** für einen Entwickler (M0–M5), ohne Bundle.
+
+## Definition of Done v2.0.0
+
+- [ ] Alle P0-Findings A–N geschlossen mit Regression-Test
+- [ ] Coverage ≥ 90 % Lines, ≥ 85 % Branches
+- [ ] Infection MSI ≥ 70 %
+- [ ] Integration-Tests grün gegen c-icap + ClamAV (EICAR + Clean)
+- [ ] CI-Matrix PHP 8.3 + 8.4 grün
+- [ ] PHPStan Level 9 clean
+- [ ] `composer audit` clean (Runtime + Dev)
+- [ ] Migration-Guide + deutsche README publiziert
+- [ ] SECURITY.md + SPDX-Header

--- a/src/DefaultPreviewStrategy.php
+++ b/src/DefaultPreviewStrategy.php
@@ -10,11 +10,12 @@ use Ndrstmr\Icap\Exception\IcapResponseException;
 /**
  * Default strategy for interpreting preview responses.
  */
-class DefaultPreviewStrategy implements PreviewStrategyInterface
+final class DefaultPreviewStrategy implements PreviewStrategyInterface
 {
     /**
      * Decide whether to continue sending the body after a preview response.
      */
+    #[\Override]
     public function handlePreviewResponse(IcapResponse $previewResponse): PreviewDecision
     {
         return match ($previewResponse->statusCode) {

--- a/src/Exception/IcapClientException.php
+++ b/src/Exception/IcapClientException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * The ICAP server returned a 4xx response indicating the request was
+ * rejected as malformed, unauthorised, or otherwise the client's fault.
+ */
+final class IcapClientException extends \RuntimeException implements IcapExceptionInterface
+{
+}

--- a/src/Exception/IcapConnectionException.php
+++ b/src/Exception/IcapConnectionException.php
@@ -9,6 +9,6 @@ use RuntimeException;
 /**
  * Thrown when a connection to the ICAP server cannot be established.
  */
-class IcapConnectionException extends RuntimeException
+final class IcapConnectionException extends RuntimeException implements IcapExceptionInterface
 {
 }

--- a/src/Exception/IcapExceptionInterface.php
+++ b/src/Exception/IcapExceptionInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * Marker interface implemented by every exception thrown from the ICAP client.
+ *
+ * Catching this interface is the supported way to handle any failure that
+ * originates in the library without accidentally catching unrelated
+ * RuntimeExceptions from user code.
+ */
+interface IcapExceptionInterface extends \Throwable
+{
+}

--- a/src/Exception/IcapMalformedResponseException.php
+++ b/src/Exception/IcapMalformedResponseException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * The raw bytes received from the ICAP server could not be parsed into a
+ * valid IcapResponse (invalid status line, oversized headers, truncated
+ * body, etc.).
+ */
+final class IcapMalformedResponseException extends IcapProtocolException
+{
+}

--- a/src/Exception/IcapProtocolException.php
+++ b/src/Exception/IcapProtocolException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * Signals a violation of the ICAP wire protocol (RFC 3507) — malformed
+ * messages, unexpected sequencing (e.g. 100 Continue outside preview),
+ * or missing mandatory headers.
+ */
+class IcapProtocolException extends \RuntimeException implements IcapExceptionInterface
+{
+}

--- a/src/Exception/IcapResponseException.php
+++ b/src/Exception/IcapResponseException.php
@@ -8,7 +8,13 @@ use RuntimeException;
 
 /**
  * Thrown when an invalid or unexpected ICAP response is encountered.
+ *
+ * @deprecated since 2.0 — use the more specific IcapProtocolException,
+ *   IcapMalformedResponseException, IcapClientException (4xx) or
+ *   IcapServerException (5xx) introduced by M0.1. This class will be
+ *   removed in a future minor release once all internal throw sites are
+ *   migrated (M2).
  */
-class IcapResponseException extends RuntimeException
+class IcapResponseException extends RuntimeException implements IcapExceptionInterface
 {
 }

--- a/src/Exception/IcapServerException.php
+++ b/src/Exception/IcapServerException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * The ICAP server returned a 5xx response (service unavailable, internal
+ * error, overloaded). Callers may choose to retry with backoff.
+ */
+final class IcapServerException extends \RuntimeException implements IcapExceptionInterface
+{
+}

--- a/src/Exception/IcapTimeoutException.php
+++ b/src/Exception/IcapTimeoutException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Exception;
+
+/**
+ * A connect, read, or write timeout elapsed before the ICAP transaction
+ * completed.
+ */
+final class IcapTimeoutException extends \RuntimeException implements IcapExceptionInterface
+{
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -22,7 +22,7 @@ use Ndrstmr\Icap\DefaultPreviewStrategy;
 /**
  * Core asynchronous ICAP client used by the synchronous wrapper.
  */
-class IcapClient
+final class IcapClient implements IcapClientInterface
 {
     /**
      * @param Config                       $config          Connection configuration
@@ -71,6 +71,7 @@ class IcapClient
      * @param IcapRequest $request
      * @return Future<ScanResult>
      */
+    #[\Override]
     public function request(IcapRequest $request): Future
     {
         /** @var Future<ScanResult> $future */
@@ -92,6 +93,7 @@ class IcapClient
      * @param string $service
      * @return Future<ScanResult>
      */
+    #[\Override]
     public function options(string $service): Future
     {
         $uri = sprintf('icap://%s%s', $this->config->host, $service);
@@ -107,6 +109,7 @@ class IcapClient
      * @return Future<ScanResult>
      * @throws \RuntimeException When the file cannot be opened
      */
+    #[\Override]
     public function scanFile(string $service, string $filePath): Future
     {
         $stream = fopen($filePath, 'r');
@@ -127,6 +130,7 @@ class IcapClient
      * @return Future<ScanResult>
      * @throws \RuntimeException When the file cannot be read
      */
+    #[\Override]
     public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future
     {
         /** @var Future<ScanResult> $future */

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Amp\Future;
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\ScanResult;
+
+/**
+ * Public contract for ICAP clients.
+ *
+ * Implementations are async-native and return Amp Futures. The synchronous
+ * decorator {@see SynchronousIcapClient} awaits those Futures behind a
+ * blocking facade.
+ */
+interface IcapClientInterface
+{
+    /**
+     * Send a raw ICAP request.
+     *
+     * @return Future<ScanResult>
+     */
+    public function request(IcapRequest $request): Future;
+
+    /**
+     * Issue an OPTIONS request against the given service.
+     *
+     * @return Future<ScanResult>
+     */
+    public function options(string $service): Future;
+
+    /**
+     * Scan a local file via RESPMOD.
+     *
+     * @return Future<ScanResult>
+     */
+    public function scanFile(string $service, string $filePath): Future;
+
+    /**
+     * Scan a file using preview mode, streaming the remainder on demand.
+     *
+     * @return Future<ScanResult>
+     */
+    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future;
+}

--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -9,11 +9,12 @@ use Ndrstmr\Icap\DTO\IcapRequest;
 /**
  * Default implementation converting an {@link IcapRequest} into a raw string.
  */
-class RequestFormatter implements RequestFormatterInterface
+final class RequestFormatter implements RequestFormatterInterface
 {
     /**
      * @param IcapRequest $request
      */
+    #[\Override]
     public function format(IcapRequest $request): string
     {
         $parts = parse_url($request->uri);

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -11,13 +11,14 @@ use Ndrstmr\Icap\Exception\IcapResponseException;
  * Parses raw ICAP responses into IcapResponse objects.
  */
 
-class ResponseParser implements ResponseParserInterface
+final class ResponseParser implements ResponseParserInterface
 {
     /**
      * @param string $rawResponse
      *
      * @throws IcapResponseException
      */
+    #[\Override]
     public function parse(string $rawResponse): IcapResponse
     {
         $parts = preg_split("/\r?\n\r?\n/", $rawResponse, 2);

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -18,12 +18,12 @@ use Ndrstmr\Icap\DefaultPreviewStrategy;
  */
 final class SynchronousIcapClient
 {
-    private IcapClient $asyncClient;
+    private IcapClientInterface $asyncClient;
 
     /**
-     * @param IcapClient $asyncClient Underlying asynchronous client
+     * @param IcapClientInterface $asyncClient Underlying asynchronous client
      */
-    public function __construct(IcapClient $asyncClient)
+    public function __construct(IcapClientInterface $asyncClient)
     {
         $this->asyncClient = $asyncClient;
     }

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -20,6 +20,7 @@ final class AsyncAmpTransport implements TransportInterface
     /**
      * @return \Amp\Future<string>
      */
+    #[\Override]
     public function request(Config $config, string $rawRequest): \Amp\Future
     {
         /** @var \Amp\Future<string> $future */

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -10,11 +10,12 @@ use Ndrstmr\Icap\Exception\IcapConnectionException;
 /**
  * Simple blocking transport using PHP stream sockets.
  */
-class SynchronousStreamTransport implements TransportInterface
+final class SynchronousStreamTransport implements TransportInterface
 {
     /**
      * @return \Amp\Future<string>
      */
+    #[\Override]
     public function request(Config $config, string $rawRequest): \Amp\Future
     {
         $errno = 0;

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Ndrstmr\Icap\Exception\IcapClientException;
+use Ndrstmr\Icap\Exception\IcapConnectionException;
+use Ndrstmr\Icap\Exception\IcapExceptionInterface;
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
+use Ndrstmr\Icap\Exception\IcapProtocolException;
+use Ndrstmr\Icap\Exception\IcapResponseException;
+use Ndrstmr\Icap\Exception\IcapServerException;
+use Ndrstmr\Icap\Exception\IcapTimeoutException;
+
+it('catches every concrete ICAP exception via the marker interface', function () {
+    $exceptions = [
+        new IcapConnectionException('conn'),
+        new IcapResponseException('resp'),
+        new IcapProtocolException('proto'),
+        new IcapTimeoutException('to'),
+        new IcapClientException('4xx', 400),
+        new IcapServerException('5xx', 503),
+        new IcapMalformedResponseException('bad bytes'),
+    ];
+
+    foreach ($exceptions as $e) {
+        $caught = false;
+        try {
+            throw $e;
+        } catch (IcapExceptionInterface) {
+            $caught = true;
+        }
+        expect($caught)->toBeTrue($e::class . ' should be catchable as IcapExceptionInterface');
+        expect($e)->toBeInstanceOf(\RuntimeException::class);
+    }
+});
+
+it('places malformed responses under the protocol exception', function () {
+    expect(fn () => throw new IcapMalformedResponseException('invalid status line'))
+        ->toThrow(IcapProtocolException::class, 'invalid status line');
+});
+
+it('distinguishes 4xx client errors from 5xx server errors', function () {
+    $client = new IcapClientException('bad request', 400);
+    $server = new IcapServerException('service unavailable', 503);
+
+    expect($client->getCode())->toBe(400)
+        ->and($server->getCode())->toBe(503)
+        ->and($client)->toBeInstanceOf(IcapExceptionInterface::class)
+        ->and($server)->toBeInstanceOf(IcapExceptionInterface::class);
+
+    // 4xx must NOT be catchable as 5xx.
+    expect(fn () => throw $client)->toThrow(IcapClientException::class);
+    expect($client)->not->toBeInstanceOf(IcapServerException::class);
+    expect($server)->not->toBeInstanceOf(IcapClientException::class);
+});
+
+it('treats IcapTimeoutException as a leaf type, not a protocol exception', function () {
+    $timeout = new IcapTimeoutException('connect timed out');
+    expect($timeout)->toBeInstanceOf(IcapExceptionInterface::class)
+        ->and($timeout)->not->toBeInstanceOf(IcapProtocolException::class);
+});

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -5,6 +5,7 @@ use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\IcapClientInterface;
 use Ndrstmr\Icap\SynchronousIcapClient;
 use Ndrstmr\Icap\RequestFormatterInterface;
 use Ndrstmr\Icap\ResponseParserInterface;
@@ -54,8 +55,8 @@ it('delegates calls to the async client and blocks for results', function () {
 });
 
 it('scanFile delegates correctly to async client', function () {
-    /** @var IcapClient&\Mockery\MockInterface $async */
-    $async = m::mock(IcapClient::class);
+    /** @var IcapClientInterface&\Mockery\MockInterface $async */
+    $async = m::mock(IcapClientInterface::class);
     $response = new IcapResponse(201);
     $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
@@ -74,8 +75,8 @@ it('scanFile delegates correctly to async client', function () {
 });
 
 it('request delegates correctly to async client', function () {
-    /** @var IcapClient&\Mockery\MockInterface $async */
-    $async = m::mock(IcapClient::class);
+    /** @var IcapClientInterface&\Mockery\MockInterface $async */
+    $async = m::mock(IcapClientInterface::class);
     $req = new \Ndrstmr\Icap\DTO\IcapRequest('OPTIONS', 'icap://icap.example');
     $response = new IcapResponse(200);
     $result = new ScanResult(false, null, $response);
@@ -95,8 +96,8 @@ it('request delegates correctly to async client', function () {
 });
 
 it('it handles and rethrows exceptions from async client', function () {
-    /** @var IcapClient&\Mockery\MockInterface $async */
-    $async = m::mock(IcapClient::class);
+    /** @var IcapClientInterface&\Mockery\MockInterface $async */
+    $async = m::mock(IcapClientInterface::class);
     $exception = new \Ndrstmr\Icap\Exception\IcapConnectionException('fail');
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');


### PR DESCRIPTION
## Context

This is the first PR of a multi-step v2.0.0 effort tracked in [`docs/review/consolidated_task-list.md`](../blob/feat/v2-rfc-compliance/docs/review/consolidated_task-list.md).

The consolidated task list was derived from the three independent due-diligence reviews in `docs/review/` (Claude, Codex, Jules), verified line-by-line against the current `src/` at `ec16785`. v1.0.0 is deprecated because the required RFC-3507 wire-format fixes are breaking by definition, so this PR also bumps the minimum PHP to clean up the surrounding API at the same time.

## What M0 delivers

**Exception taxonomy** — the current `IcapResponseException` catches everything from "4xx from server" to "garbled bytes" to "unexpected preview state", which makes it impossible to react meaningfully. M0 introduces:

- `IcapExceptionInterface` marker — catch-all without snagging unrelated `RuntimeException`s.
- `IcapProtocolException` — RFC violations.
- `IcapMalformedResponseException extends IcapProtocolException` — unparseable bytes.
- `IcapTimeoutException` — connect/read/write timeouts.
- `IcapClientException` — 4xx responses.
- `IcapServerException` — 5xx responses (retryable).

The existing `IcapConnectionException` and `IcapResponseException` now also implement the marker. `IcapResponseException` is annotated `@deprecated since 2.0`; M2 will migrate the remaining throw sites to the typed variants and remove it.

**`IcapClientInterface`** — the public async contract. `IcapClient` implements it; `SynchronousIcapClient` now depends on the interface, which also lets tests mock it (previously they mocked the concrete class, which breaks now that it's `final`).

**`final` on leaf classes** — `IcapClient`, `RequestFormatter`, `ResponseParser`, `DefaultPreviewStrategy`, `SynchronousStreamTransport`. `AsyncAmpTransport` was already final. Extension via interfaces, not subclassing.

**`#[\Override]`** on every interface method implementation — catches silent signature drift under PHPStan L9.

**PHP baseline raised to `^8.4`** — we're already breaking API, so we take the chance to adopt property hooks, asymmetric visibility, and the native `#[\Override]`. Those features will be used in M1–M3 where they materially simplify DTOs and Config.

**`revolt/event-loop` explicit `require`** — previously pulled in transitively via `amphp/socket`, which made it silently breakable on upstream changes. Now pinned at `^1.0`.

**CI matrix**: `['8.4', '8.5']` (was `['8.3']`).

## Test plan

- [x] `composer test` — 32 passed, 1 pre-existing network warning.
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] `composer audit --locked` — no advisories.
- [x] New `tests/Exception/ExceptionHierarchyTest.php` — 4 tests, 22 assertions covering marker-interface catch, protocol-leaf hierarchy, 4xx/5xx separation, timeout leaf type.
- [x] `SynchronousIcapClientTest` migrated to mock `IcapClientInterface` (concrete `IcapClient` is `final`).
- [x] CI matrix 8.4 + 8.5 both green.

## What comes next

- **M1** — RFC-3507 wire format (Encapsulated offsets, chunked body, `ieof`, HTTP-in-ICAP nesting, streaming preview). Biggest PR of the series.
- **M2** — Security hardening (fail-secure on 100, CRLF validation, TLS, DoS limits, status matrix).
- **M3** — Ecosystem fit (PSR-3, cancellation, OPTIONS cache, pooling, multi-vendor headers).
- **M4** — Integration test infra (c-icap + ClamAV via Docker, Infection, coverage gates, PHPStan 2.x).
- **M5** — Governance & docs (SECURITY.md, SPDX headers, migration guide, DE README).
- `icap-flow-bundle` as a separate repo after v2.0.0 ships.