### PR TITLE
feat(v2): Cancellation in the public API

### DIFF
--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap;
 
+use Amp\Cancellation;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\HttpResponse;
 use Ndrstmr\Icap\DTO\IcapRequest;
@@ -93,10 +94,10 @@ final class IcapClient implements IcapClientInterface
     }
 
     #[\Override]
-    public function request(IcapRequest $request): Future
+    public function request(IcapRequest $request, ?Cancellation $cancellation = null): Future
     {
         /** @var Future<ScanResult> $future */
-        $future = \Amp\async(function () use ($request): ScanResult {
+        $future = \Amp\async(function () use ($request, $cancellation): ScanResult {
             $context = [
                 'method' => $request->method,
                 'uri'    => $request->uri,
@@ -107,7 +108,7 @@ final class IcapClient implements IcapClientInterface
 
             $response = null;
             try {
-                $response = $this->executeRaw($request)->await();
+                $response = $this->executeRaw($request, $cancellation)->await();
                 $result = $this->interpretResponse($response, $this->config);
             } catch (\Throwable $e) {
                 $this->logger->warning('ICAP request failed', $context + [
@@ -137,12 +138,12 @@ final class IcapClient implements IcapClientInterface
      *
      * @return Future<IcapResponse>
      */
-    public function executeRaw(IcapRequest $request): Future
+    public function executeRaw(IcapRequest $request, ?Cancellation $cancellation = null): Future
     {
         /** @var Future<IcapResponse> $future */
-        $future = \Amp\async(function () use ($request): IcapResponse {
+        $future = \Amp\async(function () use ($request, $cancellation): IcapResponse {
             $chunks = $this->formatter->format($request);
-            $responseString = $this->transport->request($this->config, $chunks)->await();
+            $responseString = $this->transport->request($this->config, $chunks, $cancellation)->await();
             return $this->parser->parse($responseString);
         });
 
@@ -150,11 +151,11 @@ final class IcapClient implements IcapClientInterface
     }
 
     #[\Override]
-    public function options(string $service): Future
+    public function options(string $service, ?Cancellation $cancellation = null): Future
     {
         $uri = $this->buildServiceUri($service);
         $request = new IcapRequest('OPTIONS', $uri);
-        return $this->request($request);
+        return $this->request($request, $cancellation);
     }
 
     /**
@@ -166,8 +167,12 @@ final class IcapClient implements IcapClientInterface
      * @throws \RuntimeException When the file cannot be opened
      */
     #[\Override]
-    public function scanFile(string $service, string $filePath, array $extraHeaders = []): Future
-    {
+    public function scanFile(
+        string $service,
+        string $filePath,
+        array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
+    ): Future {
         // Validate first so injection attempts never reach the socket.
         $this->validateIcapHeaders($extraHeaders);
         $uri = $this->buildServiceUri($service);
@@ -194,7 +199,7 @@ final class IcapClient implements IcapClientInterface
             encapsulatedResponse: $httpResponse,
         );
 
-        return $this->request($request);
+        return $this->request($request, $cancellation);
     }
 
     /**
@@ -212,6 +217,7 @@ final class IcapClient implements IcapClientInterface
         string $filePath,
         int $previewSize = 1024,
         array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
     ): Future {
         if ($previewSize < 1) {
             throw new \InvalidArgumentException('Preview size must be >= 1, got: ' . $previewSize);
@@ -220,7 +226,7 @@ final class IcapClient implements IcapClientInterface
 
         /** @var int<1, max> $previewSize */
         /** @var Future<ScanResult> $future */
-        $future = \Amp\async(function () use ($service, $filePath, $previewSize, $extraHeaders): ScanResult {
+        $future = \Amp\async(function () use ($service, $filePath, $previewSize, $extraHeaders, $cancellation): ScanResult {
             $fileSize = filesize($filePath);
             if ($fileSize === false) {
                 throw new \RuntimeException('Unable to stat file: ' . $filePath);
@@ -266,7 +272,7 @@ final class IcapClient implements IcapClientInterface
             // Preview round: bypass interpretResponse() so a legitimate
             // 100 Continue from the server doesn't trip the fail-secure
             // guard that only applies outside preview context.
-            $previewIcapResponse = $this->executeRaw($previewRequest)->await();
+            $previewIcapResponse = $this->executeRaw($previewRequest, $cancellation)->await();
 
             if ($previewIsComplete) {
                 fclose($stream);
@@ -313,7 +319,7 @@ final class IcapClient implements IcapClientInterface
             );
 
             try {
-                return $this->request($fullRequest)->await();
+                return $this->request($fullRequest, $cancellation)->await();
             } finally {
                 fclose($stream);
             }

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap;
 
+use Amp\Cancellation;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\ScanResult;
@@ -30,6 +31,12 @@ use Ndrstmr\Icap\DTO\ScanResult;
  * Implementations are async-native and return Amp Futures. The synchronous
  * decorator {@see SynchronousIcapClient} awaits those Futures behind a
  * blocking facade.
+ *
+ * Every method takes an optional {@see Cancellation} so a caller can
+ * abort an in-flight scan from the outside (e.g. when an upstream HTTP
+ * upload has been aborted). The user-supplied token is combined with the
+ * per-request timeout cancellation derived from
+ * {@see Config::getStreamTimeout()}; whichever fires first wins.
  */
 interface IcapClientInterface
 {
@@ -38,24 +45,29 @@ interface IcapClientInterface
      *
      * @return Future<ScanResult>
      */
-    public function request(IcapRequest $request): Future;
+    public function request(IcapRequest $request, ?Cancellation $cancellation = null): Future;
 
     /**
      * Issue an OPTIONS request against the given service.
      *
      * @return Future<ScanResult>
      */
-    public function options(string $service): Future;
+    public function options(string $service, ?Cancellation $cancellation = null): Future;
 
     /**
      * Scan a local file via RESPMOD.
      *
      * @param array<string, string|string[]> $extraHeaders Extra ICAP request
      *        headers, e.g. `['X-Client-IP' => '203.0.113.5']`. Library-managed
-     *        headers (`Host`, `Encapsulated`) always take precedence.
+     *        headers (`Host`, `Encapsulated`, `Connection`) always take precedence.
      * @return Future<ScanResult>
      */
-    public function scanFile(string $service, string $filePath, array $extraHeaders = []): Future;
+    public function scanFile(
+        string $service,
+        string $filePath,
+        array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
+    ): Future;
 
     /**
      * Scan a file using preview mode, streaming the remainder on demand.
@@ -70,5 +82,6 @@ interface IcapClientInterface
         string $filePath,
         int $previewSize = 1024,
         array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
     ): Future;
 }

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap;
 
+use Amp\Cancellation;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\ScanResult;
@@ -60,29 +61,27 @@ final class SynchronousIcapClient
         return new self($asyncClient);
     }
 
-    /**
-     * @param IcapRequest $request
-     */
-    public function request(IcapRequest $request): ScanResult
+    public function request(IcapRequest $request, ?Cancellation $cancellation = null): ScanResult
     {
-        return $this->asyncClient->request($request)->await();
+        return $this->asyncClient->request($request, $cancellation)->await();
     }
 
-    /**
-     * @param string $service
-     */
-    public function options(string $service): ScanResult
+    public function options(string $service, ?Cancellation $cancellation = null): ScanResult
     {
-        return $this->asyncClient->options($service)->await();
+        return $this->asyncClient->options($service, $cancellation)->await();
     }
 
     /**
      * @param array<string, string|string[]> $extraHeaders
      * @throws \RuntimeException
      */
-    public function scanFile(string $service, string $filePath, array $extraHeaders = []): ScanResult
-    {
-        return $this->asyncClient->scanFile($service, $filePath, $extraHeaders)->await();
+    public function scanFile(
+        string $service,
+        string $filePath,
+        array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
+    ): ScanResult {
+        return $this->asyncClient->scanFile($service, $filePath, $extraHeaders, $cancellation)->await();
     }
 
     /**
@@ -94,7 +93,8 @@ final class SynchronousIcapClient
         string $filePath,
         int $previewSize = 1024,
         array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
     ): ScanResult {
-        return $this->asyncClient->scanFileWithPreview($service, $filePath, $previewSize, $extraHeaders)->await();
+        return $this->asyncClient->scanFileWithPreview($service, $filePath, $previewSize, $extraHeaders, $cancellation)->await();
     }
 }

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;
 
+use Amp\Cancellation;
+use Amp\CompositeCancellation;
 use Amp\Socket;
 use Amp\Socket\ConnectContext;
 use Amp\TimeoutCancellation;
@@ -36,6 +38,11 @@ use function Amp\async;
  * carries a {@see \Amp\Socket\ClientTlsContext}; otherwise connects
  * plain tcp://. The response is bounded by Config::maxResponseSize to
  * keep a hostile server from exhausting the client's memory.
+ *
+ * The optional user-supplied {@see Cancellation} is combined with the
+ * transport's internal {@see TimeoutCancellation} via a
+ * {@see CompositeCancellation}; whichever fires first aborts the
+ * read/write loop with `Amp\CancelledException`.
  */
 final class AsyncAmpTransport implements TransportInterface
 {
@@ -44,10 +51,10 @@ final class AsyncAmpTransport implements TransportInterface
      * @return \Amp\Future<string>
      */
     #[\Override]
-    public function request(Config $config, iterable $rawRequest): \Amp\Future
+    public function request(Config $config, iterable $rawRequest, ?Cancellation $cancellation = null): \Amp\Future
     {
         /** @var \Amp\Future<string> $future */
-        $future = async(function () use ($config, $rawRequest): string {
+        $future = async(function () use ($config, $rawRequest, $cancellation): string {
             $socket = null;
             $tls = $config->getTlsContext();
             $connectionUrl = sprintf('tcp://%s:%d', $config->host, $config->port);
@@ -56,7 +63,10 @@ final class AsyncAmpTransport implements TransportInterface
             if ($tls !== null) {
                 $connectContext = $connectContext->withTlsContext($tls);
             }
-            $cancellation = new TimeoutCancellation($config->getStreamTimeout());
+            $timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
+            $cancellation = $cancellation === null
+                ? $timeoutCancellation
+                : new CompositeCancellation($cancellation, $timeoutCancellation);
 
             try {
                 if ($tls !== null) {

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;
 
+use Amp\Cancellation;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
 use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
@@ -46,13 +47,20 @@ final class SynchronousStreamTransport implements TransportInterface
      * @return \Amp\Future<string>
      */
     #[\Override]
-    public function request(Config $config, iterable $rawRequest): \Amp\Future
+    public function request(Config $config, iterable $rawRequest, ?Cancellation $cancellation = null): \Amp\Future
     {
         if ($config->getTlsContext() !== null) {
             throw new IcapConnectionException(
                 'SynchronousStreamTransport does not support TLS; use AsyncAmpTransport for icaps://.',
             );
         }
+
+        // Cancellation is honoured opportunistically: we check it
+        // between read/write iterations. The blocking PHP stream API
+        // doesn't allow interrupting an in-flight syscall, so a hung
+        // server is still bounded only by stream_set_timeout(). The
+        // async transport gives true cancellation semantics.
+        $cancellation?->throwIfRequested();
 
         $errno = 0;
         $errstr = '';
@@ -74,6 +82,7 @@ final class SynchronousStreamTransport implements TransportInterface
             stream_set_timeout($stream, (int) $config->getStreamTimeout());
 
             foreach ($rawRequest as $chunk) {
+                $cancellation?->throwIfRequested();
                 if ($chunk !== '') {
                     fwrite($stream, $chunk);
                 }
@@ -83,6 +92,7 @@ final class SynchronousStreamTransport implements TransportInterface
             $response = '';
             $received = 0;
             while (!feof($stream)) {
+                $cancellation?->throwIfRequested();
                 $read = fread($stream, self::READ_CHUNK_SIZE);
                 if ($read === false || $read === '') {
                     break;

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Ndrstmr\Icap\Transport;
 
+use Amp\Cancellation;
 use Ndrstmr\Icap\Config;
 
 /**
@@ -28,6 +29,12 @@ use Ndrstmr\Icap\Config;
  * The raw request is supplied as an iterable of byte chunks so large
  * encapsulated HTTP bodies are streamed onto the socket without being
  * concatenated in memory.
+ *
+ * The optional {@see Cancellation} parameter lets a caller abort a
+ * request in flight (combined with the transport's internal timeout
+ * cancellation derived from Config::getStreamTimeout()). Implementations
+ * MUST honour the cancellation by aborting the read and write loops
+ * with `Amp\CancelledException`.
  */
 interface TransportInterface
 {
@@ -36,5 +43,5 @@ interface TransportInterface
      *
      * @return \Amp\Future<string>
      */
-    public function request(Config $config, iterable $rawRequest): \Amp\Future;
+    public function request(Config $config, iterable $rawRequest, ?Cancellation $cancellation = null): \Amp\Future;
 }

--- a/tests/CancellationTest.php
+++ b/tests/CancellationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Cancellation;
+use Amp\CancelledException;
+use Amp\DeferredCancellation;
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * The IcapClient API must accept an optional Amp\Cancellation that the
+ * caller can use to abort an in-flight scan from the outside (e.g.
+ * an HTTP client cancelled the upload).
+ */
+
+it('options() forwards a user-supplied Cancellation to the transport', function () {
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    $userCancellation = (new DeferredCancellation())->getCancellation();
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+
+    $captured = null;
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->withArgs(function ($cfg, $chunks, $cancellation) use (&$captured) {
+        $captured = $cancellation;
+        return true;
+    });
+    $t->andReturn(\Amp\Future::complete('RESP'));
+
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(204));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $userCancellation, &$captured) {
+        $client->options('/svc', $userCancellation)->await();
+        expect($captured)->toBe($userCancellation);
+    });
+
+    m::close();
+});
+
+it('scanFile() forwards a user-supplied Cancellation', function () {
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, 'payload');
+
+    $userCancellation = (new DeferredCancellation())->getCancellation();
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+
+    $seen = null;
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->withArgs(function ($cfg, $chunks, $c) use (&$seen) {
+        $seen = $c;
+        return true;
+    });
+    $t->andReturn(\Amp\Future::complete('RESP'));
+
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(204));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp, $userCancellation, &$seen) {
+        $client->scanFile('/svc', $tmp, [], $userCancellation)->await();
+        expect($seen)->toBe($userCancellation);
+    });
+
+    unlink($tmp);
+    m::close();
+});
+
+it('propagates cancellation as Amp\\CancelledException when the cancellation fires', function () {
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    $deferred = new DeferredCancellation();
+    $deferred->cancel();
+    $userCancellation = $deferred->getCancellation();
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturnUsing(function (Config $cfg, iterable $chunks, ?Cancellation $c) {
+        // Real transport wraps the read loop with the cancellation; our
+        // mock simulates the transport observing the already-cancelled
+        // token by returning an errored Future.
+        $c?->throwIfRequested();
+        return \Amp\Future::complete('RESP');
+    });
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $userCancellation) {
+        expect(fn () => $client->options('/svc', $userCancellation)->await())
+            ->toThrow(CancelledException::class);
+    });
+
+    m::close();
+});

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -77,7 +77,7 @@ it('scanFile delegates correctly to async client', function () {
     $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');
-    $exp->with('/service', '/tmp/file', []);
+    $exp->with('/service', '/tmp/file', [], null);
     $exp->once();
     $exp->andReturn(\Amp\Future::complete($result));
 
@@ -98,7 +98,7 @@ it('request delegates correctly to async client', function () {
     $result = new ScanResult(false, null, $response);
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('request');
-    $exp->with($req);
+    $exp->with($req, null);
     $exp->once();
     $exp->andReturn(\Amp\Future::complete($result));
 
@@ -117,7 +117,7 @@ it('it handles and rethrows exceptions from async client', function () {
     $exception = new \Ndrstmr\Icap\Exception\IcapConnectionException('fail');
     /** @var \Mockery\Expectation $exp */
     $exp = $async->shouldReceive('scanFile');
-    $exp->with('/service', '/tmp/file', []);
+    $exp->with('/service', '/tmp/file', [], null);
     $exp->once();
     $exp->andReturn(\Amp\Future::error($exception));
 


### PR DESCRIPTION
## Context

First M3 follow-up after M0–M5 landed. Adds `Amp\Cancellation` to the public API so a caller can abort an in-flight scan from the outside (upstream HTTP upload abandoned, controller hit its own timeout, user cancelled, …).

## API surface

Every method on `IcapClientInterface` (and the `SynchronousIcapClient` wrapper) gained an **optional** `?Cancellation $cancellation = null` parameter at the end:

```php
public function options(string $service, ?Cancellation $c = null): Future;
public function request(IcapRequest $req, ?Cancellation $c = null): Future;
public function scanFile(string $svc, string $path, array $extras = [], ?Cancellation $c = null): Future;
public function scanFileWithPreview(string $svc, string $path, int $preview = 1024, array $extras = [], ?Cancellation $c = null): Future;
```

`TransportInterface::request()` also gained the parameter. The optional default keeps every existing call site working unchanged.

## Implementation

- `AsyncAmpTransport` combines the user-supplied cancellation with its internal `TimeoutCancellation` via `Amp\CompositeCancellation` — whichever fires first aborts the connect/read/write loop with `Amp\CancelledException`.
- `SynchronousStreamTransport` honours cancellation opportunistically: `throwIfRequested()` between connect / each write chunk / each read iteration. PHP's blocking stream API doesn't allow interrupting an in-flight syscall, so a hung server is still bounded only by `stream_set_timeout()`. The async transport gives true cancellation semantics.
- `scanFileWithPreview` threads the same Cancellation through both the preview round (`executeRaw`) and the optional continuation request, so cancelling at any point in the multi-round flow propagates.

## Tests

`tests/CancellationTest.php` — three Mockery cases:
- `options()` forwards the user-supplied Cancellation to the transport (verified via `withArgs` capture).
- `scanFile()` forwards the same.
- An already-fired `DeferredCancellation` passed in surfaces as `Amp\CancelledException` at `await` time.

`SynchronousIcapClientTest` mocks updated to the new arity (extra trailing `null`).

## Verification

- [x] `composer test` — 69 passed (was 66), 1 pre-existing network warning, 148 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## Next

Remaining M3 follow-ups before tagging v2.0.0 on Packagist:

- **OPTIONS-response cache** — keyed by `host:port/service`, TTL from `Options-TTL`.
- **503 retry decorator** — exponential backoff, configurable max attempts.
- **Keep-Alive pooling** in `AsyncAmpTransport` — also lets us drop the `Connection: close` default in favour of proper response framing from the `Encapsulated` header.