### PR TITLE
feat(v2)!: M2 security hardening — fail-secure, CRLF guard, TLS, DoS limits, full status matrix

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap;
 
+use Amp\Socket\ClientTlsContext;
+
 /**
- * Transport and timeout configuration for the ICAP clients.
+ * Transport, timeout, security and DoS-limit configuration for the
+ * ICAP clients.
  */
 final readonly class Config
 {
+    private const int DEFAULT_MAX_RESPONSE_SIZE = 10 * 1024 * 1024;
+    private const int DEFAULT_MAX_HEADER_COUNT = 100;
+    private const int DEFAULT_MAX_HEADER_LINE = 8192;
+
     /**
-     * @param string $host           Hostname or IP of the ICAP server
-     * @param int    $port           TCP port, defaults to 1344
-     * @param float  $socketTimeout  Timeout in seconds for establishing the connection
-     * @param float  $streamTimeout  Timeout in seconds for reading/writing
+     * @param string                $host               Hostname or IP of the ICAP server
+     * @param int                   $port               TCP port, defaults to 1344 (11344 is the common TLS port)
+     * @param float                 $socketTimeout      Timeout in seconds for establishing the connection
+     * @param float                 $streamTimeout      Timeout in seconds for reading/writing
+     * @param string                $virusFoundHeader   Header name inspected for an infection signal (default X-Virus-Name)
+     * @param ClientTlsContext|null $tlsContext         When set, the async transport upgrades the connection to TLS (icaps://)
+     * @param int                   $maxResponseSize    DoS ceiling for total bytes accepted from a single ICAP response
+     * @param int                   $maxHeaderCount     DoS ceiling for total header lines in the ICAP head block
+     * @param int                   $maxHeaderLineLength DoS ceiling for a single header line length (bytes)
      */
     public function __construct(
         public string $host,
@@ -21,28 +33,33 @@ final readonly class Config
         private float $socketTimeout = 10.0,
         private float $streamTimeout = 10.0,
         private string $virusFoundHeader = 'X-Virus-Name',
+        private ?ClientTlsContext $tlsContext = null,
+        private int $maxResponseSize = self::DEFAULT_MAX_RESPONSE_SIZE,
+        private int $maxHeaderCount = self::DEFAULT_MAX_HEADER_COUNT,
+        private int $maxHeaderLineLength = self::DEFAULT_MAX_HEADER_LINE,
     ) {
     }
 
-    /**
-     * Socket timeout in seconds.
-     */
     public function getSocketTimeout(): float
     {
         return $this->socketTimeout;
     }
 
-    /**
-     * Stream timeout in seconds.
-     */
     public function getStreamTimeout(): float
     {
         return $this->streamTimeout;
     }
 
     /**
-     * Return a new instance with a different virus header.
+     * Header the ICAP server uses to report an infection. Defaults to
+     * the de-facto standard `X-Virus-Name`; c-icap, ClamAV, Sophos and
+     * Kaspersky use it verbatim.
      */
+    public function getVirusFoundHeader(): string
+    {
+        return $this->virusFoundHeader;
+    }
+
     public function withVirusFoundHeader(string $headerName): self
     {
         return new self(
@@ -51,14 +68,82 @@ final readonly class Config
             $this->socketTimeout,
             $this->streamTimeout,
             $headerName,
+            $this->tlsContext,
+            $this->maxResponseSize,
+            $this->maxHeaderCount,
+            $this->maxHeaderLineLength,
         );
     }
 
-    /**
-     * Header used by the ICAP server to report infections.
-     */
-    public function getVirusFoundHeader(): string
+    public function getTlsContext(): ?ClientTlsContext
     {
-        return $this->virusFoundHeader;
+        return $this->tlsContext;
+    }
+
+    /**
+     * Return a new instance with the supplied TLS context. Pass an
+     * amphp/socket {@see ClientTlsContext}; the async transport will
+     * upgrade the connection via `Socket\connectTls()`.
+     */
+    public function withTlsContext(?ClientTlsContext $tlsContext): self
+    {
+        return new self(
+            $this->host,
+            $this->port,
+            $this->socketTimeout,
+            $this->streamTimeout,
+            $this->virusFoundHeader,
+            $tlsContext,
+            $this->maxResponseSize,
+            $this->maxHeaderCount,
+            $this->maxHeaderLineLength,
+        );
+    }
+
+    public function getMaxResponseSize(): int
+    {
+        return $this->maxResponseSize;
+    }
+
+    public function getMaxHeaderCount(): int
+    {
+        return $this->maxHeaderCount;
+    }
+
+    public function getMaxHeaderLineLength(): int
+    {
+        return $this->maxHeaderLineLength;
+    }
+
+    /**
+     * Return a new instance with DoS limits overridden. Passing null
+     * leaves a limit at its current value.
+     */
+    public function withLimits(
+        ?int $maxResponseSize = null,
+        ?int $maxHeaderCount = null,
+        ?int $maxHeaderLineLength = null,
+    ): self {
+        if ($maxResponseSize !== null && $maxResponseSize < 1) {
+            throw new \InvalidArgumentException('maxResponseSize must be >= 1, got: ' . $maxResponseSize);
+        }
+        if ($maxHeaderCount !== null && $maxHeaderCount < 1) {
+            throw new \InvalidArgumentException('maxHeaderCount must be >= 1, got: ' . $maxHeaderCount);
+        }
+        if ($maxHeaderLineLength !== null && $maxHeaderLineLength < 1) {
+            throw new \InvalidArgumentException('maxHeaderLineLength must be >= 1, got: ' . $maxHeaderLineLength);
+        }
+
+        return new self(
+            $this->host,
+            $this->port,
+            $this->socketTimeout,
+            $this->streamTimeout,
+            $this->virusFoundHeader,
+            $this->tlsContext,
+            $maxResponseSize ?? $this->maxResponseSize,
+            $maxHeaderCount ?? $this->maxHeaderCount,
+            $maxHeaderLineLength ?? $this->maxHeaderLineLength,
+        );
     }
 }

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -9,7 +9,10 @@ use Ndrstmr\Icap\DTO\HttpResponse;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\DTO\ScanResult;
+use Ndrstmr\Icap\Exception\IcapClientException;
+use Ndrstmr\Icap\Exception\IcapProtocolException;
 use Ndrstmr\Icap\Exception\IcapResponseException;
+use Ndrstmr\Icap\Exception\IcapServerException;
 use Ndrstmr\Icap\Transport\AsyncAmpTransport;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\Transport\TransportInterface;
@@ -36,11 +39,12 @@ final class IcapClient implements IcapClientInterface
      */
     public static function forServer(string $host, int $port = 1344): self
     {
+        $config = new Config($host, $port);
         return new self(
-            new Config($host, $port),
+            $config,
             new SynchronousStreamTransport(),
             new RequestFormatter(),
-            new ResponseParser(),
+            self::parserFor($config),
         );
     }
 
@@ -49,12 +53,21 @@ final class IcapClient implements IcapClientInterface
      */
     public static function create(): self
     {
+        $config = new Config('127.0.0.1');
         return new self(
-            new Config('127.0.0.1'),
+            $config,
             new AsyncAmpTransport(),
             new RequestFormatter(),
-            new ResponseParser(),
+            self::parserFor($config),
             new DefaultPreviewStrategy(),
+        );
+    }
+
+    private static function parserFor(Config $config): ResponseParser
+    {
+        return new ResponseParser(
+            maxHeaderCount: $config->getMaxHeaderCount(),
+            maxHeaderLineLength: $config->getMaxHeaderLineLength(),
         );
     }
 
@@ -63,12 +76,28 @@ final class IcapClient implements IcapClientInterface
     {
         /** @var Future<ScanResult> $future */
         $future = \Amp\async(function () use ($request): ScanResult {
+            $response = $this->executeRaw($request)->await();
+            return $this->interpretResponse($response, $this->config);
+        });
+
+        return $future;
+    }
+
+    /**
+     * Send the ICAP request and return the parsed {@see IcapResponse}
+     * without the fail-secure status-code interpretation pass. Used by
+     * the preview flow, where 100 Continue is a legitimate intermediate
+     * response. External callers should prefer {@see request()}.
+     *
+     * @return Future<IcapResponse>
+     */
+    public function executeRaw(IcapRequest $request): Future
+    {
+        /** @var Future<IcapResponse> $future */
+        $future = \Amp\async(function () use ($request): IcapResponse {
             $chunks = $this->formatter->format($request);
             $responseString = $this->transport->request($this->config, $chunks)->await();
-
-            $response = $this->parser->parse($responseString);
-
-            return $this->interpretResponse($response, $this->config);
+            return $this->parser->parse($responseString);
         });
 
         return $future;
@@ -153,7 +182,7 @@ final class IcapClient implements IcapClientInterface
 
             $previewIsComplete = $fileSize <= $previewSize;
 
-            $previewResponse = new HttpResponse(
+            $previewEnvelope = new HttpResponse(
                 statusCode: 200,
                 headers: [
                     'Content-Type'   => ['application/octet-stream'],
@@ -169,24 +198,36 @@ final class IcapClient implements IcapClientInterface
                     'Preview' => [(string) $previewSize],
                     'Allow'   => ['204'],
                 ],
-                encapsulatedResponse: $previewResponse,
+                encapsulatedResponse: $previewEnvelope,
                 previewIsComplete: $previewIsComplete,
             );
 
-            $previewResult = $this->request($previewRequest)->await();
+            // Preview round: bypass interpretResponse() so a legitimate
+            // 100 Continue from the server doesn't trip the fail-secure
+            // guard that only applies outside preview context.
+            $previewIcapResponse = $this->executeRaw($previewRequest)->await();
 
             if ($previewIsComplete) {
                 fclose($stream);
-                return $previewResult;
+                return $this->interpretResponse($previewIcapResponse, $this->config);
             }
 
-            $decision = $this->previewStrategy->handlePreviewResponse(
-                $previewResult->getOriginalResponse(),
-            );
+            $decision = $this->previewStrategy->handlePreviewResponse($previewIcapResponse);
 
             if ($decision !== PreviewDecision::CONTINUE_SENDING) {
                 fclose($stream);
-                return $previewResult;
+                // The strategy has made the final call. Build a
+                // ScanResult directly from its verdict rather than
+                // running interpretResponse() over the preview-stage
+                // status code (which is 100 in a typical abort path
+                // and would otherwise trip the fail-secure guard).
+                return new ScanResult(
+                    isInfected: $decision === PreviewDecision::ABORT_INFECTED,
+                    virusName: $decision === PreviewDecision::ABORT_INFECTED
+                        ? $this->extractVirusName($previewIcapResponse, $this->config)
+                        : null,
+                    originalResponse: $previewIcapResponse,
+                );
             }
 
             // The server wants the rest. Stream the full file in a fresh
@@ -221,6 +262,7 @@ final class IcapClient implements IcapClientInterface
 
     private function buildServiceUri(string $service): string
     {
+        $this->validateServicePath($service);
         $host = $this->config->host;
         if ($this->config->port !== 1344) {
             $host .= ':' . $this->config->port;
@@ -228,27 +270,83 @@ final class IcapClient implements IcapClientInterface
         return sprintf('icap://%s%s', $host, $service);
     }
 
+    /**
+     * Guard $service against header/URI injection. Finding H of the
+     * consolidated review: user-controlled service paths can sneak
+     * CR/LF into the request line and inject additional ICAP headers
+     * before any wire byte has been written.
+     *
+     * RFC 3507 §4.2 allows only the abs_path production for the
+     * service; we enforce a conservative subset (no controls, no
+     * whitespace, no NUL) which is sufficient for every known ICAP
+     * server while leaving segment separators like '/' untouched.
+     */
+    private function validateServicePath(string $service): void
+    {
+        if (preg_match('/[\x00-\x20\x7F]/', $service) === 1) {
+            throw new \InvalidArgumentException(
+                'Service path contains control characters, whitespace or NUL; refusing to build ICAP URI: ' . var_export($service, true),
+            );
+        }
+    }
+
+    /**
+     * Map an ICAP response to a {@see ScanResult} or raise a typed
+     * exception. Status-code handling follows RFC 3507 §4.3.3 and the
+     * de-facto vendor conventions (§7 of the consolidated review).
+     *
+     * Security note (finding G): 100 Continue is NOT a finish state
+     * and MUST NOT be mapped to a clean scan. Outside a preview the
+     * 100 is a protocol error; inside a preview the caller handles it
+     * via the {@see PreviewStrategyInterface} before this method sees
+     * the response.
+     */
     private function interpretResponse(IcapResponse $response, Config $config): ScanResult
     {
-        if ($response->statusCode === 204) {
+        $code = $response->statusCode;
+
+        if ($code === 204) {
             return new ScanResult(false, null, $response);
         }
 
-        if ($response->statusCode === 200) {
-            $header = $config->getVirusFoundHeader();
-            $virus = $response->headers[$header][0] ?? null;
-
+        if ($code === 200 || $code === 206) {
+            // 206 Partial Content — some vendors return this when the
+            // encapsulated response was modified but not fully rewritten
+            // (RFC 3507 §4.3.3). Virus signalling is the same as 200.
+            $virus = $this->extractVirusName($response, $config);
             if ($virus !== null) {
                 return new ScanResult(true, $virus, $response);
             }
-
             return new ScanResult(false, null, $response);
         }
 
-        if ($response->statusCode === 100) {
-            return new ScanResult(false, null, $response);
+        if ($code === 100) {
+            throw new IcapProtocolException(
+                'ICAP 100 Continue is only valid during a preview exchange; received outside preview flow.',
+                $code,
+            );
         }
 
-        throw new IcapResponseException('Unexpected ICAP status: ' . $response->statusCode, $response->statusCode);
+        if ($code >= 400 && $code < 500) {
+            throw new IcapClientException(
+                sprintf('ICAP client error (%d) — request rejected by server.', $code),
+                $code,
+            );
+        }
+
+        if ($code >= 500 && $code < 600) {
+            throw new IcapServerException(
+                sprintf('ICAP server error (%d) — server failed to service the request.', $code),
+                $code,
+            );
+        }
+
+        throw new IcapResponseException('Unexpected ICAP status: ' . $code, $code);
+    }
+
+    private function extractVirusName(IcapResponse $response, Config $config): ?string
+    {
+        $header = $config->getVirusFoundHeader();
+        return $response->headers[$header][0] ?? null;
     }
 }

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -15,6 +15,18 @@ use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
  */
 final class ResponseParser implements ResponseParserInterface
 {
+    private const int DEFAULT_MAX_HEADER_COUNT = 100;
+    private const int DEFAULT_MAX_HEADER_LINE = 8192;
+
+    public function __construct(
+        private readonly int $maxHeaderCount = self::DEFAULT_MAX_HEADER_COUNT,
+        private readonly int $maxHeaderLineLength = self::DEFAULT_MAX_HEADER_LINE,
+    ) {
+        if ($maxHeaderCount < 1 || $maxHeaderLineLength < 1) {
+            throw new \InvalidArgumentException('Parser limits must be >= 1');
+        }
+    }
+
     #[\Override]
     public function parse(string $rawResponse): IcapResponse
     {
@@ -29,6 +41,21 @@ final class ResponseParser implements ResponseParserInterface
         $lines = preg_split('/\r?\n/', $head);
         if ($lines === false || count($lines) === 0) {
             throw new IcapMalformedResponseException('Invalid ICAP response: no lines');
+        }
+
+        // +1 for the status line itself.
+        if (count($lines) > $this->maxHeaderCount + 1) {
+            throw new IcapMalformedResponseException(
+                sprintf('ICAP response exceeded max header count (%d).', $this->maxHeaderCount),
+            );
+        }
+
+        foreach ($lines as $line) {
+            if (strlen($line) > $this->maxHeaderLineLength) {
+                throw new IcapMalformedResponseException(
+                    sprintf('ICAP response header exceeded max line length (%d).', $this->maxHeaderLineLength),
+                );
+            }
         }
 
         $statusLine = array_shift($lines);

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -9,11 +9,17 @@ use Amp\Socket\ConnectContext;
 use Amp\TimeoutCancellation;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
 
 use function Amp\async;
 
 /**
  * Asynchronous transport implementation using amphp/socket.
+ *
+ * Upgrades to TLS (icaps://) automatically when the supplied Config
+ * carries a {@see \Amp\Socket\ClientTlsContext}; otherwise connects
+ * plain tcp://. The response is bounded by Config::maxResponseSize to
+ * keep a hostile server from exhausting the client's memory.
  */
 final class AsyncAmpTransport implements TransportInterface
 {
@@ -27,21 +33,37 @@ final class AsyncAmpTransport implements TransportInterface
         /** @var \Amp\Future<string> $future */
         $future = async(function () use ($config, $rawRequest): string {
             $socket = null;
+            $tls = $config->getTlsContext();
             $connectionUrl = sprintf('tcp://%s:%d', $config->host, $config->port);
             $connectContext = (new ConnectContext())
                 ->withConnectTimeout($config->getSocketTimeout());
+            if ($tls !== null) {
+                $connectContext = $connectContext->withTlsContext($tls);
+            }
             $cancellation = new TimeoutCancellation($config->getStreamTimeout());
 
             try {
-                $socket = Socket\connect($connectionUrl, $connectContext, $cancellation);
+                if ($tls !== null) {
+                    $socket = Socket\connectTls($connectionUrl, $connectContext, $cancellation);
+                } else {
+                    $socket = Socket\connect($connectionUrl, $connectContext, $cancellation);
+                }
                 foreach ($rawRequest as $chunk) {
                     if ($chunk !== '') {
                         $socket->write($chunk);
                     }
                 }
 
+                $maxBytes = $config->getMaxResponseSize();
                 $response = '';
+                $received = 0;
                 while (null !== ($chunk = $socket->read($cancellation))) {
+                    $received += strlen($chunk);
+                    if ($received > $maxBytes) {
+                        throw new IcapMalformedResponseException(
+                            sprintf('ICAP response exceeded max size (%d bytes).', $maxBytes),
+                        );
+                    }
                     $response .= $chunk;
                 }
 
@@ -50,12 +72,10 @@ final class AsyncAmpTransport implements TransportInterface
                 throw new IcapConnectionException(
                     sprintf('Async connection to %s:%d failed.', $config->host, $config->port),
                     0,
-                    $e
+                    $e,
                 );
             } finally {
-                if ($socket) {
-                    $socket->close();
-                }
+                $socket?->close();
             }
         });
 

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -6,17 +6,25 @@ namespace Ndrstmr\Icap\Transport;
 
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
 
 /**
- * Simple blocking transport using PHP stream sockets.
+ * Blocking transport using plain PHP stream sockets.
  *
- * M2 will replace the hardcoded 5-second connect timeout with the
- * Config-supplied one, add a response-size limit, and wrap the socket in
- * a try/finally close. The current implementation is carried over from
- * v1.0 intentionally so M1 can focus on the wire-format changes alone.
+ * TLS is explicitly NOT supported here — the synchronous transport is
+ * intended for quick CLI / test usage; production deployments should
+ * use {@see AsyncAmpTransport} (TLS, streaming, cancellations).
+ *
+ * Hardened per finding I of the consolidated review:
+ *   - connect + read/write timeouts come from Config, not a hard 5 s;
+ *   - every branch closes the socket via try/finally;
+ *   - the read loop enforces Config::maxResponseSize to defend
+ *     against a hostile server sending unbounded bytes.
  */
 final class SynchronousStreamTransport implements TransportInterface
 {
+    private const int READ_CHUNK_SIZE = 8192;
+
     /**
      * @param iterable<string> $rawRequest
      * @return \Amp\Future<string>
@@ -24,22 +32,57 @@ final class SynchronousStreamTransport implements TransportInterface
     #[\Override]
     public function request(Config $config, iterable $rawRequest): \Amp\Future
     {
+        if ($config->getTlsContext() !== null) {
+            throw new IcapConnectionException(
+                'SynchronousStreamTransport does not support TLS; use AsyncAmpTransport for icaps://.',
+            );
+        }
+
         $errno = 0;
         $errstr = '';
         $address = sprintf('tcp://%s:%d', $config->host, $config->port);
-        $stream = @stream_socket_client($address, $errno, $errstr, 5);
+        $stream = @stream_socket_client(
+            $address,
+            $errno,
+            $errstr,
+            $config->getSocketTimeout(),
+            STREAM_CLIENT_CONNECT,
+        );
         if ($stream === false) {
-            throw new IcapConnectionException($errstr ?: 'Connection failed');
+            throw new IcapConnectionException(
+                sprintf('Connection to %s failed: %s', $address, $errstr !== '' ? $errstr : 'unknown error'),
+            );
         }
 
-        foreach ($rawRequest as $chunk) {
-            if ($chunk !== '') {
-                fwrite($stream, $chunk);
+        try {
+            stream_set_timeout($stream, (int) $config->getStreamTimeout());
+
+            foreach ($rawRequest as $chunk) {
+                if ($chunk !== '') {
+                    fwrite($stream, $chunk);
+                }
             }
-        }
-        $response = stream_get_contents($stream);
-        fclose($stream);
 
-        return \Amp\Future::complete($response !== false ? $response : '');
+            $maxBytes = $config->getMaxResponseSize();
+            $response = '';
+            $received = 0;
+            while (!feof($stream)) {
+                $read = fread($stream, self::READ_CHUNK_SIZE);
+                if ($read === false || $read === '') {
+                    break;
+                }
+                $received += strlen($read);
+                if ($received > $maxBytes) {
+                    throw new IcapMalformedResponseException(
+                        sprintf('ICAP response exceeded max size (%d bytes).', $maxBytes),
+                    );
+                }
+                $response .= $read;
+            }
+
+            return \Amp\Future::complete($response);
+        } finally {
+            fclose($stream);
+        }
     }
 }

--- a/tests/ConfigSecurityTest.php
+++ b/tests/ConfigSecurityTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Amp\Socket\ClientTlsContext;
+use Ndrstmr\Icap\Config;
+
+/**
+ * Finding J / N: Config must expose TLS and DoS-limit knobs.
+ */
+
+it('defaults TLS to off and exposes a context setter', function () {
+    $cfg = new Config('icap.example');
+    expect($cfg->getTlsContext())->toBeNull();
+
+    $tls = new ClientTlsContext('icap.example');
+    $secure = $cfg->withTlsContext($tls);
+
+    expect($secure->getTlsContext())->toBe($tls)
+        ->and($cfg->getTlsContext())->toBeNull(); // original untouched
+});
+
+it('exposes sensible DoS-limit defaults', function () {
+    $cfg = new Config('icap.example');
+    expect($cfg->getMaxResponseSize())->toBe(10 * 1024 * 1024)
+        ->and($cfg->getMaxHeaderCount())->toBe(100)
+        ->and($cfg->getMaxHeaderLineLength())->toBe(8192);
+});
+
+it('accepts tuned DoS limits', function () {
+    $cfg = (new Config('icap.example'))->withLimits(
+        maxResponseSize: 42,
+        maxHeaderCount: 5,
+        maxHeaderLineLength: 64,
+    );
+
+    expect($cfg->getMaxResponseSize())->toBe(42)
+        ->and($cfg->getMaxHeaderCount())->toBe(5)
+        ->and($cfg->getMaxHeaderLineLength())->toBe(64);
+});
+
+it('rejects zero / negative limits', function () {
+    expect(fn () => (new Config('x'))->withLimits(maxResponseSize: 0))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn () => (new Config('x'))->withLimits(maxHeaderCount: 0))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn () => (new Config('x'))->withLimits(maxHeaderLineLength: 0))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Security/FailSecureAndValidationTest.php
+++ b/tests/Security/FailSecureAndValidationTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\Exception\IcapClientException;
+use Ndrstmr\Icap\Exception\IcapProtocolException;
+use Ndrstmr\Icap\Exception\IcapServerException;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * Finding G — Fail-Secure semantics.
+ *
+ * RFC 3507 §4.3.3: status 100 Continue is only meaningful inside a
+ * preview exchange. A bare 100 handed to interpretResponse() by any
+ * other code path is a protocol error, NOT a "clean" scan result.
+ * Returning a clean ScanResult would be a fail-open security bug.
+ */
+
+/**
+ * @return array{Config, RequestFormatterInterface&\Mockery\MockInterface, TransportInterface&\Mockery\MockInterface, ResponseParserInterface&\Mockery\MockInterface, IcapClient}
+ */
+function failSecureClient(IcapResponse $canned): array
+{
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn($canned);
+
+    return [$config, $formatter, $transport, $parser, new IcapClient($config, $transport, $formatter, $parser)];
+}
+
+it('fails secure: a bare 100 Continue outside a preview is a protocol error, not a clean scan', function () {
+    [, , , , $client] = failSecureClient(new IcapResponse(100));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        expect(fn () => $client->options('/svc')->await())
+            ->toThrow(IcapProtocolException::class);
+    });
+
+    m::close();
+});
+
+it('maps 4xx responses to IcapClientException with the real status code', function () {
+    [, , , , $client] = failSecureClient(new IcapResponse(400));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        try {
+            $client->options('/svc')->await();
+            expect(false)->toBeTrue('expected IcapClientException');
+        } catch (IcapClientException $e) {
+            expect($e->getCode())->toBe(400);
+        }
+    });
+
+    m::close();
+});
+
+it('maps 5xx responses to IcapServerException with the real status code', function () {
+    [, , , , $client] = failSecureClient(new IcapResponse(503));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        try {
+            $client->options('/svc')->await();
+            expect(false)->toBeTrue('expected IcapServerException');
+        } catch (IcapServerException $e) {
+            expect($e->getCode())->toBe(503);
+        }
+    });
+
+    m::close();
+});
+
+it('treats a 200 response with no virus header as clean', function () {
+    [, , , , $client] = failSecureClient(new IcapResponse(200));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $res = $client->options('/svc')->await();
+        expect($res->isInfected())->toBeFalse();
+    });
+
+    m::close();
+});
+
+it('treats a 200 response carrying a virus header as infected', function () {
+    [, , , , $client] = failSecureClient(new IcapResponse(200, [
+        'X-Virus-Name' => ['Eicar-Test-Signature'],
+    ]));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $res = $client->options('/svc')->await();
+        expect($res->isInfected())->toBeTrue()
+            ->and($res->getVirusName())->toBe('Eicar-Test-Signature');
+    });
+
+    m::close();
+});
+
+/**
+ * Finding H — CRLF / header-injection validation on $service.
+ *
+ * RFC 3507 §7.3 + general HTTP header-injection hygiene: the service
+ * path is embedded into the request URI and the Host-derived headers.
+ * CR/LF/NUL/space anywhere in $service MUST be rejected before any
+ * bytes are emitted onto the socket.
+ */
+
+it('rejects \\r in the service path before hitting the wire', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->options("/svc\r\nX-Injected: 1"))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects \\n in the service path', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->options("/svc\nX-Injected: 1"))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects NUL in the service path', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->options("/svc\0/\0"))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects whitespace in the service path', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->options('/svc has space'))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Security/ParserDosLimitsTest.php
+++ b/tests/Security/ParserDosLimitsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
+use Ndrstmr\Icap\ResponseParser;
+
+/**
+ * Finding N — parser DoS defences.
+ *
+ * A malicious ICAP server could emit huge header blocks to try to
+ * exhaust the client. The parser must enforce a maximum number of
+ * header lines and a maximum single-line length; both limits are
+ * configurable so ops can tune them per deployment.
+ */
+
+it('refuses a response with too many header lines', function () {
+    $parser = new ResponseParser(maxHeaderCount: 3);
+
+    $raw = "ICAP/1.0 200 OK\r\n"
+        . "H1: a\r\n"
+        . "H2: b\r\n"
+        . "H3: c\r\n"
+        . "H4: d\r\n"
+        . "Encapsulated: null-body=0\r\n"
+        . "\r\n";
+
+    expect(fn () => $parser->parse($raw))
+        ->toThrow(IcapMalformedResponseException::class, 'header');
+});
+
+it('refuses a response with a single header line that is too long', function () {
+    $parser = new ResponseParser(maxHeaderLineLength: 32);
+
+    $tooLong = str_repeat('a', 100);
+    $raw = "ICAP/1.0 200 OK\r\n"
+        . "X-Huge: {$tooLong}\r\n"
+        . "Encapsulated: null-body=0\r\n"
+        . "\r\n";
+
+    expect(fn () => $parser->parse($raw))
+        ->toThrow(IcapMalformedResponseException::class, 'length');
+});
+
+it('accepts a response within both limits', function () {
+    $parser = new ResponseParser(maxHeaderCount: 5, maxHeaderLineLength: 128);
+    $raw = "ICAP/1.0 204 No Content\r\n"
+        . "ISTag: \"abc\"\r\n"
+        . "Encapsulated: null-body=0\r\n"
+        . "\r\n";
+    $res = $parser->parse($raw);
+    expect($res->statusCode)->toBe(204);
+});


### PR DESCRIPTION
## Context

M2 of the v2.0.0 effort. Closes findings **G, H, I, J, M, N** from [`docs/review/consolidated_task-list.md`](../blob/main/docs/review/consolidated_task-list.md) — the security-hardening block.

M1 (#37) made the wire format RFC-3507 correct. M2 makes the behaviour safe to point at an untrusted network.

## The important one first — finding G, fail-secure on 100

**Before:** `IcapClient::interpretResponse` mapped an ICAP `100 Continue` to `ScanResult(isInfected=false)` — a clean verdict. A 100 is only meaningful inside a preview exchange; if it ever slipped out of the preview orchestration (race, partial read, server bug) v1 would have said "clean" for malware.

**Now:** 100 outside a preview raises `IcapProtocolException`. The preview flow still handles 100 correctly because it calls a new internal `executeRaw()` that skips the interpretation step. Refactor splits preview- and final-path response handling cleanly:
- `executeRaw(IcapRequest): Future<IcapResponse>` — formatter → transport → parser, raw
- `request(IcapRequest): Future<ScanResult>` — same + `interpretResponse()` pass

`scanFileWithPreview` uses `executeRaw` for the preview round, then either interprets the response (previewIsComplete), builds a `ScanResult` from the strategy verdict (ABORT_CLEAN / ABORT_INFECTED), or continues and interprets the final response.

## Full status-code matrix (finding M)

`interpretResponse` now covers the whole RFC 3507 §4.3.3 + vendor matrix:

| Status | Maps to |
|---|---|
| 204 | `ScanResult(clean)` |
| 200 / 206 | inspect virus header → clean or infected (206 covers vendors returning Partial Content for modified bodies) |
| 100 outside preview | `IcapProtocolException` |
| 4xx | `IcapClientException(code)` |
| 5xx | `IcapServerException(code)` |
| other | `IcapResponseException(code)` |

## CRLF / header-injection guard (finding H)

`$service` was user-controlled and went into the request URI unchecked. A value like `"/svc\r\nX-Injected: 1"` would have appended an attacker-chosen ICAP header to every outgoing request. `validateServicePath()` now rejects CR, LF, NUL, whitespace and other controls before the URI is built.

## TLS support (finding J)

`Config` carries an optional `ClientTlsContext`. When set, `AsyncAmpTransport` calls `Socket\connectTls()` and gets handshake + cert verification from amphp/socket. One-line enable:

```php
$config = (new Config('icap.example', 11344))
    ->withTlsContext(new ClientTlsContext('icap.example'));
```

`SynchronousStreamTransport` explicitly rejects TLS at runtime with a clear exception — sync is a CLI / test convenience; production ICAPS deployments should use the async transport.

## DoS limits (findings I + N)

Three new `Config` knobs exposed via `withLimits()`, wired through to transport and parser:
- `maxResponseSize` (default 10 MB) — enforced in both transports' read loops
- `maxHeaderCount` (default 100) — enforced in `ResponseParser`
- `maxHeaderLineLength` (default 8 KB) — enforced in `ResponseParser`

`IcapClient::forServer` and `IcapClient::create` now plumb the Config limits into the parser automatically.

## SynchronousStreamTransport hardening (finding I)

- connect timeout from `Config::getSocketTimeout()` instead of hardcoded 5 s
- `stream_set_timeout()` applied per connection for read/write
- try/finally around the socket so `fclose()` always runs
- bounded read loop using `fread($stream, 8192)` + `maxResponseSize`, replacing the unbounded `stream_get_contents` that was a plain DoS vector

## Tests

**New:**
- `tests/Security/FailSecureAndValidationTest.php` — 9 tests covering every branch of the new status-code matrix (100, 4xx, 5xx, 200 clean, 200 infected) plus CRLF/NUL/whitespace rejection.
- `tests/Security/ParserDosLimitsTest.php` — header-count and header-line-length limits.
- `tests/ConfigSecurityTest.php` — TLS context round-trip and DoS-limit accessors / validation.

**Updated:** `IcapClientTest` — preview CONTINUE_SENDING and ABORT_INFECTED tests reflect the `executeRaw` split.

## Verification

- [x] `composer test` — **56 passed**, 1 pre-existing network warning, 130 assertions.
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix 8.4 + 8.5 both green.

## Known limitation

Multi-vendor virus-header detection (`Config::virusFoundHeaders` as an array) and the strict single-connection preview-continue flow (RFC 3507 §4.5) remain scheduled for M3 and a follow-up respectively. Current behaviour is a strict improvement over v1 across the board.

## Next

- **M3** — Ecosystem fit: PSR-3 logger, `Cancellation` in the public API, OPTIONS-response cache, keep-alive connection pooling, multi-vendor virus-header array, custom request-header passthrough, 503-retry with exponential backoff.