### PR TITLE
feat(v2): response framing — drop Connection: close, set up for keep-alive

### DIFF
--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -154,15 +154,6 @@ final class RequestFormatter implements RequestFormatterInterface
         if (!isset($headers['Host'])) {
             $headers['Host'] = [$host];
         }
-        // Until the transport layer learns to detect end-of-response
-        // from the Encapsulated header (scheduled with keep-alive
-        // pooling in M3 follow-up), default to Connection: close so
-        // the server closes the socket after answering and our read
-        // loop sees EOF instead of waiting for the stream timeout.
-        // RFC 3507 §5.5 explicitly permits Connection: close.
-        if (!isset($headers['Connection'])) {
-            $headers['Connection'] = ['close'];
-        }
         // Encapsulated is computed by the formatter — any user-supplied
         // value would contradict the actual byte layout.
         $headers['Encapsulated'] = [$encapsulated];

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -27,7 +27,6 @@ use Amp\Socket\ConnectContext;
 use Amp\TimeoutCancellation;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
-use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
 
 use function Amp\async;
 
@@ -43,6 +42,13 @@ use function Amp\async;
  * transport's internal {@see TimeoutCancellation} via a
  * {@see CompositeCancellation}; whichever fires first aborts the
  * read/write loop with `Amp\CancelledException`.
+ *
+ * Response framing is done by {@see ResponseFrameReader} so the
+ * read loop terminates as soon as the message is complete — no
+ * dependency on the server closing the socket. That means the
+ * `Connection: close` request-side hack from M4 is gone, and a
+ * future pooling implementation can reuse the socket for the next
+ * request without changing this code.
  */
 final class AsyncAmpTransport implements TransportInterface
 {
@@ -80,20 +86,11 @@ final class AsyncAmpTransport implements TransportInterface
                     }
                 }
 
-                $maxBytes = $config->getMaxResponseSize();
-                $response = '';
-                $received = 0;
-                while (null !== ($chunk = $socket->read($cancellation))) {
-                    $received += strlen($chunk);
-                    if ($received > $maxBytes) {
-                        throw new IcapMalformedResponseException(
-                            sprintf('ICAP response exceeded max size (%d bytes).', $maxBytes),
-                        );
-                    }
-                    $response .= $chunk;
-                }
-
-                return $response;
+                $reader = new ResponseFrameReader(
+                    maxResponseSize: $config->getMaxResponseSize(),
+                    maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+                );
+                return $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
             } catch (Socket\ConnectException $e) {
                 throw new IcapConnectionException(
                     sprintf('Async connection to %s:%d failed.', $config->host, $config->port),

--- a/src/Transport/ResponseFrameReader.php
+++ b/src/Transport/ResponseFrameReader.php
@@ -1,0 +1,202 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Closure;
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
+
+/**
+ * Frames a single ICAP response off a stream of byte chunks.
+ *
+ * RFC 3507 §5.5 lets servers keep the TCP connection open for the
+ * next request, which means transports cannot rely on socket-EOF to
+ * delimit the response. The framing rules come from the response
+ * itself:
+ *
+ *   1. The ICAP head ends at the first `\r\n\r\n`.
+ *   2. The Encapsulated header in that head says either `null-body`
+ *      (no encapsulated body — message ends at the blank line) or
+ *      it gives an offset to the encapsulated HTTP body, which is
+ *      always HTTP/1.1 chunk-encoded.
+ *   3. The chunk-encoded body ends with `0\r\n\r\n` (optionally with
+ *      a chunk-extension like `0; ieof\r\n\r\n`).
+ *
+ * The reader stops as soon as it has a complete message, leaving any
+ * trailing bytes in the underlying socket for the next request.
+ */
+final class ResponseFrameReader
+{
+    public function __construct(
+        private readonly int $maxResponseSize,
+        private readonly int $maxHeaderLineLength,
+    ) {
+        if ($maxResponseSize < 1 || $maxHeaderLineLength < 1) {
+            throw new \InvalidArgumentException('Reader limits must be >= 1.');
+        }
+    }
+
+    /**
+     * Read a complete ICAP response from the supplied producer.
+     *
+     * The producer is a callable that returns the next chunk of bytes
+     * (or null on EOF). It is invoked only when the reader needs more
+     * bytes to complete the framing.
+     *
+     * @param Closure(): ?string $produce
+     */
+    public function readFrom(Closure $produce): string
+    {
+        $buffer = '';
+        $messageEnd = null;
+
+        while ($messageEnd === null) {
+            $chunk = $produce();
+            if ($chunk === null) {
+                throw new IcapMalformedResponseException(
+                    'Connection closed before the response was complete (got ' . strlen($buffer) . ' bytes).',
+                );
+            }
+            $buffer .= $chunk;
+            if (strlen($buffer) > $this->maxResponseSize) {
+                throw new IcapMalformedResponseException(
+                    sprintf('ICAP response exceeded max size (%d bytes).', $this->maxResponseSize),
+                );
+            }
+            $messageEnd = $this->detectMessageEnd($buffer);
+        }
+
+        // Trim any bytes that came in past the end of this message —
+        // they belong to the next request on the same socket and must
+        // be left in the producer for the caller to handle. With the
+        // current single-shot transports this never happens (we close
+        // after each request), but the contract is honoured for the
+        // upcoming pooling work.
+        return substr($buffer, 0, $messageEnd);
+    }
+
+    /**
+     * Returns the byte offset just past the end of a complete ICAP
+     * message in $buffer, or null if the message isn't complete yet.
+     */
+    private function detectMessageEnd(string $buffer): ?int
+    {
+        $headEnd = strpos($buffer, "\r\n\r\n");
+        if ($headEnd === false) {
+            // Don't even have the ICAP head yet — but enforce the
+            // single-line cap so a malicious server can't push us off
+            // a cliff before we know it.
+            $longestLine = $this->longestUnterminatedLine($buffer);
+            if ($longestLine > $this->maxHeaderLineLength) {
+                throw new IcapMalformedResponseException(
+                    sprintf('ICAP header line exceeded %d bytes before CRLF.', $this->maxHeaderLineLength),
+                );
+            }
+            return null;
+        }
+
+        $headBlock = substr($buffer, 0, $headEnd);
+        $bodyStart = $headEnd + 4;
+
+        $encapsulated = $this->findEncapsulatedHeader($headBlock);
+        if ($encapsulated === null) {
+            // No Encapsulated header — by RFC 3507 §4.4.1 every ICAP
+            // message MUST carry one, but there's no body, so treat
+            // the message as ending right after the head separator.
+            return $bodyStart;
+        }
+
+        $bodyOffset = $this->encapsulatedBodyOffset($encapsulated);
+        if ($bodyOffset === null) {
+            // null-body or header-only — message ends at the blank line.
+            return $bodyStart;
+        }
+
+        // Encapsulated says the chunked body starts at $bodyOffset
+        // (relative to $bodyStart). Look for the chunked terminator
+        // beginning at that absolute offset.
+        $absoluteBodyStart = $bodyStart + $bodyOffset;
+        if (strlen($buffer) <= $absoluteBodyStart) {
+            return null;
+        }
+
+        $terminator = $this->findChunkedTerminator($buffer, $absoluteBodyStart);
+        return $terminator;
+    }
+
+    private function findEncapsulatedHeader(string $headBlock): ?string
+    {
+        $lines = preg_split('/\r?\n/', $headBlock) ?: [];
+        foreach ($lines as $line) {
+            if (preg_match('/^Encapsulated\s*:\s*(.+)$/i', $line, $m) === 1) {
+                return trim($m[1]);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the body-section offset (req-body / res-body) declared
+     * in an Encapsulated header value, or null when the header
+     * advertises null-body / has no body section.
+     */
+    private function encapsulatedBodyOffset(string $value): ?int
+    {
+        foreach (array_map('trim', explode(',', $value)) as $entry) {
+            if (preg_match('/^(req-body|res-body)\s*=\s*(\d+)$/i', $entry, $m) === 1) {
+                return (int) $m[2];
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Scan $buffer starting at $offset for the chunked-transfer
+     * terminator `0\r\n\r\n` (or `0; ext\r\n\r\n` per RFC 7230 §4.1).
+     * Returns the absolute byte offset just past the terminator, or
+     * null when not yet present.
+     */
+    private function findChunkedTerminator(string $buffer, int $offset): ?int
+    {
+        // Match either `\n0\r\n\r\n` or `\n0; ext\r\n\r\n` — the
+        // mandatory leading newline is what separates the size line
+        // of the last chunk from the previous chunk's data.
+        if (preg_match('/\r?\n0(?:;[^\r\n]*)?\r\n\r\n/', $buffer, $m, PREG_OFFSET_CAPTURE, $offset) === 1) {
+            return (int) $m[0][1] + strlen((string) $m[0][0]);
+        }
+        // The very first chunk could be the zero-chunk if there's no
+        // payload — match it at the start of the body.
+        if (preg_match('/^0(?:;[^\r\n]*)?\r\n\r\n/', substr($buffer, $offset), $m) === 1) {
+            return $offset + strlen($m[0]);
+        }
+        return null;
+    }
+
+    /**
+     * Length of the longest sequence in $buffer not separated by a
+     * line break. Used to spot the "no CRLF in 16 MB" attack before
+     * the full message has been received.
+     */
+    private function longestUnterminatedLine(string $buffer): int
+    {
+        $lastBreak = max(strrpos($buffer, "\n"), strrpos($buffer, "\r"));
+        return strlen($buffer) - ($lastBreak === false ? 0 : $lastBreak + 1);
+    }
+}

--- a/src/Transport/SynchronousStreamTransport.php
+++ b/src/Transport/SynchronousStreamTransport.php
@@ -23,7 +23,6 @@ namespace Ndrstmr\Icap\Transport;
 use Amp\Cancellation;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
-use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
 
 /**
  * Blocking transport using plain PHP stream sockets.
@@ -88,23 +87,21 @@ final class SynchronousStreamTransport implements TransportInterface
                 }
             }
 
-            $maxBytes = $config->getMaxResponseSize();
-            $response = '';
-            $received = 0;
-            while (!feof($stream)) {
+            $reader = new ResponseFrameReader(
+                maxResponseSize: $config->getMaxResponseSize(),
+                maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+            );
+            $response = $reader->readFrom(static function () use ($stream, $cancellation): ?string {
                 $cancellation?->throwIfRequested();
+                if (feof($stream)) {
+                    return null;
+                }
                 $read = fread($stream, self::READ_CHUNK_SIZE);
                 if ($read === false || $read === '') {
-                    break;
+                    return null;
                 }
-                $received += strlen($read);
-                if ($received > $maxBytes) {
-                    throw new IcapMalformedResponseException(
-                        sprintf('ICAP response exceeded max size (%d bytes).', $maxBytes),
-                    );
-                }
-                $response .= $read;
-            }
+                return $read;
+            });
 
             return \Amp\Future::complete($response);
         } finally {

--- a/tests/Transport/ResponseFrameReaderTest.php
+++ b/tests/Transport/ResponseFrameReaderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Ndrstmr\Icap\Exception\IcapMalformedResponseException;
+use Ndrstmr\Icap\Transport\ResponseFrameReader;
+
+/**
+ * The transport must learn when an ICAP response ends WITHOUT relying
+ * on the server closing the connection. Servers are allowed (and
+ * default) to hold the connection open for keep-alive (RFC 3507 §5.5).
+ *
+ * The framing is unambiguous from the response itself:
+ *   1. ICAP head ends at the first `\r\n\r\n`.
+ *   2. The Encapsulated header tells us where the body starts (or
+ *      that there is no body — `null-body=N`).
+ *   3. If a body is present, it is HTTP/1.1 chunked-encoded, so the
+ *      message ends right after the chunked terminator
+ *      `0\r\n\r\n` (or `0; ieof\r\n\r\n`).
+ */
+
+it('returns the response when the server keeps the connection open after a null-body OPTIONS reply', function () {
+    $bytes = "ICAP/1.0 200 OK\r\n"
+        . "Methods: RESPMOD\r\n"
+        . "ISTag: \"abc\"\r\n"
+        . "Encapsulated: null-body=0\r\n"
+        . "\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([$bytes]));
+
+    expect($response)->toBe($bytes);
+});
+
+it('returns the response when the encapsulated body has a 0-chunk terminator', function () {
+    $http = "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: 5\r\n\r\n";
+    $bytes = "ICAP/1.0 200 OK\r\n"
+        . "ISTag: \"x\"\r\n"
+        . 'Encapsulated: res-hdr=0, res-body=' . strlen($http) . "\r\n"
+        . "\r\n"
+        . $http
+        . "5\r\nhello\r\n0\r\n\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([$bytes]));
+
+    expect($response)->toBe($bytes);
+});
+
+it('handles fragmented arrivals — header split across two reads', function () {
+    $bytes = "ICAP/1.0 204 No Content\r\nEncapsulated: null-body=0\r\n\r\n";
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([
+        "ICAP/1.0 204 No Co",
+        "ntent\r\nEncapsulated: null-body=0\r\n",
+        "\r\n",
+    ]));
+
+    expect($response)->toBe($bytes);
+});
+
+it('does not consume bytes past the response — the next request can use the same socket', function () {
+    $http = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\n";
+    $first = "ICAP/1.0 200 OK\r\n"
+        . 'Encapsulated: res-hdr=0, res-body=' . strlen($http) . "\r\n"
+        . "\r\n"
+        . $http
+        . "5\r\nhello\r\n0\r\n\r\n";
+    $second = "ICAP/1.0 204 No Content\r\nEncapsulated: null-body=0\r\n\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    // The producer is given the two responses concatenated as a single
+    // chunk — the reader must stop consuming after the first one.
+    $producer = makeChunkProducer([$first . $second]);
+
+    $response = $reader->readFrom($producer);
+
+    expect($response)->toBe($first);
+});
+
+it('aborts when the response exceeds maxResponseSize', function () {
+    $reader = new ResponseFrameReader(maxResponseSize: 32, maxHeaderLineLength: 8192);
+    expect(fn () => $reader->readFrom(makeChunkProducer([str_repeat('A', 100)])))
+        ->toThrow(IcapMalformedResponseException::class, 'max size');
+});
+
+it('raises a malformed-response exception on EOF before any separator', function () {
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    expect(fn () => $reader->readFrom(makeChunkProducer(['ICAP/1.0 200 OK'])))
+        ->toThrow(IcapMalformedResponseException::class);
+});
+
+/**
+ * @param list<string> $chunks
+ * @return Closure(): ?string
+ */
+function makeChunkProducer(array $chunks): Closure
+{
+    $i = 0;
+    return static function () use (&$i, $chunks): ?string {
+        if ($i >= count($chunks)) {
+            return null;
+        }
+        return $chunks[$i++];
+    };
+}

--- a/tests/Wire/RequestFormatterWireTest.php
+++ b/tests/Wire/RequestFormatterWireTest.php
@@ -54,7 +54,6 @@ it('formats an OPTIONS request with null-body=0 (RFC 3507 ยง4.10)', function () 
     $expected = "OPTIONS icap://icap.example.net/service ICAP/1.0\r\n"
         . "Host: icap.example.net\r\n"
         . "User-Agent: icap-flow/2.0\r\n"
-        . "Connection: close\r\n"
         . "Encapsulated: null-body=0\r\n"
         . "\r\n";
 
@@ -89,7 +88,6 @@ it('formats a RESPMOD request with encapsulated HTTP response and chunked body (
 
     $expected = "RESPMOD icap://icap.example.net/scan ICAP/1.0\r\n"
         . "Host: icap.example.net\r\n"
-        . "Connection: close\r\n"
         . "Encapsulated: res-hdr=0, res-body={$resBodyOffset}\r\n"
         . "\r\n"
         . $httpHeaderBlock
@@ -127,7 +125,6 @@ it('formats a REQMOD with encapsulated HTTP request and chunked body (RFC 3507 ย
 
     $expected = "REQMOD icap://icap.example.net/scan ICAP/1.0\r\n"
         . "Host: icap.example.net\r\n"
-        . "Connection: close\r\n"
         . "Encapsulated: req-hdr=0, req-body={$reqBodyOffset}\r\n"
         . "\r\n"
         . $httpHeaderBlock
@@ -169,7 +166,6 @@ it('emits 0; ieof\\r\\n\\r\\n when the preview body is the complete payload (RFC
     $expected = "RESPMOD icap://icap.example.net/scan ICAP/1.0\r\n"
         . "Host: icap.example.net\r\n"
         . "Preview: 5\r\n"
-        . "Connection: close\r\n"
         . "Encapsulated: res-hdr=0, res-body={$resBodyOffset}\r\n"
         . "\r\n"
         . $httpHeaderBlock


### PR DESCRIPTION
## Context

Last M3 follow-up before tagging **v2.0.0**. Replaces the M4-era `Connection: close` request-side hack with a real `Encapsulated`-aware response reader. The transport now knows when the message ends by looking at the bytes on the wire — no more dependency on the server closing the socket — which both restores RFC 3507 §5.5 behaviour and lays the groundwork for connection pooling.

Pooling itself is post-v2 (v2.1) — the prerequisite is done.

## New: `ResponseFrameReader`

`src/Transport/ResponseFrameReader.php` frames a single ICAP response off any byte-chunk producer. It stops as soon as the message is complete:

- Reads until the first `\r\n\r\n` (end of ICAP head).
- Parses the `Encapsulated` header from the head.
- If the entry is `null-body` or there's no body at all → message ends right after the head separator.
- Otherwise the body is HTTP/1.1 chunked → message ends after `\r\n0\r\n\r\n` (or `0; ext\r\n\r\n` per RFC 7230 §4.1).

DoS limits enforced inline: `maxResponseSize` aborts a runaway server early; `maxHeaderLineLength` catches the "no CRLF in 16 MB" attack before the head is even complete.

**Trailing bytes** that arrived past the end of the response are **not** consumed — the contract returns exactly the response bytes, leaving the rest in the producer for the next request. With the current single-shot transports this is moot, but it's the contract a pooling transport will need.

## Transports updated

- `AsyncAmpTransport` now feeds `ResponseFrameReader` directly off `Socket::read()` — no more accumulating until `null`. Cancellation / CompositeCancellation behaviour from M3 unchanged.
- `SynchronousStreamTransport` feeds the reader off `feof()` / `fread()` and returns the framed response.

## `Connection: close` default removed

`src/RequestFormatter.php` no longer auto-injects `Connection: close`. Servers are free to keep the socket open per RFC 3507 §5.5 — the transport doesn't need EOF to know it has the response. Wire-format tests updated: 4 fixtures in `tests/Wire/RequestFormatterWireTest.php` no longer expect the header.

## Tests

- `tests/Transport/ResponseFrameReaderTest.php` (6 cases):
  - null-body OPTIONS reply with the connection still open
  - encapsulated body delimited by 0-chunk terminator
  - fragmented arrivals (head split across two reads)
  - trailing bytes are left in the producer (sets up pooling)
  - `maxResponseSize` abort
  - mid-message EOF raises `IcapMalformedResponseException`
- All existing wire-level tests still pass under the new reader.

## Verification

- [x] `composer test` — 84 passed (was 78), 1 pre-existing network warning, 167 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## What's left for v2.0.0 tag

After this lands, every item in the consolidated task list from the original three reviews is closed. The v2.0.0 Packagist tag is one merge + one git tag away.

Post-v2.0:
- **v2.1.0** — keep-alive connection pooling (now a tractable transport-only refactor; framing prerequisite is done).