### PR TITLE
docs(v2): M5 — README + AI-origin disclaimer, migration guide, SECURITY.md, SPDX headers

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,11 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src')
     ->in(__DIR__ . '/tests');
 
+$header = <<<'HEADER'
+SPDX-License-Identifier: EUPL-1.2
+
+This file is part of icap-flow.
+
+Licensed under the EUPL, Version 1.2 only (the "Licence");
+you may not use this work except in compliance with the Licence.
+You may obtain a copy of the Licence at:
+
+    https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the Licence is distributed on an "AS IS" basis,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+HEADER;
+
 return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
+        'header_comment' => [
+            'header' => $header,
+            'comment_type' => 'PHPDoc',
+            'location' => 'after_open',
+            'separate' => 'both',
+        ],
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2025-06-18
+## [Unreleased]
+
+### Added
+- This release line will track post-v2.0.0 follow-up work, in particular: `Cancellation` in the public client API, OPTIONS-response cache, 503 retry with exponential backoff, single-connection preview-continue (RFC 3507 §4.5), keep-alive connection pooling.
+
+## [2.0.0] - 2026-04-24
+
+### Why a major release
+v1.0.0 had several RFC-3507-blocking bugs that no real ICAP server (c-icap, Symantec, Sophos, Kaspersky, Trend Micro) would have accepted, plus a fail-open security bug in the response interpreter. Closing those required wire-format changes that are by definition breaking.
+
+### Breaking changes
+- **Minimum PHP version is 8.4.** The CI matrix tests 8.4 and 8.5.
+- `IcapRequest`: removed `mixed $body`; encapsulated payload is now modelled by two typed slots (`?HttpRequest $encapsulatedRequest`, `?HttpResponse $encapsulatedResponse`) plus a `bool $previewIsComplete` flag.
+- `RequestFormatterInterface::format()` now returns `iterable<string>` instead of one big `string`. Transports stream chunks onto the socket, so multi-GB encapsulated bodies are never buffered.
+- `TransportInterface::request()` now accepts `iterable<string>` for the raw request.
+- `IcapClient::scanFile()` and `IcapClient::scanFileWithPreview()` gained an optional `array $extraHeaders = []` parameter.
+- `Config` constructor signature changed: TLS context, DoS limits and the multi-vendor virus-header list moved into named-argument territory; the legacy single-string `$virusFoundHeader` param is still accepted but the canonical accessor is `getVirusFoundHeaders(): list<string>`.
+- `interpretResponse()` is no longer fail-open on status 100 — a stray 100 outside the preview flow now raises `IcapProtocolException`. 4xx responses raise `IcapClientException`, 5xx raise `IcapServerException`.
+- New runtime dependency: `psr/log ^3.0`.
+- New explicit dependency: `revolt/event-loop ^1.0` (was a hidden transitive in v1).
+- `tests/RequestFormatterTest.php` deleted (it asserted the broken wire format and blocked any real fix). Replaced by `tests/Wire/RequestFormatterWireTest.php` with hand-computed RFC-3507 byte fixtures.
+
+### Added — RFC 3507 correctness
+- Real `Encapsulated` offsets, computed from the rendered HTTP header block length. No more hardcoded `null-body=0` when a body is present.
+- HTTP-in-ICAP nesting: the encapsulated block is a real HTTP/1.1 request or response, not naked file bytes.
+- String- **and** stream-resource bodies are always chunk-encoded.
+- `0; ieof\r\n\r\n` terminator when the preview window is the complete payload (RFC 3507 §4.5).
+- `Allow: 204` is sent on every preview request.
+- `ResponseParser` honours the server's `Encapsulated` header to locate the HTTP body inside the encapsulated block; null-body responses now return `body=''` as RFC 3507 §4.4.1 mandates.
+- `ResponseParser` accepts both `ICAP/1.0` and `ICAP/1.1` status lines.
+- `ResponseParser` honours RFC 7230 §3.2.4 obsolete header line folding (whitespace-prefixed continuation lines), required to parse c-icap's multi-line `X-Violations-Found` header (§6.4).
+
+### Added — security hardening
+- **Fail-secure on 100 Continue** outside a preview exchange (`IcapProtocolException`).
+- **CRLF / NUL / control-character validation** on `$service` and on every user-supplied ICAP header name and value, before any byte is written to the socket.
+- **TLS / `icaps://`** via `Config::withTlsContext(ClientTlsContext)` — `AsyncAmpTransport` switches to `Socket\connectTls()`. `SynchronousStreamTransport` explicitly rejects TLS at runtime.
+- **DoS limits**: `maxResponseSize` (default 10 MB), `maxHeaderCount` (100), `maxHeaderLineLength` (8 KB) — enforced in both transports' read loops and in the parser.
+- **`SynchronousStreamTransport` hardening**: connect timeout from `Config::getSocketTimeout()` (was hardcoded 5 s), `stream_set_timeout()` per connection, try/finally `fclose()`, bounded `fread()` loop replacing the unbounded `stream_get_contents()`.
+- **Full status-code matrix**: 4xx → `IcapClientException(code)`, 5xx → `IcapServerException(code)`, 206 inspected for virus header, 200 unchanged, 204 clean.
+
+### Added — ecosystem fit
+- **PSR-3 logger** optional injection on `IcapClient`. Three structured events per request (`info` started / `info` completed / `warning` failed) with method, URI, host, port, status code, infected flag.
+- **Multi-vendor virus headers**: `Config::withVirusFoundHeaders(list<string>)` and `getVirusFoundHeaders(): list<string>`. The client returns the first header that the server actually sent.
+- **Custom request headers** on `scanFile()` / `scanFileWithPreview()` — `X-Client-IP`, `X-Authenticated-User`, etc. — with CRLF guard and library-managed-headers-win semantics.
+
+### Added — exception taxonomy
+- New marker interface `Ndrstmr\Icap\Exception\IcapExceptionInterface`. Every concrete exception implements it.
+- `IcapProtocolException`, `IcapTimeoutException`, `IcapClientException`, `IcapServerException`, `IcapMalformedResponseException` (extends `IcapProtocolException`).
+- `IcapClient` is now `final` and implements the new `IcapClientInterface` contract. `RequestFormatter`, `ResponseParser`, `DefaultPreviewStrategy`, `SynchronousStreamTransport` are also `final`.
+- `#[\Override]` attributes on every interface implementation.
+
+### Added — test infrastructure
+- `tests/Wire/RequestFormatterWireTest.php` and `tests/Wire/ResponseParserWireTest.php` with hand-computed RFC-3507 byte fixtures.
+- `tests/Security/FailSecureAndValidationTest.php` and `tests/Security/ParserDosLimitsTest.php` covering every branch of the new status matrix and DoS limits.
+- `tests/Integration/IcapServerSmokeTest.php` against a real ICAP server (skips gracefully when `ICAP_HOST` is unset).
+- `docker-compose.yml` for local integration runs against `mnemoshare/clamav-icap:0.14.5`.
+- CI matrix expanded to PHP 8.4 + 8.5; new integration job; `roave/security-advisories` in dev-deps; PHPStan upgraded to 2.x; `beStrictAboutCoverageMetadata` and a separate Integration testsuite in `phpunit.xml.dist`.
+
+### Removed
+- v1 `mixed $body` on `IcapRequest`.
+- v1 wire format with hardcoded `Encapsulated: null-body=0`.
+- v1 `tests/RequestFormatterTest.php` (bug-cementing test).
+- The fail-open mapping of ICAP 100 to `ScanResult(isInfected=false)`.
+
+## [1.0.0] - 2025-06-18 (deprecated)
+
+> **Deprecated.** v1.0.0 ships with several RFC-3507-blocking bugs and a fail-open response mapper. Use v2.0.0+. The full list of v1 findings is in [`docs/review/consolidated_task-list.md`](docs/review/consolidated_task-list.md).
+
 ### Added
 - Initial release of the IcapFlow library.
 - User-friendly `ScanResult` DTO for easy interpretation of scan results.
@@ -13,6 +80,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extensible Preview-Handling via the `PreviewStrategyInterface`.
 - Factory methods (`::create()`) for easy, dependency-free instantiation.
 - Support for ICAP `REQMOD`, `RESPMOD`, and `OPTIONS` methods.
-- Advanced, memory-safe streaming for large file processing via stream resources.
-- Comprehensive test suite (>80% coverage), static analysis (PHPStan Level 9), and a full CI/CD pipeline.
-
+- Streaming for large file processing via stream resources (note: in v1 the preview path still buffered the whole file — fixed in v2).
+- Comprehensive test suite (>80 % coverage), static analysis (PHPStan Level 9), and a full CI/CD pipeline.

--- a/README.md
+++ b/README.md
@@ -11,93 +11,189 @@
 
 # icap-flow
 
-A modern, robust, and async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.3+.
+An async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.4+, focused on RFC 3507 correctness, fail-secure semantics and a small surface area that is comfortable to drop into a Symfony / Laravel / framework-less code base.
 
-## Project Vision
+> [!WARNING]
+> **AI-assisted origin & production-use disclaimer.** Large parts of this library — code, tests, docs and CI plumbing — were authored with substantial AI assistance, captured under three independent due-diligence reviews in [`docs/review/`](docs/review/). The v2 line closes the protocol- and security-blocking findings of those reviews, but a piece of code that scans uploads for malware sits in the security-critical path of any application that uses it. **Do not deploy this in production without a deep, independent review and an integration-test bake-out against the ICAP server you actually use.** A non-exhaustive checklist:
+>
+> - End-to-end test against your production ICAP vendor (c-icap, Symantec, Trend Micro, McAfee Web Gateway, Sophos, Kaspersky, …) — wire formats vary in subtle ways.
+> - Fail-secure verification: confirm an unreachable / 5xx / malformed-response server makes your application **block the upload**, not silently pass it through.
+> - TLS configuration review (cipher policy, hostname verification, cert pinning where appropriate).
+> - Resource limits (`Config::withLimits(...)`) tuned to your traffic profile.
+> - Audit logging via PSR-3 wired into your central log pipeline.
+>
+> This software is provided AS IS under EUPL-1.2; the licence's "no warranty" clauses apply unconditionally.
 
-This library aims to be the de-facto standard solution for PHP developers needing ICAP connectivity, focusing on quality, performance, and an excellent developer experience. For more details, see our [mission charter](docs/agent.md).
+## What changed in v2
+
+`v2.0.0` is a **breaking** release that fixes RFC-3507-blocking bugs in v1. The v1 line is **deprecated**. Highlights:
+
+- **RFC-3507 wire format** is correct: real `Encapsulated` offsets, HTTP-in-ICAP nesting, chunked bodies for both string and stream payloads, `0; ieof` terminator on preview-complete.
+- **Streaming-safe preview** — `scanFileWithPreview()` no longer buffers the file; only the preview window is read.
+- **Fail-secure on status 100** — a stray 100 outside the preview flow now throws `IcapProtocolException` instead of silently mapping to a clean scan.
+- **CRLF / header-injection guard** on `$service` and on user-supplied ICAP headers.
+- **TLS / icaps://** support via amphp's `ClientTlsContext`.
+- **DoS limits** — `maxResponseSize`, `maxHeaderCount`, `maxHeaderLineLength`.
+- **Full status-code matrix** — 4xx → `IcapClientException`, 5xx → `IcapServerException`, 206 inspected, …
+- **Multi-vendor virus headers** — Config takes an ordered list (`X-Virus-Name`, `X-Infection-Found`, `X-Violations-Found`, `X-Virus-ID`).
+- **PSR-3 logger** optional, structured events on every request.
+- **Custom request headers** (`X-Client-IP`, `X-Authenticated-User`) on `scanFile()` / `scanFileWithPreview()`.
+- **PHP 8.4** minimum; **PHP 8.5** in CI.
+
+The migration guide is [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). The full per-finding closure list is in [`docs/review/consolidated_task-list.md`](docs/review/consolidated_task-list.md).
 
 ## Installation
 
 ```bash
-composer require ndrstmr/icap-flow
+composer require ndrstmr/icap-flow:^2.0
 ```
 
-## Basic Usage
-
-For most projects, the `SynchronousIcapClient` offers a very simple, blocking API.
+## Quickstart — synchronous
 
 ```php
+use Ndrstmr\Icap\SynchronousIcapClient;
+
 $icap = SynchronousIcapClient::create();
 
-$result = $icap->scanFile('/service', '/path/to/your/file.txt');
+$result = $icap->scanFile('/avscan', '/path/to/upload.bin');
 
 echo $result->isInfected()
-    ? 'Virus found: ' . $result->getVirusName()
-    : 'File is clean';
+    ? 'Virus found: ' . $result->getVirusName() . PHP_EOL
+    : 'File is clean' . PHP_EOL;
 ```
 
-## Advanced Usage: Asynchronous Requests
-
-To take advantage of non-blocking I/O, interact with the `IcapClient` directly
-within an event loop:
+## Quickstart — asynchronous (amphp v3 / Revolt)
 
 ```php
+use Ndrstmr\Icap\IcapClient;
 use Revolt\EventLoop;
 
 $icap = IcapClient::create();
 
 EventLoop::run(function () use ($icap) {
-    $future = $icap->scanFile('/service', '/path/to/your/file.txt');
+    $future = $icap->scanFile('/avscan', '/path/to/upload.bin');
     $result = $future->await();
 
     echo $result->isInfected()
         ? 'Virus: ' . $result->getVirusName() . PHP_EOL
-        : 'File is clean' . PHP_EOL;
+        : 'Clean' . PHP_EOL;
 });
 ```
 
 ## Configuration
 
-Adjust the connection settings using the `Config` DTO:
-
 ```php
+use Amp\Socket\ClientTlsContext;
 use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
 
-$config = new Config(
+$config = (new Config(
     host: 'icap.example.com',
-    port: 1344,
+    port: 11344,                 // 1344 is plain ICAP, 11344 is the de-facto TLS port
     socketTimeout: 5.0,
     streamTimeout: 30.0,
-    // Header used by the ICAP server to report infections
-    virusFoundHeader: 'X-Virus-Name',
+))
+    ->withTlsContext(new ClientTlsContext('icap.example.com'))
+    ->withVirusFoundHeaders([
+        'X-Virus-Name',          // ClamAV / c-icap
+        'X-Infection-Found',     // ISS Proventia
+        'X-Violations-Found',    // Trend Micro
+        'X-Virus-ID',            // Symantec
+    ])
+    ->withLimits(
+        maxResponseSize: 10 * 1024 * 1024,
+        maxHeaderCount: 100,
+        maxHeaderLineLength: 8192,
+    );
+
+$client = new IcapClient(
+    $config,
+    new AsyncAmpTransport(),
+    new RequestFormatter(),
+    new ResponseParser(
+        maxHeaderCount: $config->getMaxHeaderCount(),
+        maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+    ),
+    null,                        // PreviewStrategyInterface (DefaultPreviewStrategy if null)
+    $logger,                     // Psr\Log\LoggerInterface (NullLogger if null)
 );
 ```
 
-This object can be passed to the client factory methods.
+## Custom request headers
 
-## Extensibility (Cookbook)
-
-Preview handling uses the Strategy pattern. Custom strategies implement
-`PreviewStrategyInterface` and can be registered on the client. Detailed
-examples can be found in the [`examples/cookbook/`](examples/cookbook/) directory.
-
-## For Developers
-
-Run the test suite with the following command:
-
-```bash
-composer test
+```php
+$result = $icap->scanFile('/avscan', '/path/to/upload.bin', [
+    'X-Client-IP'          => '203.0.113.5',
+    'X-Authenticated-User' => base64_encode('user@example.org'),
+]);
 ```
 
-Further details about the pull request workflow can be found in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+Header names and values are validated against CR / LF / NUL / control characters — injection attempts raise `InvalidArgumentException` before any byte hits the socket. Library-managed headers (`Encapsulated`, `Host`, `Connection`, and inside the preview flow `Preview` / `Allow`) always take precedence over caller-supplied values.
 
-## License
+## Exception taxonomy
 
-This project is licensed under the EUPL-1.2 License. See the LICENSE file for details.
+Every exception this library throws implements `Ndrstmr\Icap\Exception\IcapExceptionInterface` so you can catch the whole family in one block.
+
+| Exception | Trigger |
+|---|---|
+| `IcapConnectionException` | TCP-level failure (refused, timeout, TLS handshake, ...) |
+| `IcapTimeoutException` | Stream cancellation timed out |
+| `IcapProtocolException` | RFC-3507 violation (e.g. status 100 outside preview, malformed `Encapsulated`) |
+| `IcapMalformedResponseException` (extends `IcapProtocolException`) | Server response can't be parsed (no separator, header line without `:`, oversize lines) |
+| `IcapClientException` | ICAP 4xx response — request rejected by server, code is the real status |
+| `IcapServerException` | ICAP 5xx response — server failed, code is the real status |
+| `IcapResponseException` | Status code that doesn't fit any other bucket |
+
+## Examples
+
+The `examples/` directory has runnable demos, including a full Symfony-ready async cookbook:
+
+- `examples/01-sync-scan.php` — minimal synchronous scan
+- `examples/02-async-scan.php` — async scan inside `Revolt\EventLoop`
+- `examples/cookbook/01-custom-headers.php` — `X-Client-IP`, `X-Authenticated-User`
+- `examples/cookbook/02-custom-preview-strategy.php` — vendor-specific preview interpretation
+- `examples/cookbook/03-options-request.php` — capability discovery via OPTIONS
+
+## Integration tests
+
+A docker-compose stack (`docker-compose.yml`) brings up [`mnemoshare/clamav-icap`](https://hub.docker.com/r/mnemoshare/clamav-icap) on port 1344. The tests in `tests/Integration/` skip when `ICAP_HOST` is unset, so contributors without Docker get a green `composer test:integration` while CI exercises a real wire-level round trip on every PR.
+
+```bash
+docker compose up -d
+ICAP_HOST=127.0.0.1 ICAP_PORT=1344 \
+  ICAP_ECHO_SERVICE=/avscan \
+  ICAP_CLAMAV_SERVICE=/avscan \
+    composer test:integration
+```
+
+## Provenance & due diligence
+
+`docs/review/` carries the three independent due-diligence reports (Claude, Codex, Jules) that drove the v2 redesign, and a verified consolidated task list. They are part of the repo, not after-the-fact marketing — every closed finding maps back to a specific file/line in those docs.
+
+## Developers
+
+```bash
+composer test           # unit suite (Pest)
+composer test:integration   # against a configured ICAP server
+composer stan           # PHPStan level 9 + bleedingEdge
+composer cs-check       # PSR-12 (php-cs-fixer)
+composer cs-fix         # apply fixes
+composer audit          # composer + roave/security-advisories
+```
+
+CI matrix: PHP 8.4 + 8.5. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the PR workflow.
+
+## Licence
+
+EUPL-1.2 — see [`LICENSE`](LICENSE). The licence is OpenCoDE-compatible and explicitly designed for European public-sector software.
+
+## Security
+
+To report a vulnerability, see [`SECURITY.md`](SECURITY.md). Please **do not** open a public GitHub issue for security findings.
 
 ## Changelog
 
-A list of all changes can be found in [CHANGELOG.md](CHANGELOG.md).
-
+[`CHANGELOG.md`](CHANGELOG.md) — Keep a Changelog format, SemVer-committed.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security policy
+
+`icap-flow` sits in the security-critical path of any application that uses it for upload virus scanning. We take vulnerability reports seriously.
+
+## Reporting a vulnerability
+
+**Do not** open a public GitHub issue for a security finding.
+
+1. Use GitHub's [private vulnerability report](https://github.com/ndrstmr/icap-flow/security/advisories/new) form, **or**
+2. Open an issue marked "Security disclosure request" — we'll reply with a private channel — without including the details.
+
+Please include:
+- the affected version (`composer.lock` snippet is fine),
+- a clear reproduction or proof of concept (curl / php script / PHPUnit fixture),
+- the impact you observed and what an attacker could do with it,
+- whether the finding is already public elsewhere (CVE, blog post, social media).
+
+## What you can expect
+
+| Step | Target |
+|---|---|
+| Initial acknowledgement | within 5 working days |
+| First triage / severity rating (CVSS v3.1) | within 10 working days |
+| Fix or workaround | depends on severity (see below) |
+| Public advisory | after fix is released, with reporter credit unless anonymity is requested |
+
+### Severity bands and target windows
+
+| CVSS v3.1 | Target fix window |
+|---|---|
+| 9.0 – 10.0 (Critical) | 7 days |
+| 7.0 – 8.9 (High) | 30 days |
+| 4.0 – 6.9 (Medium) | 90 days |
+| 0.1 – 3.9 (Low) | next regular release |
+
+These are targets, not contractual SLAs.
+
+## Coordinated disclosure
+
+We follow [responsible disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure):
+
+1. You report privately.
+2. We confirm and develop a fix.
+3. We coordinate a release date with you.
+4. The advisory is published with your name (or anonymously) on the agreed date.
+5. We file a CVE where appropriate.
+
+## Scope
+
+In scope:
+- Anything in `src/` of this repository.
+- The published Composer package on Packagist (`ndrstmr/icap-flow`).
+- The default `docker-compose.yml` and CI workflow shipped in this repo.
+
+Out of scope:
+- Vulnerabilities in your ICAP server (c-icap, ClamAV, vendor products) — report those upstream.
+- Vulnerabilities in transitive Composer dependencies — see their own security policies.
+- Issues that require privileged local access to the host running the library.
+
+## Security-relevant defaults & guarantees
+
+The v2 line was reviewed against three independent due-diligence reports (`docs/review/`) and ships with the following guarantees you can audit:
+
+- **Fail-secure on protocol errors.** ICAP `100 Continue` outside a preview exchange raises `IcapProtocolException` — never a clean scan result.
+- **CRLF / NUL / control-character validation** on `$service` and on every user-supplied request header (name + value), enforced before any byte hits the socket.
+- **TLS available** via `Config::withTlsContext(ClientTlsContext)`. The default `ClientTlsContext` performs hostname verification against the certificate.
+- **Bounded reads.** `Config::withLimits(maxResponseSize, maxHeaderCount, maxHeaderLineLength)` caps every response. Defaults: 10 MB total, 100 headers, 8 KB per line.
+- **No fail-open on 5xx.** Server errors raise `IcapServerException`. Your application is responsible for blocking the upload — the library will never silently report it as clean.
+
+## What this library does NOT guarantee
+
+- It does **not** authenticate the ICAP server beyond TLS hostname verification — if you need mutual TLS or pinning, configure the `ClientTlsContext` accordingly.
+- It does **not** retry on transient failures. A `IcapServerException` (5xx) propagates to the caller; the caller must decide whether to retry or fail.
+- It does **not** cache OPTIONS responses (RFC 3507 §4.10.2 `Options-TTL`); use a PSR-16 cache decorator if you need this.
+- It does **not** pool connections — each scan opens a fresh TCP/TLS connection. (Pooling is on the post-v2 roadmap.)
+
+## AI-assisted origin
+
+Large parts of this library were authored with substantial AI assistance and reviewed by three independent due-diligence audits. **Do not deploy this in production without an independent review**. See the [`README.md`](README.md) disclaimer block.
+
+## Hall of fame
+
+Reporters who have helped harden `icap-flow` will be listed here once we have any.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -2,7 +2,12 @@
 
 * Agent: OpenAI Codex
 * Date: 17 June 2025
-* Status: Active
+* Status: **Historical — v1.0 charter only.** v2.0 was a substantial redesign driven by three independent due-diligence audits; see [`review/`](review/) for the verified findings and [`migration-v1-to-v2.md`](migration-v1-to-v2.md) for what changed.
+
+> [!NOTE]
+> This document is the original charter that drove the v1.0.0 release. Several of its claims (PSR-7 `StreamInterface` body, Psalm, PHP 8.3 minimum, "Test coverage exceeds 98 %") were aspirational and did not match the v1 implementation, which is part of why the v2 redesign was needed. Kept as provenance — for the current state of the library refer to the top-level [`README.md`](../README.md) and [`CHANGELOG.md`](../CHANGELOG.md).
+
+---
 
 ## 1. Mission Statement & Vision
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -1,0 +1,243 @@
+# Migration guide: v1 → v2
+
+`v2.0.0` is a deliberately breaking release. v1 had RFC-3507-blocking bugs in the wire format and a fail-open security bug in the response interpreter; closing both required wire-format and API surface changes that no semver-friendly minor could have shipped.
+
+This guide walks through every API break and shows the v1 → v2 mapping.
+
+---
+
+## TL;DR
+
+```diff
+-use Ndrstmr\Icap\Config;
+-use Ndrstmr\Icap\IcapClient;
+-use Ndrstmr\Icap\DTO\IcapRequest;
++use Ndrstmr\Icap\Config;
++use Ndrstmr\Icap\IcapClient;
++use Ndrstmr\Icap\DTO\HttpResponse;
++use Ndrstmr\Icap\DTO\IcapRequest;
+
+-$req = new IcapRequest('RESPMOD', $uri, [], $fileBody);
++$req = new IcapRequest(
++    method: 'RESPMOD',
++    uri:    $uri,
++    encapsulatedResponse: new HttpResponse(
++        statusCode: 200,
++        headers:    ['Content-Type' => ['application/octet-stream'], 'Content-Length' => [(string) $size]],
++        body:       $fileBody,
++    ),
++);
+```
+
+For the common case — `scanFile()` and `scanFileWithPreview()` — you don't need to construct anything by hand. The high-level methods do it for you, and the only surface-level change is an optional new `array $extraHeaders = []` parameter.
+
+---
+
+## 1. PHP version
+
+- **v1**: `php >= 8.3`
+- **v2**: `php ^8.4`
+
+The CI matrix runs 8.4 + 8.5. If you can't move off 8.3, stay on `^1.0`.
+
+---
+
+## 2. `IcapRequest`: `mixed $body` is gone
+
+v1 stored a freeform body on `IcapRequest`. v2 splits the encapsulated payload into typed slots that match RFC 3507 semantics:
+
+```diff
+-public function __construct(
+-    public string $method,
+-    public string $uri = '/',
+-    array  $headers = [],
+-    public mixed  $body = '',
+-) { ... }
++public function __construct(
++    public string         $method,
++    public string         $uri = '/',
++    array                 $headers = [],
++    public ?HttpRequest   $encapsulatedRequest  = null,  // REQMOD payload
++    public ?HttpResponse  $encapsulatedResponse = null,  // RESPMOD payload
++    public bool           $previewIsComplete    = false, // emit `0; ieof\r\n\r\n`
++) { ... }
+```
+
+Two new DTOs you'll use to construct payloads:
+
+```php
+namespace Ndrstmr\Icap\DTO;
+
+final readonly class HttpRequest
+{
+    public function __construct(
+        public string $method,
+        public string $requestTarget = '/',
+        /** @var array<string, string[]> */ public array $headers = [],
+        public mixed  $body = null,                      // string | resource | null
+        public string $httpVersion = 'HTTP/1.1',
+    ) {}
+}
+
+final readonly class HttpResponse
+{
+    public function __construct(
+        public int    $statusCode,
+        public string $reasonPhrase = 'OK',
+        /** @var array<string, string[]> */ public array $headers = [],
+        public mixed  $body = null,                      // string | resource | null
+        public string $httpVersion = 'HTTP/1.1',
+    ) {}
+}
+```
+
+If you only ever called `scanFile()` / `scanFileWithPreview()`, you don't construct these by hand — `IcapClient` synthesises a minimal `HttpResponse` envelope around the file for you.
+
+---
+
+## 3. `RequestFormatterInterface::format()` returns `iterable<string>`
+
+v1 returned a single `string`. v2 returns chunks so the transport can stream them onto the socket without buffering multi-GB bodies.
+
+```diff
+-public function format(IcapRequest $request): string;
++public function format(IcapRequest $request): iterable;
+```
+
+If you implemented your own formatter, switch to `yield`:
+
+```php
+public function format(IcapRequest $request): iterable
+{
+    yield $this->renderHead($request);
+    if ($body !== null) {
+        yield from $this->chunkBody($body);
+    }
+}
+```
+
+---
+
+## 4. `TransportInterface::request()` accepts `iterable<string>`
+
+```diff
+-public function request(Config $config, string $rawRequest): \Amp\Future;
++public function request(Config $config, iterable $rawRequest): \Amp\Future;
+```
+
+Transports iterate the chunks and write each one to the socket as it arrives.
+
+---
+
+## 5. `IcapClient::scanFile()` / `scanFileWithPreview()` got a trailing `$extraHeaders`
+
+```diff
+-public function scanFile(string $service, string $filePath): Future;
+-public function scanFileWithPreview(string $service, string $filePath, int $previewSize = 1024): Future;
++public function scanFile(
++    string $service,
++    string $filePath,
++    array  $extraHeaders = [],
++): Future;
++public function scanFileWithPreview(
++    string $service,
++    string $filePath,
++    int    $previewSize = 1024,
++    array  $extraHeaders = [],
++): Future;
+```
+
+Extra headers are caller-controlled metadata like `X-Client-IP`, `X-Authenticated-User`, `X-Server-IP`. Header names and values are validated for CR/LF/NUL/control characters. Library-managed headers (`Encapsulated`, `Host`, `Connection`, `Preview`, `Allow`) always win.
+
+Existing call sites with two positional args still work — the parameter is optional.
+
+---
+
+## 6. `Config` constructor + new accessors
+
+The constructor signature grew. The legacy `string $virusFoundHeader` parameter is still accepted for back-compat, but the canonical accessor is now `getVirusFoundHeaders(): list<string>`.
+
+```php
+$config = (new Config(
+    host: 'icap.example.com',
+    port: 11344,
+    socketTimeout: 5.0,
+    streamTimeout: 30.0,
+))
+    ->withTlsContext(new ClientTlsContext('icap.example.com'))
+    ->withVirusFoundHeaders(['X-Virus-Name', 'X-Infection-Found', 'X-Violations-Found'])
+    ->withLimits(maxResponseSize: 10 * 1024 * 1024, maxHeaderCount: 100, maxHeaderLineLength: 8192);
+```
+
+If you only used `new Config('host')` / `withVirusFoundHeader()`, your code keeps working as-is.
+
+---
+
+## 7. `IcapClient` constructor: optional logger param
+
+```diff
+ public function __construct(
+     Config                       $config,
+     TransportInterface           $transport,
+     RequestFormatterInterface    $formatter,
+     ResponseParserInterface      $parser,
+     ?PreviewStrategyInterface    $previewStrategy = null,
++    ?Psr\Log\LoggerInterface     $logger          = null,
+ );
+```
+
+Defaults to `Psr\Log\NullLogger`. Three structured events per `request()` call: `ICAP request started`, `ICAP request completed`, `ICAP request failed`.
+
+---
+
+## 8. Status-code mapping changed (security fix)
+
+v1's `interpretResponse` mapped status `100 Continue` to `ScanResult(isInfected: false)` — a **fail-open** bug. If a 100 ever leaked outside the preview flow (race, partial read, server bug), malware would have passed as clean.
+
+v2 throws the right exception for every status it doesn't expect:
+
+| Status | v1 behaviour | v2 behaviour |
+|---|---|---|
+| 100 outside preview | `ScanResult(clean)` | `IcapProtocolException` |
+| 4xx | `IcapResponseException` | `IcapClientException(code)` |
+| 5xx | `IcapResponseException` | `IcapServerException(code)` |
+| 206 | `IcapResponseException` | inspect virus header (200-style) |
+
+If you `catch (IcapResponseException $e)` you now want `catch (IcapExceptionInterface $e)` to capture the new richer types in one block.
+
+---
+
+## 9. CRLF guard on `$service`
+
+v1 happily concatenated whatever you passed as `$service` into the request URI. v2 rejects CR/LF/NUL/control/whitespace with `InvalidArgumentException` before any byte is written. If you're passing `$service` through from untrusted input you may need to handle the new exception.
+
+---
+
+## 10. Test surface
+
+If you're vendoring tests:
+- `tests/RequestFormatterTest.php` was deleted (it asserted the broken wire format and blocked the fix).
+- Wire-format expectations now live in `tests/Wire/RequestFormatterWireTest.php` with hand-computed RFC-3507 byte fixtures.
+- Integration tests are gated behind `ICAP_HOST` env vars and skip by default.
+
+---
+
+## 11. New runtime deps
+
+```diff
+ "require": {
+     "php": "^8.4",
+     "amphp/socket": "^2.3",
++    "psr/log": "^3.0",
++    "revolt/event-loop": "^1.0"
+ }
+```
+
+`revolt/event-loop` was a transitive in v1 but the source code already used it — v2 declares it explicitly so you can rely on it.
+
+---
+
+## Need help?
+
+- The full per-finding closure list is in [`docs/review/consolidated_task-list.md`](review/consolidated_task-list.md).
+- Open an issue if you hit something not covered here — please include the v1 code and the migration target.

--- a/docs/review/consolidated_task-list.md
+++ b/docs/review/consolidated_task-list.md
@@ -1,5 +1,7 @@
 # Konsolidierte Task-Liste — v2.0.0 RFC-Compliance & Hardening
 
+> **Status (24.04.2026):** M0 (#36) ✅, M1 (#37) ✅, M2 (#38) ✅, M3-Core (#39) ✅, M4 (#40) ✅. M5 in Arbeit (dieser PR). M3-Follow-ups (Cancellation, OPTIONS-Cache, 503-Retry, Keep-Alive-Pooling) sind als dedizierte Folge-PRs nach v2.0.0 vorgemerkt. **Alle P0-Findings A–N sind geschlossen** — der Integration-Lauf gegen `mnemoshare/clamav-icap` (c-icap 0.6.3 + ClamAV) erkennt EICAR und attestiert Clean-Files korrekt.
+
 **Ziel:** `ndrstmr/icap-flow` zum quasi-Standard PHP-ICAP-Client ausbauen — RFC-3507-konform, fail-secure, streaming-sicher, Symfony-ready.
 
 **Basis:** Synthese der drei unabhängigen Due-Diligence-Reviews in `docs/review/` (Claude, Codex, Jules), verifiziert am aktuellen `src/`-Stand bei commit `ec16785`.
@@ -133,16 +135,16 @@
 ## Milestone M5 — Governance & Doku
 
 **Aufwand:** 1 PT
-**PR:** `docs(v2): SECURITY.md, SPDX headers, migration guide, DE README`
+**PR:** `docs(v2): SECURITY.md, SPDX headers, migration guide, AI disclaimer`
 
-- [ ] **M5.1** `SECURITY.md` (Disclosure-Prozess, contact)
-- [ ] **M5.2** SPDX-Header (`SPDX-License-Identifier: EUPL-1.2`) via `.php-cs-fixer.dist.php`-Regel in allen `src/`- und `tests/`-Dateien
-- [ ] **M5.3** `README.md` ehrlich machen: Versprechen aus `docs/agent.md` entweder einlösen oder dort streichen
-- [ ] **M5.4** `README.de.md` — deutsche Fassung für Public-Sector-Adoption
-- [ ] **M5.5** `docs/migration-v1-to-v2.md` — Breaking-Change-Guide
-- [ ] **M5.6** `CHANGELOG.md` v2.0.0-Entry
-- [ ] **M5.7** Cookbook-Fix: `examples/cookbook/02-custom-preview-strategy.php:16` — 304 ist kein ICAP-Status
-- [ ] **M5.8** v2.0.0-Tag
+- [x] **M5.1** `SECURITY.md` mit Disclosure-Prozess + AI-Origin-Disclaimer
+- [x] **M5.2** SPDX-Header (`SPDX-License-Identifier: EUPL-1.2`) via `.php-cs-fixer.dist.php`-Regel auf allen `src/` + `tests/` Dateien
+- [x] **M5.3** `README.md` ehrlich gemacht: prominenter AI-Origin-Disclaimer + Production-Caveat oben, v2-API-Beispiele, `docs/agent.md` als Historical-Document gekennzeichnet
+- [x] **M5.4** `docs/migration-v1-to-v2.md` — Breaking-Change-Guide
+- [x] **M5.5** `CHANGELOG.md` v2.0.0-Entry, v1.0.0 als deprecated markiert
+- [x] **M5.6** Cookbook-Files (`examples/01-sync-scan.php`, `02-async-scan.php`, `cookbook/01..03.php`) auf v2-API umgeschrieben — Multi-Vendor-Header, `executeRaw`-Pattern, Exception-Taxonomie
+- [ ] **M5.7** v2.0.0-Tag (separater Commit nach M5-Merge, kein Inhalt im PR)
+- [ ] **M5.8** `README.de.md` — deutsche Fassung für Public-Sector-Adoption (verschoben in M5-Follow-up; nicht release-blocking)
 
 ---
 

--- a/examples/01-sync-scan.php
+++ b/examples/01-sync-scan.php
@@ -1,29 +1,45 @@
 <?php
+
+declare(strict_types=1);
+
 require __DIR__ . '/../vendor/autoload.php';
 
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\IcapClient;
-use Ndrstmr\Icap\SynchronousIcapClient;
-use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\RequestFormatter;
 use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\SynchronousIcapClient;
+use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 
-$config = new Config('127.0.0.1', 1344);
+$config = (new Config('127.0.0.1', 1344))->withVirusFoundHeaders([
+    'X-Virus-Name',
+    'X-Infection-Found',
+    'X-Violations-Found',
+    'X-Virus-ID',
+]);
+
 $client = new SynchronousIcapClient(new IcapClient(
     $config,
     new SynchronousStreamTransport(),
     new RequestFormatter(),
-    new ResponseParser()
+    new ResponseParser(
+        maxHeaderCount: $config->getMaxHeaderCount(),
+        maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+    ),
 ));
 
 $eicarFile = __DIR__ . '/eicar.com';
 if (!file_exists($eicarFile)) {
-    file_put_contents($eicarFile, 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*');
+    // EICAR test signature, split so this file itself doesn't trip AV.
+    file_put_contents(
+        $eicarFile,
+        'X5O!P%@AP[4\PZX54(P^)7CC)7}$' . 'EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*',
+    );
 }
 
-echo "Scanning file $eicarFile synchronously...\n";
-$result = $client->scanFile('/service', $eicarFile);
+echo 'Scanning ' . $eicarFile . ' synchronously...' . PHP_EOL;
+$result = $client->scanFile('/avscan', $eicarFile);
 
 echo $result->isInfected()
-    ? 'Virus found: ' . $result->getVirusName() . PHP_EOL
-    : "File is clean\n";
+    ? 'Virus found: ' . ($result->getVirusName() ?? 'unknown') . PHP_EOL
+    : 'File is clean' . PHP_EOL;

--- a/examples/02-async-scan.php
+++ b/examples/02-async-scan.php
@@ -1,35 +1,52 @@
 <?php
+
+declare(strict_types=1);
+
 require __DIR__ . '/../vendor/autoload.php';
 
-use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\Config;
-use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+use Ndrstmr\Icap\Exception\IcapExceptionInterface;
+use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\RequestFormatter;
 use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
 use Revolt\EventLoop;
 
 EventLoop::run(function () {
     try {
-        $config = new Config('127.0.0.1', 1344);
+        $config = (new Config('127.0.0.1', 1344))->withVirusFoundHeaders([
+            'X-Virus-Name',
+            'X-Infection-Found',
+            'X-Violations-Found',
+            'X-Virus-ID',
+        ]);
+
         $eicarFile = __DIR__ . '/eicar.com';
         if (!file_exists($eicarFile)) {
-            file_put_contents($eicarFile, 'X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*');
+            file_put_contents(
+                $eicarFile,
+                'X5O!P%@AP[4\PZX54(P^)7CC)7}$' . 'EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*',
+            );
         }
+
         $client = new IcapClient(
             $config,
             new AsyncAmpTransport(),
             new RequestFormatter(),
-            new ResponseParser()
+            new ResponseParser(
+                maxHeaderCount: $config->getMaxHeaderCount(),
+                maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+            ),
         );
 
-        echo "Scanning file $eicarFile asynchronously...\n";
-        $future = $client->scanFile('/service', $eicarFile);
-        $result = $future->await();
+        echo 'Scanning ' . $eicarFile . ' asynchronously...' . PHP_EOL;
+        $result = $client->scanFile('/avscan', $eicarFile)->await();
 
         echo $result->isInfected()
-            ? 'Virus: ' . $result->getVirusName() . "\n"
-            : "File is clean\n";
-    } catch (\Exception $e) {
-        echo "An error occurred: " . $e->getMessage() . "\n";
+            ? 'Virus: ' . ($result->getVirusName() ?? 'unknown') . PHP_EOL
+            : 'File is clean' . PHP_EOL;
+    } catch (IcapExceptionInterface $e) {
+        echo 'ICAP error (' . $e::class . '): ' . $e->getMessage() . PHP_EOL;
+        exit(1);
     }
 });

--- a/examples/cookbook/01-custom-headers.php
+++ b/examples/cookbook/01-custom-headers.php
@@ -1,15 +1,27 @@
 <?php
+
+declare(strict_types=1);
+
 require __DIR__ . '/../../vendor/autoload.php';
 
-use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\SynchronousIcapClient;
-use Ndrstmr\Icap\DTO\IcapRequest;
+
+/*
+ * Custom ICAP request headers — useful for downstream policy decisions
+ * (X-Client-IP, X-Authenticated-User, X-Server-IP). Header names and
+ * values are validated for CR/LF/NUL before any byte is written, and
+ * library-managed headers (Encapsulated/Host/Connection/Preview/Allow)
+ * always take precedence over caller input.
+ */
 
 $icap = SynchronousIcapClient::create();
 
-$request = (new IcapRequest('RESPMOD', 'icap://127.0.0.1/service'))
-    ->withHeader('X-Client-IP', '203.0.113.5');
+$result = $icap->scanFile('/avscan', __DIR__ . '/../eicar.com', [
+    'X-Client-IP'          => '203.0.113.5',
+    'X-Authenticated-User' => base64_encode('user@example.org'),
+    'X-Server-IP'          => '198.51.100.10',
+]);
 
-$result = $icap->request($request);
-
-print_r($result->getOriginalResponse()->headers);
+echo $result->isInfected()
+    ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+    : 'Clean' . PHP_EOL;

--- a/examples/cookbook/02-custom-preview-strategy.php
+++ b/examples/cookbook/02-custom-preview-strategy.php
@@ -1,35 +1,57 @@
 <?php
+
+declare(strict_types=1);
+
 require __DIR__ . '/../../vendor/autoload.php';
 
-use Ndrstmr\Icap\PreviewStrategyInterface;
-use Ndrstmr\Icap\PreviewDecision;
-use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\PreviewDecision;
+use Ndrstmr\Icap\PreviewStrategyInterface;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+use Revolt\EventLoop;
 
-class McAfeePreviewStrategy implements PreviewStrategyInterface
+/*
+ * Vendors disagree on what constitutes a "clean" or "infected"
+ * preview response. Implement PreviewStrategyInterface to route the
+ * vendor-specific status code matrix into the three decisions
+ * IcapClient understands: CONTINUE_SENDING, ABORT_CLEAN, ABORT_INFECTED.
+ *
+ * Note: 304 is not a defined ICAP status code (RFC 3507 §4.3.3 only
+ * mandates 1xx/2xx/4xx/5xx). The example below maps it conservatively
+ * to ABORT_INFECTED ("treat as suspicious") for vendor profiles that
+ * still emit it; if your server is RFC-compliant, remove that branch.
+ */
+final class McAfeePreviewStrategy implements PreviewStrategyInterface
 {
     public function handlePreviewResponse(IcapResponse $previewResponse): PreviewDecision
     {
         return match ($previewResponse->statusCode) {
-            100 => PreviewDecision::CONTINUE_SENDING,
+            100      => PreviewDecision::CONTINUE_SENDING,
             200, 204 => PreviewDecision::ABORT_CLEAN,
-            304 => PreviewDecision::ABORT_INFECTED,
-            default => PreviewDecision::ABORT_INFECTED,
+            default  => PreviewDecision::ABORT_INFECTED,
         };
     }
 }
 
+$config = new Config('127.0.0.1');
 $client = new IcapClient(
-    new Ndrstmr\Icap\Config('127.0.0.1'),
-    new Ndrstmr\Icap\Transport\AsyncAmpTransport(),
-    new Ndrstmr\Icap\RequestFormatter(),
-    new Ndrstmr\Icap\ResponseParser(),
-    new McAfeePreviewStrategy()
+    $config,
+    new AsyncAmpTransport(),
+    new RequestFormatter(),
+    new ResponseParser(
+        maxHeaderCount: $config->getMaxHeaderCount(),
+        maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+    ),
+    new McAfeePreviewStrategy(),
 );
 
-$future = $client->scanFileWithPreview('/service', __DIR__ . '/../eicar.com');
-$result = $future->await();
-
-echo $result->isInfected()
-    ? 'Virus: ' . $result->getVirusName() . PHP_EOL
-    : 'Clean' . PHP_EOL;
+EventLoop::run(function () use ($client) {
+    $result = $client->scanFileWithPreview('/avscan', __DIR__ . '/../eicar.com')->await();
+    echo $result->isInfected()
+        ? 'Virus: ' . ($result->getVirusName() ?? 'unknown') . PHP_EOL
+        : 'Clean' . PHP_EOL;
+});

--- a/examples/cookbook/03-options-request.php
+++ b/examples/cookbook/03-options-request.php
@@ -1,20 +1,34 @@
 <?php
+
+declare(strict_types=1);
+
 require __DIR__ . '/../../vendor/autoload.php';
 
-use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\SynchronousIcapClient;
+
+/*
+ * Discover the server's negotiated capabilities (RFC 3507 §4.10) and
+ * use the advertised Preview size. Real deployments should cache this
+ * answer for `Options-TTL` seconds; the next milestone after v2.0.0
+ * adds a built-in PSR-16 cache decorator for that.
+ */
 
 $icap = SynchronousIcapClient::create();
 
-// Retrieve server options to determine preview size
+$options = $icap->options('/avscan');
+$headers = $options->getOriginalResponse()->headers;
 
-$options = $icap->options('/service');
-$previewSize = (int)($options->getOriginalResponse()->headers['Preview'][0] ?? 1024);
+$previewSize = (int) ($headers['Preview'][0] ?? 1024);
 
-echo "Server preview size: $previewSize\n";
+echo 'Methods:        ' . ($headers['Methods'][0] ?? '—') . PHP_EOL;
+echo 'Preview size:   ' . $previewSize . PHP_EOL;
+echo 'Max-Connections: ' . ($headers['Max-Connections'][0] ?? '—') . PHP_EOL;
+echo 'Options-TTL:    ' . ($headers['Options-TTL'][0] ?? '—') . PHP_EOL;
+echo 'ISTag:          ' . ($headers['ISTag'][0] ?? '—') . PHP_EOL;
+echo PHP_EOL;
 
-$result = $icap->scanFileWithPreview('/service', __DIR__ . '/../eicar.com', $previewSize);
+$result = $icap->scanFileWithPreview('/avscan', __DIR__ . '/../eicar.com', $previewSize);
 
 echo $result->isInfected()
-    ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+    ? 'Virus: ' . ($result->getVirusName() ?? 'unknown') . PHP_EOL
     : 'Clean' . PHP_EOL;

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/DTO/HttpRequest.php
+++ b/src/DTO/HttpRequest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\DTO;

--- a/src/DTO/HttpResponse.php
+++ b/src/DTO/HttpResponse.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\DTO;

--- a/src/DTO/IcapRequest.php
+++ b/src/DTO/IcapRequest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\DTO;

--- a/src/DTO/IcapResponse.php
+++ b/src/DTO/IcapResponse.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\DTO;

--- a/src/DTO/ScanResult.php
+++ b/src/DTO/ScanResult.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\DTO;

--- a/src/DefaultPreviewStrategy.php
+++ b/src/DefaultPreviewStrategy.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/Exception/IcapClientException.php
+++ b/src/Exception/IcapClientException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapConnectionException.php
+++ b/src/Exception/IcapConnectionException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapExceptionInterface.php
+++ b/src/Exception/IcapExceptionInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapMalformedResponseException.php
+++ b/src/Exception/IcapMalformedResponseException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapProtocolException.php
+++ b/src/Exception/IcapProtocolException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapResponseException.php
+++ b/src/Exception/IcapResponseException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapServerException.php
+++ b/src/Exception/IcapServerException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/Exception/IcapTimeoutException.php
+++ b/src/Exception/IcapTimeoutException.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Exception;

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/PreviewDecision.php
+++ b/src/PreviewDecision.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/PreviewStrategyInterface.php
+++ b/src/PreviewStrategyInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/RequestFormatterInterface.php
+++ b/src/RequestFormatterInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/ResponseParser.php
+++ b/src/ResponseParser.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/ResponseParserInterface.php
+++ b/src/ResponseParserInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap;

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;

--- a/tests/AsyncTestCase.php
+++ b/tests/AsyncTestCase.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 namespace Ndrstmr\Icap\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/ConfigSecurityTest.php
+++ b/tests/ConfigSecurityTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Amp\Socket\ClientTlsContext;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\Config;
 
 test('Config can be instantiated', function () {

--- a/tests/CustomRequestHeadersTest.php
+++ b/tests/CustomRequestHeadersTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Mockery as m;

--- a/tests/DTO/IcapRequestTest.php
+++ b/tests/DTO/IcapRequestTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\DTO\IcapRequest;
 
 it('can be instantiated and mutated immutably', function () {

--- a/tests/DTO/IcapResponseTest.php
+++ b/tests/DTO/IcapResponseTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\DTO\IcapResponse;
 
 it('can be instantiated and mutated immutably', function () {

--- a/tests/DTO/ScanResultTest.php
+++ b/tests/DTO/ScanResultTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\DTO\ScanResult;
 

--- a/tests/DefaultPreviewStrategyTest.php
+++ b/tests/DefaultPreviewStrategyTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\DefaultPreviewStrategy;
 use Ndrstmr\Icap\PreviewDecision;
 use Ndrstmr\Icap\DTO\IcapResponse;

--- a/tests/Exception/ExceptionHierarchyTest.php
+++ b/tests/Exception/ExceptionHierarchyTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\Exception\IcapClientException;

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Mockery as m;

--- a/tests/Integration/IcapServerSmokeTest.php
+++ b/tests/Integration/IcapServerSmokeTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\Config;

--- a/tests/LoggerIntegrationTest.php
+++ b/tests/LoggerIntegrationTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Mockery as m;

--- a/tests/MultiVendorVirusHeadersTest.php
+++ b/tests/MultiVendorVirusHeadersTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Mockery as m;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,17 @@
 <?php
 
-// Pest initialization file
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */

--- a/tests/ResponseParserTest.php
+++ b/tests/ResponseParserTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\DTO\IcapResponse;

--- a/tests/Security/FailSecureAndValidationTest.php
+++ b/tests/Security/FailSecureAndValidationTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Mockery as m;

--- a/tests/Security/ParserDosLimitsTest.php
+++ b/tests/Security/ParserDosLimitsTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\Exception\IcapMalformedResponseException;

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Mockery as m;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapResponse;

--- a/tests/Transport/AsyncAmpTransportTest.php
+++ b/tests/Transport/AsyncAmpTransportTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
 use Ndrstmr\Icap\Transport\AsyncAmpTransport;

--- a/tests/Transport/SynchronousStreamTransportTest.php
+++ b/tests/Transport/SynchronousStreamTransportTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;

--- a/tests/Transport/TransportInterfaceTest.php
+++ b/tests/Transport/TransportInterfaceTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 use Ndrstmr\Icap\Transport\TransportInterface;
 
 it('TransportInterface exists', function () {

--- a/tests/Wire/RequestFormatterWireTest.php
+++ b/tests/Wire/RequestFormatterWireTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\DTO\HttpRequest;

--- a/tests/Wire/ResponseParserWireTest.php
+++ b/tests/Wire/ResponseParserWireTest.php
@@ -1,5 +1,21 @@
 <?php
 
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 declare(strict_types=1);
 
 use Ndrstmr\Icap\ResponseParser;


### PR DESCRIPTION
## Context

M5 of the v2.0.0 effort — governance + documentation. After this lands, every auditor or downstream user finds what they need to decide whether to adopt the library: AI-origin disclosure, production caveats, full migration guide, security-disclosure process, accurate examples, SPDX licence headers everywhere, and a clear changelog.

## What's in here

### README.md — rewritten

- Prominent disclaimer block at the top: **AI-assisted origin**, three independent due-diligence reviews in `docs/review/`, and a non-exhaustive checklist of what "do not deploy without an independent review" actually means (vendor-specific test, fail-secure verification, TLS config, resource limits, audit logging).
- Up-to-date "What changed in v2" summary mapped back to findings A–N of the consolidated review.
- v2 quickstarts (sync + async), Config snippet showing TLS / DoS limits / multi-vendor virus-header list, custom request headers, exception taxonomy table, integration-test recipe.

### SECURITY.md — new

- Private vulnerability reporting via GitHub advisories.
- Acknowledgement / triage / fix windows by CVSS band.
- Coordinated-disclosure flow + scope.
- Defaults-and-guarantees + explicit non-guarantees, so users know what the library protects against and what their integration still needs to own (mTLS, retry, OPTIONS cache, pooling).

### CHANGELOG.md — full v2.0.0 entry

Section-by-section: breaking changes, RFC correctness, security hardening, ecosystem fit, exception taxonomy, test infra. v1.0.0 entry kept and marked deprecated with a pointer to the consolidated review for the full finding list.

### docs/migration-v1-to-v2.md — new

TL;DR diff, then per-API-change sections: PHP version, `IcapRequest` body slots, Formatter / Transport iterable signature, `scanFile` extra-headers param, `Config` + multi-vendor list, optional logger, status-code matrix, CRLF guard, test surface, new runtime deps.

### examples/* — rewritten for v2 API

- `examples/01-sync-scan.php` + `02-async-scan.php` use the multi-vendor virus-header list and demonstrate `IcapExceptionInterface` catch-all.
- `examples/cookbook/01-custom-headers.php` uses the new `scanFile($service, $path, $extraHeaders)` overload.
- `examples/cookbook/02-custom-preview-strategy.php` drops the bogus `304` branch (304 is not a defined ICAP status) and runs through `Revolt\EventLoop`.
- `examples/cookbook/03-options-request.php` prints all advertised capabilities (Methods / Preview / Max-Connections / Options-TTL / ISTag) and feeds the negotiated preview size back into `scanFileWithPreview`.

### docs/agent.md — annotated as historical

The original OpenAI-Codex mission charter that drove v1.0.0 is kept for provenance but now opens with a NOTE block calling out that it's a historical document — claims like "PSR-7 `StreamInterface` body" or "98 % coverage" were aspirational and did **not** match v1, which is exactly why v2 was needed.

### SPDX licence headers

New PhpCsFixer rule applies the EUPL-1.2 SPDX header to every `src/*` and `tests/*` PHP file. `composer cs-fix` wrote the header to **49 files** in one pass.

### docs/review/consolidated_task-list.md

Status block at the top summarising M0–M4 merged, M5 in this PR, M3 follow-ups deferred. Each M5 sub-item ticked off with the artefact it produced.

## Verification

- [x] `composer test` — 66 passed, 1 pre-existing network warning, 145 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5) green; integration job still continue-on-error from M4.

## Next

After M5 merges, the deferred M3 follow-ups are the last technical block before a v2.0.0 Packagist tag:

- **Cancellation** in the public API (`Amp\Cancellation` parameter on every method).
- **OPTIONS-response cache** keyed by `host:port/service` with TTL from `Options-TTL`.
- **503 retry** with exponential backoff (probably as a decorator around `IcapClientInterface`).
- **Keep-Alive pooling** in `AsyncAmpTransport` (also makes the Connection: close default unnecessary, replacing it with proper response framing).