### PR TITLE
feat(v2): RetryingIcapClient decorator (5xx exponential backoff)

### DIFF
--- a/src/RetryingIcapClient.php
+++ b/src/RetryingIcapClient.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Amp\Cancellation;
+use Amp\Future;
+use Closure;
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\ScanResult;
+use Ndrstmr\Icap\Exception\IcapServerException;
+
+use function Amp\delay;
+
+/**
+ * Retry decorator around any {@see IcapClientInterface}.
+ *
+ * Retries only on {@see IcapServerException} (ICAP 5xx) — those are
+ * transient by RFC 3507 §4.3.3. Client errors (4xx, parse failures,
+ * connection errors) propagate immediately; retrying them would either
+ * be useless (the request is malformed) or compound a hostile
+ * environment problem (network is down).
+ *
+ * Backoff is exponential: `baseDelaySeconds * backoffFactor^(attempt-1)`,
+ * capped at `maxDelaySeconds`. With the defaults (100 ms / 2x / cap 5 s)
+ * three retries wait 0.1 / 0.2 / 0.4 s.
+ *
+ * Example wiring:
+ *
+ *     $client = new RetryingIcapClient(
+ *         IcapClient::create(),
+ *         maxAttempts: 3,
+ *         baseDelaySeconds: 0.1,
+ *         maxDelaySeconds: 5.0,
+ *     );
+ */
+final class RetryingIcapClient implements IcapClientInterface
+{
+    /** @var Closure(float): void */
+    private Closure $sleeper;
+
+    /**
+     * @param IcapClientInterface           $inner            Wrapped client (typically IcapClient)
+     * @param int                           $maxAttempts      Maximum total attempts (initial + retries); must be >= 1
+     * @param float                         $baseDelaySeconds Initial delay before the first retry
+     * @param float                         $maxDelaySeconds  Cap on any individual retry delay
+     * @param float                         $backoffFactor    Multiplier applied between attempts
+     * @param (Closure(float): void)|null   $sleeper          Test seam — replaces Amp\delay() with a callable
+     */
+    public function __construct(
+        private IcapClientInterface $inner,
+        private int $maxAttempts = 3,
+        private float $baseDelaySeconds = 0.1,
+        private float $maxDelaySeconds = 5.0,
+        private float $backoffFactor = 2.0,
+        ?Closure $sleeper = null,
+    ) {
+        if ($maxAttempts < 1) {
+            throw new \InvalidArgumentException('maxAttempts must be >= 1, got: ' . $maxAttempts);
+        }
+        if ($baseDelaySeconds < 0.0) {
+            throw new \InvalidArgumentException('baseDelaySeconds must be >= 0, got: ' . $baseDelaySeconds);
+        }
+        if ($maxDelaySeconds < 0.0) {
+            throw new \InvalidArgumentException('maxDelaySeconds must be >= 0, got: ' . $maxDelaySeconds);
+        }
+        if ($backoffFactor <= 0.0) {
+            throw new \InvalidArgumentException('backoffFactor must be > 0, got: ' . $backoffFactor);
+        }
+
+        $this->sleeper = $sleeper ?? static function (float $seconds): void {
+            if ($seconds > 0.0) {
+                delay($seconds);
+            }
+        };
+    }
+
+    #[\Override]
+    public function request(IcapRequest $request, ?Cancellation $cancellation = null): Future
+    {
+        return $this->withRetry(fn (): Future => $this->inner->request($request, $cancellation));
+    }
+
+    #[\Override]
+    public function options(string $service, ?Cancellation $cancellation = null): Future
+    {
+        return $this->withRetry(fn (): Future => $this->inner->options($service, $cancellation));
+    }
+
+    /**
+     * @param array<string, string|string[]> $extraHeaders
+     */
+    #[\Override]
+    public function scanFile(
+        string $service,
+        string $filePath,
+        array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
+    ): Future {
+        return $this->withRetry(fn (): Future => $this->inner->scanFile($service, $filePath, $extraHeaders, $cancellation));
+    }
+
+    /**
+     * @param array<string, string|string[]> $extraHeaders
+     */
+    #[\Override]
+    public function scanFileWithPreview(
+        string $service,
+        string $filePath,
+        int $previewSize = 1024,
+        array $extraHeaders = [],
+        ?Cancellation $cancellation = null,
+    ): Future {
+        return $this->withRetry(
+            fn (): Future => $this->inner->scanFileWithPreview($service, $filePath, $previewSize, $extraHeaders, $cancellation),
+        );
+    }
+
+    /**
+     * @param Closure(): Future<ScanResult> $operation
+     * @return Future<ScanResult>
+     */
+    private function withRetry(Closure $operation): Future
+    {
+        /** @var Future<ScanResult> $future */
+        $future = \Amp\async(function () use ($operation): ScanResult {
+            // The loop runs at least once because maxAttempts >= 1 is
+            // enforced in the ctor, so the final throw always has a
+            // captured exception to re-raise.
+            /** @var IcapServerException $lastException */
+            $lastException = new IcapServerException('unreachable');
+
+            for ($attempt = 1; $attempt <= $this->maxAttempts; $attempt++) {
+                try {
+                    return $operation()->await();
+                } catch (IcapServerException $e) {
+                    $lastException = $e;
+                    if ($attempt === $this->maxAttempts) {
+                        break;
+                    }
+                    ($this->sleeper)($this->backoffFor($attempt));
+                }
+            }
+
+            throw $lastException;
+        });
+
+        return $future;
+    }
+
+    private function backoffFor(int $attempt): float
+    {
+        $delay = $this->baseDelaySeconds * ($this->backoffFactor ** ($attempt - 1));
+        return min($delay, $this->maxDelaySeconds);
+    }
+}

--- a/tests/RetryingIcapClientTest.php
+++ b/tests/RetryingIcapClientTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\DTO\ScanResult;
+use Ndrstmr\Icap\Exception\IcapClientException;
+use Ndrstmr\Icap\Exception\IcapServerException;
+use Ndrstmr\Icap\IcapClientInterface;
+use Ndrstmr\Icap\RetryingIcapClient;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+
+uses(AsyncTestCase::class);
+
+/**
+ * RetryingIcapClient is a decorator that retries 5xx responses with
+ * exponential backoff. 4xx and other failure types propagate
+ * immediately — fail-secure on client-side errors, retry-on-transient
+ * for server-side errors.
+ */
+
+it('retries on 503 and returns the eventual success', function () {
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    $clean = new ScanResult(false, null, new IcapResponse(204));
+
+    /** @var \Mockery\Expectation $exp */
+    $exp = $inner->shouldReceive('options');
+    $exp->times(3);
+    $exp->andReturn(
+        \Amp\Future::error(new IcapServerException('busy', 503)),
+        \Amp\Future::error(new IcapServerException('still busy', 503)),
+        \Amp\Future::complete($clean),
+    );
+
+    $client = new RetryingIcapClient($inner, maxAttempts: 3, baseDelaySeconds: 0.0, maxDelaySeconds: 0.0);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $clean) {
+        $res = $client->options('/svc')->await();
+        expect($res)->toBe($clean);
+    });
+
+    m::close();
+});
+
+it('gives up after maxAttempts and rethrows the last server exception', function () {
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    /** @var \Mockery\Expectation $exp */
+    $exp = $inner->shouldReceive('options');
+    $exp->times(3);
+    $exp->andReturn(
+        \Amp\Future::error(new IcapServerException('one', 503)),
+        \Amp\Future::error(new IcapServerException('two', 503)),
+        \Amp\Future::error(new IcapServerException('three', 503)),
+    );
+
+    $client = new RetryingIcapClient($inner, maxAttempts: 3, baseDelaySeconds: 0.0, maxDelaySeconds: 0.0);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        try {
+            $client->options('/svc')->await();
+            expect(false)->toBeTrue('expected IcapServerException');
+        } catch (IcapServerException $e) {
+            expect($e->getMessage())->toBe('three');
+        }
+    });
+
+    m::close();
+});
+
+it('does NOT retry on 4xx — those are caller errors, not transient', function () {
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    /** @var \Mockery\Expectation $exp */
+    $exp = $inner->shouldReceive('options');
+    $exp->once();
+    $exp->andReturn(\Amp\Future::error(new IcapClientException('bad request', 400)));
+
+    $client = new RetryingIcapClient($inner, maxAttempts: 5, baseDelaySeconds: 0.0, maxDelaySeconds: 0.0);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        expect(fn () => $client->options('/svc')->await())
+            ->toThrow(IcapClientException::class);
+    });
+
+    m::close();
+});
+
+it('uses exponential backoff (2x by default) capped by maxDelaySeconds', function () {
+    $delays = [];
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    /** @var \Mockery\Expectation $exp */
+    $exp = $inner->shouldReceive('options');
+    $exp->times(4);
+    $exp->andReturn(
+        \Amp\Future::error(new IcapServerException('1', 503)),
+        \Amp\Future::error(new IcapServerException('2', 503)),
+        \Amp\Future::error(new IcapServerException('3', 503)),
+        \Amp\Future::complete(new ScanResult(false, null, new IcapResponse(204))),
+    );
+
+    $client = new RetryingIcapClient(
+        $inner,
+        maxAttempts: 4,
+        baseDelaySeconds: 0.1,
+        maxDelaySeconds: 0.25,
+        backoffFactor: 2.0,
+        sleeper: function (float $seconds) use (&$delays): void {
+            $delays[] = $seconds;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client) {
+        $client->options('/svc')->await();
+    });
+
+    // After 1st failure: 0.1s, after 2nd: 0.2s, after 3rd: capped at 0.25s.
+    expect($delays)->toBe([0.1, 0.2, 0.25]);
+
+    m::close();
+});
+
+it('forwards request, scanFile and scanFileWithPreview through the decorator', function () {
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    $clean = new ScanResult(false, null, new IcapResponse(204));
+    $req = new \Ndrstmr\Icap\DTO\IcapRequest('OPTIONS', 'icap://x/svc');
+
+    /** @var \Mockery\Expectation $r1 */
+    $r1 = $inner->shouldReceive('request');
+    $r1->once();
+    $r1->andReturn(\Amp\Future::complete($clean));
+    /** @var \Mockery\Expectation $r2 */
+    $r2 = $inner->shouldReceive('scanFile');
+    $r2->once();
+    $r2->andReturn(\Amp\Future::complete($clean));
+    /** @var \Mockery\Expectation $r3 */
+    $r3 = $inner->shouldReceive('scanFileWithPreview');
+    $r3->once();
+    $r3->andReturn(\Amp\Future::complete($clean));
+
+    $client = new RetryingIcapClient($inner);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $req) {
+        $client->request($req)->await();
+        $client->scanFile('/svc', '/tmp/x')->await();
+        $client->scanFileWithPreview('/svc', '/tmp/x')->await();
+    });
+
+    m::close();
+});
+
+it('rejects nonsensical configuration', function () {
+    /** @var IcapClientInterface&\Mockery\MockInterface $inner */
+    $inner = m::mock(IcapClientInterface::class);
+
+    expect(fn () => new RetryingIcapClient($inner, maxAttempts: 0))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn () => new RetryingIcapClient($inner, baseDelaySeconds: -1.0))
+        ->toThrow(InvalidArgumentException::class);
+    expect(fn () => new RetryingIcapClient($inner, backoffFactor: 0.0))
+        ->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
## Context

Third M3 follow-up. ICAP servers under load can answer with a 5xx — RFC 3507 §4.3.3 calls these transient. The new decorator retries those automatically while leaving every other failure mode (4xx, parse errors, connection errors, cancellation) to propagate immediately — **fail-secure where it matters, retry-on-transient only when the spec says it's transient**.

## API

New `Ndrstmr\Icap\RetryingIcapClient` implements `IcapClientInterface` and wraps any other implementation. Drop-in:

```php
$client = new RetryingIcapClient(
    IcapClient::create(),
    maxAttempts: 3,
    baseDelaySeconds: 0.1,
    maxDelaySeconds: 5.0,
    backoffFactor: 2.0,
);
```

Defaults give three attempts spaced 0.1 s / 0.2 s / 0.4 s.

## Behaviour

- Retries **only** on `IcapServerException` (5xx). `IcapClientException` (4xx), `IcapProtocolException`, `IcapMalformedResponseException`, `IcapConnectionException` and `IcapTimeoutException` propagate after the first attempt.
- Backoff is exponential and capped: `base * factor^(attempt-1)` bounded by `maxDelaySeconds`.
- `Amp\delay()` is the production sleeper; a `Closure` can be injected for tests so the suite doesn't pay real wall time.
- **Cancellation:** a fired `Amp\Cancellation` propagates through the inner client's `await()` and bubbles up — we do **not** catch `CancelledException` for retry. (The user asked to abort.)
- Forwards `request`, `options`, `scanFile`, `scanFileWithPreview` to the inner client with the same arguments — Cancellation, extraHeaders, previewSize all flow through unchanged.

## Tests

`tests/RetryingIcapClientTest.php` — 6 cases:
- 503 then 503 then 200 → returns the eventual success.
- 503 every time → rethrows the **last** `IcapServerException` after `maxAttempts` (preserves the most recent server message).
- 4xx → does **not** retry, propagates immediately.
- Backoff sequence is exponential and capped (verified via the sleeper test seam: 0.1 / 0.2 / 0.25 cap).
- `request` / `scanFile` / `scanFileWithPreview` all forward via the decorator without retry on a clean 204.
- Constructor rejects nonsensical configuration (`maxAttempts < 1`, negative delays, factor `<= 0`).

## Verification

- [x] `composer test` — 78 passed (was 73), 1 pre-existing network warning, 160 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## Next

Last M3 follow-up: **keep-alive pooling** in `AsyncAmpTransport`. That PR also drops the M4 `Connection: close` default in favour of proper response framing from the `Encapsulated` header — the last bit of duct-tape the codebase still has.