### PR TITLE
feat(v2): OPTIONS-response cache with Options-TTL honour

### DIFF
--- a/src/Cache/InMemoryOptionsCache.php
+++ b/src/Cache/InMemoryOptionsCache.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Cache;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+
+/**
+ * Process-local OPTIONS-response cache.
+ *
+ * The default implementation. Sufficient for long-running async
+ * workers (Symfony Messenger consumers, RoadRunner workers, php-fpm
+ * with pre-warmed bytecode caches that share state across requests
+ * — note: vanilla php-fpm does NOT share state, use APCu or Redis
+ * for that).
+ *
+ * Not safe across processes. Implement {@see OptionsCacheInterface}
+ * against your shared cache for cross-process deployments.
+ */
+final class InMemoryOptionsCache implements OptionsCacheInterface
+{
+    /** @var array<string, array{response: IcapResponse, expiresAt: int}> */
+    private array $entries = [];
+
+    /**
+     * Test seam — lets unit tests advance the cache's notion of "now"
+     * past a stored entry's TTL without sleeping.
+     */
+    private int $clockOffsetSeconds = 0;
+
+    #[\Override]
+    public function get(string $key): ?IcapResponse
+    {
+        $entry = $this->entries[$key] ?? null;
+        if ($entry === null) {
+            return null;
+        }
+
+        if ($this->now() >= $entry['expiresAt']) {
+            unset($this->entries[$key]);
+            return null;
+        }
+
+        return $entry['response'];
+    }
+
+    #[\Override]
+    public function set(string $key, IcapResponse $response, int $ttlSeconds): void
+    {
+        if ($ttlSeconds <= 0) {
+            return;
+        }
+
+        $this->entries[$key] = [
+            'response'  => $response,
+            'expiresAt' => $this->now() + $ttlSeconds,
+        ];
+    }
+
+    #[\Override]
+    public function delete(string $key): void
+    {
+        unset($this->entries[$key]);
+    }
+
+    /**
+     * Advance the cache's notion of "now" by $seconds. Strictly for
+     * tests — production code should use a real clock.
+     */
+    public function advanceClockForTesting(int $seconds): void
+    {
+        $this->clockOffsetSeconds += $seconds;
+    }
+
+    private function now(): int
+    {
+        return time() + $this->clockOffsetSeconds;
+    }
+}

--- a/src/Cache/OptionsCacheInterface.php
+++ b/src/Cache/OptionsCacheInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Cache;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+
+/**
+ * Storage for cached ICAP OPTIONS responses (RFC 3507 §4.10.2).
+ *
+ * The library ships a default in-memory implementation
+ * ({@see InMemoryOptionsCache}); production deployments that want
+ * cross-process caching can implement this interface against
+ * Redis / APCu / file system / PSR-16 adapter / etc.
+ *
+ * Implementations MUST honour the TTL passed to {@see set()} and
+ * return null from {@see get()} once the entry has expired.
+ */
+interface OptionsCacheInterface
+{
+    /**
+     * Return the cached response for $key, or null on cache miss
+     * (entry absent or expired).
+     */
+    public function get(string $key): ?IcapResponse;
+
+    /**
+     * Store $response under $key for at most $ttlSeconds. A value
+     * <= 0 means "do not cache".
+     */
+    public function set(string $key, IcapResponse $response, int $ttlSeconds): void;
+
+    /**
+     * Remove the cached entry for $key. Idempotent.
+     */
+    public function delete(string $key): void;
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -22,6 +22,7 @@ namespace Ndrstmr\Icap;
 
 use Amp\Cancellation;
 use Amp\Future;
+use Ndrstmr\Icap\Cache\OptionsCacheInterface;
 use Ndrstmr\Icap\DTO\HttpResponse;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
@@ -51,6 +52,7 @@ final class IcapClient implements IcapClientInterface
         private ResponseParserInterface $parser,
         ?PreviewStrategyInterface $previewStrategy = null,
         ?LoggerInterface $logger = null,
+        private ?OptionsCacheInterface $optionsCache = null,
     ) {
         $this->previewStrategy = $previewStrategy ?? new DefaultPreviewStrategy();
         $this->logger = $logger ?? new NullLogger();
@@ -153,9 +155,60 @@ final class IcapClient implements IcapClientInterface
     #[\Override]
     public function options(string $service, ?Cancellation $cancellation = null): Future
     {
+        // Validate first so injection attempts never reach the cache key.
         $uri = $this->buildServiceUri($service);
-        $request = new IcapRequest('OPTIONS', $uri);
-        return $this->request($request, $cancellation);
+
+        $cacheKey = $this->config->host . ':' . $this->config->port . $service;
+
+        if ($this->optionsCache !== null) {
+            $cached = $this->optionsCache->get($cacheKey);
+            if ($cached !== null) {
+                return Future::complete($this->interpretResponse($cached, $this->config));
+            }
+        }
+
+        /** @var Future<ScanResult> $future */
+        $future = \Amp\async(function () use ($uri, $cacheKey, $cancellation): ScanResult {
+            $request = new IcapRequest('OPTIONS', $uri);
+            $context = [
+                'method' => $request->method,
+                'uri'    => $request->uri,
+                'host'   => $this->config->host,
+                'port'   => $this->config->port,
+            ];
+            $this->logger->info('ICAP request started', $context);
+
+            $response = null;
+            try {
+                $response = $this->executeRaw($request, $cancellation)->await();
+                $result = $this->interpretResponse($response, $this->config);
+            } catch (\Throwable $e) {
+                $this->logger->warning('ICAP request failed', $context + [
+                    'statusCode' => $response?->statusCode,
+                    'exception'  => $e::class,
+                    'message'    => $e->getMessage(),
+                ]);
+                throw $e;
+            }
+
+            $this->logger->info('ICAP request completed', $context + [
+                'statusCode' => $response->statusCode,
+                'infected'   => $result->isInfected(),
+            ]);
+
+            // Cache the parsed IcapResponse, keyed by host:port + service.
+            // TTL is taken from the server's Options-TTL header
+            // (RFC 3507 §4.10.2); fall back to 0 (no caching) when the
+            // server didn't specify one.
+            if ($this->optionsCache !== null) {
+                $ttl = (int) ($response->headers['Options-TTL'][0] ?? '0');
+                $this->optionsCache->set($cacheKey, $response, $ttl);
+            }
+
+            return $result;
+        });
+
+        return $future;
     }
 
     /**

--- a/tests/OptionsCacheTest.php
+++ b/tests/OptionsCacheTest.php
@@ -1,0 +1,214 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Cache\InMemoryOptionsCache;
+use Ndrstmr\Icap\Cache\OptionsCacheInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+/**
+ * RFC 3507 §4.10.2 specifies an Options-TTL header that lets the
+ * server tell the client how long it can cache the OPTIONS response.
+ * IcapClient honours this by consulting an OptionsCacheInterface on
+ * each options() call and skipping the round trip on a cache hit.
+ */
+
+/**
+ * @return array{IcapClient, RequestFormatterInterface&\Mockery\MockInterface, TransportInterface&\Mockery\MockInterface, ResponseParserInterface&\Mockery\MockInterface, OptionsCacheInterface}
+ */
+function makeOptionsClient(?OptionsCacheInterface $cache = null, ?IcapResponse $canned = null): array
+{
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    $cache ??= new InMemoryOptionsCache();
+    $canned ??= new IcapResponse(200, ['Options-TTL' => ['3600']]);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RESP'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn($canned);
+
+    $client = new IcapClient(
+        $config,
+        $transport,
+        $formatter,
+        $parser,
+        previewStrategy: null,
+        logger: null,
+        optionsCache: $cache,
+    );
+
+    return [$client, $formatter, $transport, $parser, $cache];
+}
+
+it('skips the transport on a cache hit', function () {
+    $cache = new InMemoryOptionsCache();
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->once();
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->once();
+    $t->andReturn(\Amp\Future::complete('RESP'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->once();
+    $p->andReturn(new IcapResponse(200, ['Options-TTL' => ['3600']]));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser, optionsCache: $cache);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/avscan')->await();
+        // Second call must be served from cache; the once() expectations
+        // above will fail at m::close() if the transport / formatter /
+        // parser are touched a second time.
+        $client->options('/avscan')->await();
+    });
+
+    m::close();
+});
+
+it('isolates cache entries per service path', function () {
+    $cache = new InMemoryOptionsCache();
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->twice();
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->twice();
+    $t->andReturn(\Amp\Future::complete('RESP'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->twice();
+    $p->andReturn(new IcapResponse(200, ['Options-TTL' => ['3600']]));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser, optionsCache: $cache);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/avscan')->await();
+        $client->options('/other-service')->await();
+    });
+
+    expect(true)->toBeTrue(); // explicit assertion to satisfy strict-mode
+
+    m::close();
+});
+
+it('honours the Options-TTL header when storing', function () {
+    $response = new IcapResponse(200, ['Options-TTL' => ['7']]);
+    $cache = new InMemoryOptionsCache();
+
+    [$client] = makeOptionsClient($cache, $response);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/avscan')->await();
+    });
+
+    $entry = $cache->get('icap.example:1344/avscan');
+    expect($entry)->not->toBeNull()
+        ->and($entry?->statusCode)->toBe(200);
+
+    m::close();
+});
+
+it('treats an expired cache entry as a miss', function () {
+    $cache = new InMemoryOptionsCache();
+    // Entry with a TTL of 1 second, then artificially advance the
+    // cache's notion of "now" past it.
+    $cache->set('k', new IcapResponse(200), 1);
+    $cache->advanceClockForTesting(2);
+    expect($cache->get('k'))->toBeNull();
+});
+
+it('is a no-op when no cache is configured', function () {
+    // Passing optionsCache: null re-enters the original behaviour.
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->twice();
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->twice();
+    $t->andReturn(\Amp\Future::complete('RESP'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->twice();
+    $p->andReturn(new IcapResponse(200, ['Options-TTL' => ['3600']]));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/avscan')->await();
+        $client->options('/avscan')->await();
+    });
+
+    expect(true)->toBeTrue();
+
+    m::close();
+});


### PR DESCRIPTION
## Context

Second M3 follow-up. RFC 3507 §4.10.2 lets the server tell the client how long it can cache the OPTIONS response via the `Options-TTL` header. Each OPTIONS round trip on a busy ICAP server is a wasted ~10 ms; with a few hundred uploads/minute this adds up.

## API

New namespace `Ndrstmr\Icap\Cache`:
- **`OptionsCacheInterface`** — `get` / `set` / `delete`. Caches `IcapResponse` keyed by an opaque string. Implementations honour the TTL parameter and return null on expiry.
- **`InMemoryOptionsCache`** — process-local default; sufficient for long-lived workers (Symfony Messenger, RoadRunner, …). Cross-process deployments can implement the interface against Redis / APCu / a PSR-16 wrapper / whatever.

`IcapClient` constructor gained an optional last argument:

```php
new IcapClient($config, $transport, $formatter, $parser, optionsCache: $cache);
```

If null (default), behaviour is identical to before — every `options()` hits the wire.

## Behaviour

- `options($service)` computes the cache key from `config.host:config.port + service`. Service-path validation (CRLF / NUL / control chars from M2) runs first, so a malformed path can't slip into the key.
- On cache **hit**, the parsed `IcapResponse` is returned synchronously via `Future::complete(...)` — no fiber suspension, no transport call, no parser call.
- On cache **miss**, the normal request → parse → interpret pipeline runs, and the resulting `IcapResponse` is stored with `TTL = (int) Options-TTL`. Servers that omit the header default to `TTL=0` → not cached, matching RFC intent.
- `interpretResponse()` runs on every cache hit too — fail-secure semantics (status-code matrix, 4xx/5xx exception mapping) stay applied to cached responses.

## Tests

`tests/OptionsCacheTest.php` — 5 cases:
- Cache hit skips formatter / transport / parser.
- Separate service paths get separate cache entries.
- `Options-TTL` value is the stored TTL.
- Expired entries are treated as a miss (uses `InMemoryOptionsCache::advanceClockForTesting()` test seam).
- No cache configured = original behaviour, two round trips.

## Verification

- [x] `composer test` — 73 passed (was 69), 1 pre-existing network warning, 153 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## Next

- **503 retry decorator** with exponential backoff, configurable max attempts.
- **Keep-Alive pooling** in `AsyncAmpTransport` — also drops the `Connection: close` default in favour of `Encapsulated`-aware response framing.