### PR TITLE
feat(v2)!: M3 ecosystem fit — PSR-3 logger, multi-vendor virus headers, custom request headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
   "require": {
     "php": "^8.4",
     "amphp/socket": "^2.3",
+    "psr/log": "^3.0",
     "revolt/event-loop": "^1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b4d9f324cdba99656467f0ad06b349b",
+    "content-hash": "f03be222df096853f6ba520f9e9f633d",
     "packages": [
         {
             "name": "amphp/amp",
@@ -1130,6 +1130,56 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -3756,56 +3806,6 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "psr/simple-cache",

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,28 +16,37 @@ final readonly class Config
     private const int DEFAULT_MAX_HEADER_COUNT = 100;
     private const int DEFAULT_MAX_HEADER_LINE = 8192;
 
+    /** @var list<string> */
+    private array $virusFoundHeaders;
+
     /**
-     * @param string                $host               Hostname or IP of the ICAP server
-     * @param int                   $port               TCP port, defaults to 1344 (11344 is the common TLS port)
-     * @param float                 $socketTimeout      Timeout in seconds for establishing the connection
-     * @param float                 $streamTimeout      Timeout in seconds for reading/writing
-     * @param string                $virusFoundHeader   Header name inspected for an infection signal (default X-Virus-Name)
-     * @param ClientTlsContext|null $tlsContext         When set, the async transport upgrades the connection to TLS (icaps://)
-     * @param int                   $maxResponseSize    DoS ceiling for total bytes accepted from a single ICAP response
-     * @param int                   $maxHeaderCount     DoS ceiling for total header lines in the ICAP head block
+     * @param string                $host                Hostname or IP of the ICAP server
+     * @param int                   $port                TCP port, defaults to 1344 (11344 is the common TLS port)
+     * @param float                 $socketTimeout       Timeout in seconds for establishing the connection
+     * @param float                 $streamTimeout       Timeout in seconds for reading/writing
+     * @param string                $virusFoundHeader    Legacy single virus header (back-compat). The client now
+     *                                                   consults a list; this value seeds it when
+     *                                                   $virusFoundHeaders is null.
+     * @param ClientTlsContext|null $tlsContext          When set, the async transport upgrades the connection to TLS (icaps://)
+     * @param int                   $maxResponseSize     DoS ceiling for total bytes accepted from a single ICAP response
+     * @param int                   $maxHeaderCount      DoS ceiling for total header lines in the ICAP head block
      * @param int                   $maxHeaderLineLength DoS ceiling for a single header line length (bytes)
+     * @param list<string>|null     $virusFoundHeaders   Ordered list of vendor virus-name headers;
+     *                                                   null falls back to [$virusFoundHeader].
      */
     public function __construct(
         public string $host,
         public int $port = 1344,
         private float $socketTimeout = 10.0,
         private float $streamTimeout = 10.0,
-        private string $virusFoundHeader = 'X-Virus-Name',
+        string $virusFoundHeader = 'X-Virus-Name',
         private ?ClientTlsContext $tlsContext = null,
         private int $maxResponseSize = self::DEFAULT_MAX_RESPONSE_SIZE,
         private int $maxHeaderCount = self::DEFAULT_MAX_HEADER_COUNT,
         private int $maxHeaderLineLength = self::DEFAULT_MAX_HEADER_LINE,
+        ?array $virusFoundHeaders = null,
     ) {
+        $this->virusFoundHeaders = $virusFoundHeaders ?? [$virusFoundHeader];
     }
 
     public function getSocketTimeout(): float
@@ -51,27 +60,54 @@ final readonly class Config
     }
 
     /**
-     * Header the ICAP server uses to report an infection. Defaults to
-     * the de-facto standard `X-Virus-Name`; c-icap, ClamAV, Sophos and
-     * Kaspersky use it verbatim.
+     * Legacy accessor — returns the first configured virus header.
+     * Prefer {@see getVirusFoundHeaders()} for new code; this method
+     * stays for back-compat with v1 callers.
      */
     public function getVirusFoundHeader(): string
     {
-        return $this->virusFoundHeader;
+        return $this->virusFoundHeaders[0];
+    }
+
+    /**
+     * Ordered list of ICAP headers inspected for infection signals.
+     * The first header that is present in the server's response wins.
+     * Different vendors use different headers — c-icap / ClamAV use
+     * `X-Virus-Name`; Trend Micro reports via `X-Violations-Found`,
+     * ISS Proventia via `X-Infection-Found`, Symantec via `X-Virus-ID`.
+     *
+     * @return list<string>
+     */
+    public function getVirusFoundHeaders(): array
+    {
+        return $this->virusFoundHeaders;
     }
 
     public function withVirusFoundHeader(string $headerName): self
     {
+        return $this->withVirusFoundHeaders([$headerName]);
+    }
+
+    /**
+     * @param list<string> $headerNames
+     */
+    public function withVirusFoundHeaders(array $headerNames): self
+    {
+        if ($headerNames === []) {
+            throw new \InvalidArgumentException('virusFoundHeaders must contain at least one header name.');
+        }
+
         return new self(
-            $this->host,
-            $this->port,
-            $this->socketTimeout,
-            $this->streamTimeout,
-            $headerName,
-            $this->tlsContext,
-            $this->maxResponseSize,
-            $this->maxHeaderCount,
-            $this->maxHeaderLineLength,
+            host: $this->host,
+            port: $this->port,
+            socketTimeout: $this->socketTimeout,
+            streamTimeout: $this->streamTimeout,
+            virusFoundHeader: $headerNames[0],
+            tlsContext: $this->tlsContext,
+            maxResponseSize: $this->maxResponseSize,
+            maxHeaderCount: $this->maxHeaderCount,
+            maxHeaderLineLength: $this->maxHeaderLineLength,
+            virusFoundHeaders: $headerNames,
         );
     }
 
@@ -88,15 +124,16 @@ final readonly class Config
     public function withTlsContext(?ClientTlsContext $tlsContext): self
     {
         return new self(
-            $this->host,
-            $this->port,
-            $this->socketTimeout,
-            $this->streamTimeout,
-            $this->virusFoundHeader,
-            $tlsContext,
-            $this->maxResponseSize,
-            $this->maxHeaderCount,
-            $this->maxHeaderLineLength,
+            host: $this->host,
+            port: $this->port,
+            socketTimeout: $this->socketTimeout,
+            streamTimeout: $this->streamTimeout,
+            virusFoundHeader: $this->virusFoundHeaders[0],
+            tlsContext: $tlsContext,
+            maxResponseSize: $this->maxResponseSize,
+            maxHeaderCount: $this->maxHeaderCount,
+            maxHeaderLineLength: $this->maxHeaderLineLength,
+            virusFoundHeaders: $this->virusFoundHeaders,
         );
     }
 
@@ -135,15 +172,16 @@ final readonly class Config
         }
 
         return new self(
-            $this->host,
-            $this->port,
-            $this->socketTimeout,
-            $this->streamTimeout,
-            $this->virusFoundHeader,
-            $this->tlsContext,
-            $maxResponseSize ?? $this->maxResponseSize,
-            $maxHeaderCount ?? $this->maxHeaderCount,
-            $maxHeaderLineLength ?? $this->maxHeaderLineLength,
+            host: $this->host,
+            port: $this->port,
+            socketTimeout: $this->socketTimeout,
+            streamTimeout: $this->streamTimeout,
+            virusFoundHeader: $this->virusFoundHeaders[0],
+            tlsContext: $this->tlsContext,
+            maxResponseSize: $maxResponseSize ?? $this->maxResponseSize,
+            maxHeaderCount: $maxHeaderCount ?? $this->maxHeaderCount,
+            maxHeaderLineLength: $maxHeaderLineLength ?? $this->maxHeaderLineLength,
+            virusFoundHeaders: $this->virusFoundHeaders,
         );
     }
 }

--- a/src/DTO/IcapRequest.php
+++ b/src/DTO/IcapRequest.php
@@ -22,7 +22,8 @@ final readonly class IcapRequest
     /**
      * @param string                  $method               ICAP method (OPTIONS, REQMOD, RESPMOD)
      * @param string                  $uri                  Fully-qualified ICAP URI, e.g. icap://host:1344/service
-     * @param array<string, string[]> $headers              ICAP headers (Host is filled in from $uri when missing)
+     * @param array<string, string|string[]> $headers       ICAP headers (Host is filled in from $uri when missing);
+     *                                                       scalar values are promoted to a one-element list
      * @param HttpRequest|null        $encapsulatedRequest  Encapsulated HTTP request (REQMOD)
      * @param HttpResponse|null       $encapsulatedResponse Encapsulated HTTP response (RESPMOD)
      * @param bool                    $previewIsComplete    When true, the body attached to the encapsulated HTTP

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -16,6 +16,8 @@ use Ndrstmr\Icap\Exception\IcapServerException;
 use Ndrstmr\Icap\Transport\AsyncAmpTransport;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\Transport\TransportInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Core asynchronous ICAP client used by the synchronous wrapper.
@@ -23,6 +25,7 @@ use Ndrstmr\Icap\Transport\TransportInterface;
 final class IcapClient implements IcapClientInterface
 {
     private PreviewStrategyInterface $previewStrategy;
+    private LoggerInterface $logger;
 
     public function __construct(
         private Config $config,
@@ -30,8 +33,10 @@ final class IcapClient implements IcapClientInterface
         private RequestFormatterInterface $formatter,
         private ResponseParserInterface $parser,
         ?PreviewStrategyInterface $previewStrategy = null,
+        ?LoggerInterface $logger = null,
     ) {
         $this->previewStrategy = $previewStrategy ?? new DefaultPreviewStrategy();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -76,8 +81,33 @@ final class IcapClient implements IcapClientInterface
     {
         /** @var Future<ScanResult> $future */
         $future = \Amp\async(function () use ($request): ScanResult {
-            $response = $this->executeRaw($request)->await();
-            return $this->interpretResponse($response, $this->config);
+            $context = [
+                'method' => $request->method,
+                'uri'    => $request->uri,
+                'host'   => $this->config->host,
+                'port'   => $this->config->port,
+            ];
+            $this->logger->info('ICAP request started', $context);
+
+            $response = null;
+            try {
+                $response = $this->executeRaw($request)->await();
+                $result = $this->interpretResponse($response, $this->config);
+            } catch (\Throwable $e) {
+                $this->logger->warning('ICAP request failed', $context + [
+                    'statusCode' => $response?->statusCode,
+                    'exception'  => $e::class,
+                    'message'    => $e->getMessage(),
+                ]);
+                throw $e;
+            }
+
+            $this->logger->info('ICAP request completed', $context + [
+                'statusCode' => $response->statusCode,
+                'infected'   => $result->isInfected(),
+            ]);
+
+            return $result;
         });
 
         return $future;
@@ -120,8 +150,12 @@ final class IcapClient implements IcapClientInterface
      * @throws \RuntimeException When the file cannot be opened
      */
     #[\Override]
-    public function scanFile(string $service, string $filePath): Future
+    public function scanFile(string $service, string $filePath, array $extraHeaders = []): Future
     {
+        // Validate first so injection attempts never reach the socket.
+        $this->validateIcapHeaders($extraHeaders);
+        $uri = $this->buildServiceUri($service);
+
         $stream = fopen($filePath, 'rb');
         if ($stream === false) {
             throw new \RuntimeException('Unable to open file: ' . $filePath);
@@ -139,7 +173,8 @@ final class IcapClient implements IcapClientInterface
 
         $request = new IcapRequest(
             method: 'RESPMOD',
-            uri: $this->buildServiceUri($service),
+            uri: $uri,
+            headers: $extraHeaders,
             encapsulatedResponse: $httpResponse,
         );
 
@@ -156,15 +191,20 @@ final class IcapClient implements IcapClientInterface
      * @throws \RuntimeException When the file cannot be opened
      */
     #[\Override]
-    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future
-    {
+    public function scanFileWithPreview(
+        string $service,
+        string $filePath,
+        int $previewSize = 1024,
+        array $extraHeaders = [],
+    ): Future {
         if ($previewSize < 1) {
             throw new \InvalidArgumentException('Preview size must be >= 1, got: ' . $previewSize);
         }
+        $this->validateIcapHeaders($extraHeaders);
 
         /** @var int<1, max> $previewSize */
         /** @var Future<ScanResult> $future */
-        $future = \Amp\async(function () use ($service, $filePath, $previewSize): ScanResult {
+        $future = \Amp\async(function () use ($service, $filePath, $previewSize, $extraHeaders): ScanResult {
             $fileSize = filesize($filePath);
             if ($fileSize === false) {
                 throw new \RuntimeException('Unable to stat file: ' . $filePath);
@@ -191,13 +231,18 @@ final class IcapClient implements IcapClientInterface
                 body: $previewBytes,
             );
 
+            // Merge caller-supplied headers, but library-managed headers
+            // MUST win: letting the caller override Preview/Allow would
+            // put the protocol exchange into an inconsistent state.
+            $headers = $this->mergeHeaders($extraHeaders, [
+                'Preview' => [(string) $previewSize],
+                'Allow'   => ['204'],
+            ]);
+
             $previewRequest = new IcapRequest(
                 method: 'RESPMOD',
                 uri: $this->buildServiceUri($service),
-                headers: [
-                    'Preview' => [(string) $previewSize],
-                    'Allow'   => ['204'],
-                ],
+                headers: $headers,
                 encapsulatedResponse: $previewEnvelope,
                 previewIsComplete: $previewIsComplete,
             );
@@ -247,6 +292,7 @@ final class IcapClient implements IcapClientInterface
             $fullRequest = new IcapRequest(
                 method: 'RESPMOD',
                 uri: $this->buildServiceUri($service),
+                headers: $extraHeaders,
                 encapsulatedResponse: $fullResponse,
             );
 
@@ -346,7 +392,58 @@ final class IcapClient implements IcapClientInterface
 
     private function extractVirusName(IcapResponse $response, Config $config): ?string
     {
-        $header = $config->getVirusFoundHeader();
-        return $response->headers[$header][0] ?? null;
+        foreach ($config->getVirusFoundHeaders() as $header) {
+            if (isset($response->headers[$header][0])) {
+                return $response->headers[$header][0];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reject header names or values that contain CR/LF, NUL or would
+     * otherwise break the wire format. Finding H, applied to
+     * user-supplied ICAP headers in addition to the service path.
+     *
+     * @param array<string, string|string[]> $headers
+     */
+    private function validateIcapHeaders(array $headers): void
+    {
+        foreach ($headers as $name => $value) {
+            if (preg_match('/[\x00-\x1F\x7F:]/', $name) === 1) {
+                throw new \InvalidArgumentException(
+                    'ICAP header name contains control characters or separator: ' . var_export($name, true),
+                );
+            }
+            foreach ((array) $value as $v) {
+                if (preg_match('/[\x00\r\n]/', $v) === 1) {
+                    throw new \InvalidArgumentException(
+                        sprintf('ICAP header %s carries a value with CR/LF/NUL; refusing to send.', $name),
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Merge caller-supplied headers with library-managed headers. The
+     * library-managed map always wins, keeping protocol-critical
+     * headers (Preview, Allow, Encapsulated, Host) out of caller
+     * control.
+     *
+     * @param  array<string, string|string[]> $caller
+     * @param  array<string, string[]>        $managed
+     * @return array<string, string[]>
+     */
+    private function mergeHeaders(array $caller, array $managed): array
+    {
+        $merged = [];
+        foreach ($caller as $name => $value) {
+            $merged[$name] = (array) $value;
+        }
+        foreach ($managed as $name => $value) {
+            $merged[$name] = $value;
+        }
+        return $merged;
     }
 }

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -34,14 +34,25 @@ interface IcapClientInterface
     /**
      * Scan a local file via RESPMOD.
      *
+     * @param array<string, string|string[]> $extraHeaders Extra ICAP request
+     *        headers, e.g. `['X-Client-IP' => '203.0.113.5']`. Library-managed
+     *        headers (`Host`, `Encapsulated`) always take precedence.
      * @return Future<ScanResult>
      */
-    public function scanFile(string $service, string $filePath): Future;
+    public function scanFile(string $service, string $filePath, array $extraHeaders = []): Future;
 
     /**
      * Scan a file using preview mode, streaming the remainder on demand.
      *
+     * @param array<string, string|string[]> $extraHeaders See {@see scanFile()}.
+     *        `Preview` and `Allow` are library-managed and cannot be
+     *        overridden via this parameter.
      * @return Future<ScanResult>
      */
-    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future;
+    public function scanFileWithPreview(
+        string $service,
+        string $filePath,
+        int $previewSize = 1024,
+        array $extraHeaders = [],
+    ): Future;
 }

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -61,18 +61,24 @@ final class SynchronousIcapClient
     }
 
     /**
+     * @param array<string, string|string[]> $extraHeaders
      * @throws \RuntimeException
      */
-    public function scanFile(string $service, string $filePath): ScanResult
+    public function scanFile(string $service, string $filePath, array $extraHeaders = []): ScanResult
     {
-        return $this->asyncClient->scanFile($service, $filePath)->await();
+        return $this->asyncClient->scanFile($service, $filePath, $extraHeaders)->await();
     }
 
     /**
+     * @param array<string, string|string[]> $extraHeaders
      * @throws \RuntimeException
      */
-    public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): ScanResult
-    {
-        return $this->asyncClient->scanFileWithPreview($service, $filePath, $previewSize)->await();
+    public function scanFileWithPreview(
+        string $service,
+        string $filePath,
+        int $previewSize = 1024,
+        array $extraHeaders = [],
+    ): ScanResult {
+        return $this->asyncClient->scanFileWithPreview($service, $filePath, $previewSize, $extraHeaders)->await();
     }
 }

--- a/tests/CustomRequestHeadersTest.php
+++ b/tests/CustomRequestHeadersTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * M3.6 — custom ICAP request headers.
+ *
+ * Real deployments need to pass `X-Client-IP`, `X-Authenticated-User`,
+ * `X-Server-IP` etc. through to the ICAP server for policy decisions
+ * (RFC 3507 §4.3.2 + de-facto vendor additions). Both scanFile and
+ * scanFileWithPreview must accept an optional $extraHeaders map.
+ */
+
+it('scanFile merges caller-supplied headers into the outgoing request', function () {
+    $captured = null;
+
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->withArgs(function (IcapRequest $req) use (&$captured) {
+        $captured = $req;
+        return true;
+    });
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(204));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, 'payload');
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp, &$captured) {
+        $client->scanFile('/svc', $tmp, [
+            'X-Client-IP'          => '203.0.113.5',
+            'X-Authenticated-User' => 'dGVzdA==',
+        ])->await();
+
+        assert($captured instanceof IcapRequest);
+        expect($captured->headers['X-Client-IP'])->toBe(['203.0.113.5'])
+            ->and($captured->headers['X-Authenticated-User'])->toBe(['dGVzdA==']);
+    });
+
+    unlink($tmp);
+    m::close();
+});
+
+it('scanFileWithPreview merges caller-supplied headers without overriding Preview/Allow', function () {
+    $captured = null;
+
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->withArgs(function (IcapRequest $req) use (&$captured) {
+        $captured = $req;
+        return true;
+    });
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(204));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, 'abc');
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp, &$captured) {
+        $client->scanFileWithPreview('/svc', $tmp, 3, [
+            'X-Client-IP' => '203.0.113.99',
+            // Caller tries to override Preview — library-managed
+            // headers MUST win to keep the protocol state sound.
+            'Preview'     => 'ignored',
+            'Allow'       => 'also-ignored',
+        ])->await();
+
+        assert($captured instanceof IcapRequest);
+        expect($captured->headers['X-Client-IP'])->toBe(['203.0.113.99'])
+            ->and($captured->headers['Preview'])->toBe(['3'])
+            ->and($captured->headers['Allow'])->toBe(['204']);
+    });
+
+    unlink($tmp);
+    m::close();
+});
+
+it('rejects header names that contain CR/LF (injection)', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->scanFile('/svc', __FILE__, ["X-Bad\r\nInjected" => 'value']))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects header values that contain CR/LF (injection)', function () {
+    $client = IcapClient::forServer('icap.example');
+    expect(fn () => $client->scanFile('/svc', __FILE__, ['X-Bad' => "value\r\nInjected: 1"]))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/LoggerIntegrationTest.php
+++ b/tests/LoggerIntegrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+use Psr\Log\LoggerInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * M3.1 — PSR-3 logger observability.
+ *
+ * The client must emit structured events at request start and at
+ * request completion (with status code). Deployments in the public
+ * sector rely on this for BSI-Grundschutz-compatible auditing.
+ */
+
+it('logs a request-started event with the ICAP method + service URI', function () {
+    /** @var LoggerInterface&\Mockery\MockInterface $logger */
+    $logger = m::mock(LoggerInterface::class);
+
+    /** @var \Mockery\Expectation $start */
+    $start = $logger->shouldReceive('info');
+    $start->once();
+    $start->withArgs(function (string $msg, array $ctx) {
+        return str_contains($msg, 'ICAP request')
+            && ($ctx['method'] ?? null) === 'OPTIONS'
+            && str_contains((string) ($ctx['uri'] ?? ''), '/svc');
+    });
+
+    /** @var \Mockery\Expectation $done */
+    $done = $logger->shouldReceive('info');
+    $done->once();
+    $done->withArgs(function (string $msg, array $ctx) {
+        return str_contains($msg, 'completed')
+            && ($ctx['statusCode'] ?? null) === 204;
+    });
+
+    [$client] = buildClientWithLogger($logger, new IcapResponse(204));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/svc')->await();
+    });
+
+    m::close();
+});
+
+it('logs a warning when the request raises an exception', function () {
+    /** @var LoggerInterface&\Mockery\MockInterface $logger */
+    $logger = m::mock(LoggerInterface::class);
+
+    // Start event always fires.
+    /** @var \Mockery\Expectation $start */
+    $start = $logger->shouldReceive('info');
+    $start->once();
+    // Warning carries the status code when available.
+    /** @var \Mockery\Expectation $warn */
+    $warn = $logger->shouldReceive('warning');
+    $warn->once();
+    $warn->withArgs(function (string $msg, array $ctx) {
+        return str_contains($msg, 'failed')
+            && ($ctx['statusCode'] ?? null) === 503;
+    });
+
+    [$client] = buildClientWithLogger($logger, new IcapResponse(503));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        expect(fn () => $client->options('/svc')->await())->toThrow(\Ndrstmr\Icap\Exception\IcapServerException::class);
+    });
+
+    m::close();
+});
+
+/**
+ * @return array{IcapClient}
+ */
+function buildClientWithLogger(LoggerInterface $logger, IcapResponse $canned): array
+{
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn($canned);
+
+    return [new IcapClient($config, $transport, $formatter, $parser, null, $logger)];
+}

--- a/tests/MultiVendorVirusHeadersTest.php
+++ b/tests/MultiVendorVirusHeadersTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * M3.5 — multi-vendor virus-name detection.
+ *
+ * Different ICAP server vendors report infections via different
+ * headers. Config must accept an ordered list of candidate headers
+ * and the client picks the first one the server actually sent.
+ *
+ *   - Clam AV / c-icap:   X-Virus-Name
+ *   - Trend Micro:        X-Violations-Found
+ *   - ISS Proventia:      X-Infection-Found
+ *   - Symantec:           X-Virus-ID
+ */
+
+/**
+ * @param list<string>            $virusHeaders
+ * @param array<string, string[]> $headers
+ */
+function buildClientWithVirusHeaders(array $virusHeaders, array $headers): IcapClient
+{
+    $config = (new Config('icap.example'))->withVirusFoundHeaders($virusHeaders);
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(200, $headers));
+
+    return new IcapClient($config, $transport, $formatter, $parser);
+}
+
+it('backwards-compat: Config defaults to X-Virus-Name only', function () {
+    $cfg = new Config('h');
+    expect($cfg->getVirusFoundHeaders())->toBe(['X-Virus-Name'])
+        ->and($cfg->getVirusFoundHeader())->toBe('X-Virus-Name');
+});
+
+it('detects a virus via the first vendor header that is present', function () {
+    $client = buildClientWithVirusHeaders(
+        ['X-Virus-Name', 'X-Infection-Found', 'X-Violations-Found'],
+        ['X-Infection-Found' => ['Type=0; Resolution=2; Threat=EICAR;']],
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $res = $client->options('/svc')->await();
+        expect($res->isInfected())->toBeTrue()
+            ->and($res->getVirusName())->toBe('Type=0; Resolution=2; Threat=EICAR;');
+    });
+
+    m::close();
+});
+
+it('returns clean when none of the configured virus headers is present', function () {
+    $client = buildClientWithVirusHeaders(
+        ['X-Virus-Name', 'X-Infection-Found'],
+        ['ISTag' => ['"1234"']],
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $res = $client->options('/svc')->await();
+        expect($res->isInfected())->toBeFalse();
+    });
+
+    m::close();
+});
+
+it('picks the first header in the configured order when multiple are present', function () {
+    $client = buildClientWithVirusHeaders(
+        ['X-Virus-Name', 'X-Infection-Found'],
+        [
+            'X-Virus-Name'      => ['Eicar-Test'],
+            'X-Infection-Found' => ['Type=0; Threat=OtherName;'],
+        ],
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $res = $client->options('/svc')->await();
+        expect($res->getVirusName())->toBe('Eicar-Test');
+    });
+
+    m::close();
+});
+
+it('rejects an empty virus-header list', function () {
+    expect(fn () => (new Config('h'))->withVirusFoundHeaders([]))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -61,7 +61,7 @@ it('scanFile delegates correctly to async client', function () {
     $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');
-    $exp->with('/service', '/tmp/file');
+    $exp->with('/service', '/tmp/file', []);
     $exp->once();
     $exp->andReturn(\Amp\Future::complete($result));
 
@@ -101,7 +101,7 @@ it('it handles and rethrows exceptions from async client', function () {
     $exception = new \Ndrstmr\Icap\Exception\IcapConnectionException('fail');
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');
-    $exp->with('/service', '/tmp/file');
+    $exp->with('/service', '/tmp/file', []);
     $exp->once();
     $exp->andReturn(\Amp\Future::error($exception));
 


### PR DESCRIPTION
## Context

M3 of the v2.0.0 effort. First three items of the Ecosystem-Fit milestone from [`docs/review/consolidated_task-list.md`](../blob/main/docs/review/consolidated_task-list.md). The remaining M3 items (Cancellation in public API, OPTIONS cache, 503 retry, keep-alive pooling) are substantial enough to ship as follow-up PRs rather than bloat this one.

Runtime dep added: `psr/log ^3.0`.

## PSR-3 Logger (M3.1)

`IcapClient` accepts an optional `LoggerInterface` (defaults to `NullLogger`) and emits three structured events per public `request()` call:

| Level | Message | Context keys |
|---|---|---|
| info | `ICAP request started` | method, uri, host, port |
| info | `ICAP request completed` | + statusCode, infected |
| warning | `ICAP request failed` | + statusCode (if known), exception, message |

Fits BSI-Grundschutz / Dataport auditability flagged in the due-diligence review. Zero cost when no logger is injected.

## Multi-vendor virus headers (M3.5)

Different ICAP vendors use different infection headers:

- Clam AV / c-icap: `X-Virus-Name` (default, back-compat)
- Trend Micro: `X-Violations-Found`
- ISS Proventia: `X-Infection-Found`
- Symantec: `X-Virus-ID`

`Config` now carries an ordered list; the client scans it in order and returns the first match. New API:

```php
$config = (new Config('icap.example'))->withVirusFoundHeaders([
    'X-Virus-Name', 'X-Infection-Found', 'X-Violations-Found',
]);
```

`Config::withVirusFoundHeader(string)` kept as a back-compat shortcut for the single-header case. Empty lists rejected with `InvalidArgumentException`.

## Custom ICAP request headers (M3.6)

`scanFile()` and `scanFileWithPreview()` gained an optional `array $extraHeaders` parameter. Real deployments need to pass `X-Client-IP`, `X-Authenticated-User`, `X-Server-IP` etc. through for policy decisions.

Two hard invariants:
1. **Header names / values are validated** for CR/LF/NUL/control characters (finding H, applied to the headers map as well as `$service`). Injection attempts fail fast with `InvalidArgumentException` before any byte is written.
2. **Library-managed headers always win**: a caller cannot override `Preview`, `Allow`, `Encapsulated`, or `Host` — those are protocol-critical and would otherwise corrupt the exchange.

`IcapClientInterface` and `SynchronousIcapClient` got matching signatures; the parameter is optional so existing call sites work unchanged.

## Tests

**New:**
- `tests/LoggerIntegrationTest.php` — start/complete pair on a clean run, start/failed pair on 5xx.
- `tests/MultiVendorVirusHeadersTest.php` — default back-compat, first-match-wins, header-not-present returns clean, ordering semantics, empty-list rejection.
- `tests/CustomRequestHeadersTest.php` — caller headers merged in scanFile / scanFileWithPreview, library-managed headers winning over caller, CRLF in header name / value rejected.

**Updated:** `SynchronousIcapClientTest` — new trailing `$extraHeaders = []` parameter.

## Verification

- [x] `composer test` — **66 passed**, 1 pre-existing network warning, 145 assertions.
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix 8.4 + 8.5 both green.

## Deferred to follow-up PRs

- **Cancellation** in the public API (`Amp\Cancellation` parameter)
- **OPTIONS-response cache** keyed by `host:port/service`, TTL from `Options-TTL`
- **503 retry** with exponential backoff (likely a decorator around `IcapClientInterface`)
- **Keep-Alive connection pooling** in `AsyncAmpTransport` (requires transport-level redesign; invasive enough that it really does need its own PR)

## Next

After M3 follow-ups land, **M4** — Test infrastructure: c-icap + ClamAV docker-compose, `tests/Integration/` against real servers with EICAR fixtures, coverage/mutation gates, PHPStan 2.x upgrade, `roave/security-advisories` in dev-deps.