### PR TITLE
docs: v2.0.0 release prep — CHANGELOG, README, consolidated task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- This release line will track post-v2.0.0 follow-up work, in particular: `Cancellation` in the public client API, OPTIONS-response cache, 503 retry with exponential backoff, single-connection preview-continue (RFC 3507 §4.5), keep-alive connection pooling.
+### Planned for v2.1.0
+- Keep-alive connection pooling in `AsyncAmpTransport` (the response-framing prerequisite landed in v2.0.0; this is now a tractable transport-only refactor).
+- Single-connection preview-continue per RFC 3507 §4.5 strict reading.
 
-## [2.0.0] - 2026-04-24
+## [2.0.0] - 2026-04-25
 
 ### Why a major release
 v1.0.0 had several RFC-3507-blocking bugs that no real ICAP server (c-icap, Symantec, Sophos, Kaspersky, Trend Micro) would have accepted, plus a fail-open security bug in the response interpreter. Closing those required wire-format changes that are by definition breaking.
@@ -49,6 +50,13 @@ v1.0.0 had several RFC-3507-blocking bugs that no real ICAP server (c-icap, Syma
 - **PSR-3 logger** optional injection on `IcapClient`. Three structured events per request (`info` started / `info` completed / `warning` failed) with method, URI, host, port, status code, infected flag.
 - **Multi-vendor virus headers**: `Config::withVirusFoundHeaders(list<string>)` and `getVirusFoundHeaders(): list<string>`. The client returns the first header that the server actually sent.
 - **Custom request headers** on `scanFile()` / `scanFileWithPreview()` — `X-Client-IP`, `X-Authenticated-User`, etc. — with CRLF guard and library-managed-headers-win semantics.
+- **External cancellation**: every public method (`request`, `options`, `scanFile`, `scanFileWithPreview`) takes an optional `?Amp\Cancellation` parameter. `AsyncAmpTransport` combines it with the internal `TimeoutCancellation` via `CompositeCancellation`. `SynchronousStreamTransport` honours it opportunistically between read/write iterations.
+- **OPTIONS-response cache** (RFC 3507 §4.10.2 `Options-TTL`): new `Ndrstmr\Icap\Cache\OptionsCacheInterface` with default `InMemoryOptionsCache`. Optional last constructor argument on `IcapClient`. On a cache hit, no transport call, no parser call — the parsed `IcapResponse` is returned synchronously and still runs through `interpretResponse()` for the fail-secure status pass.
+- **`RetryingIcapClient` decorator**: configurable exponential backoff (default 3 attempts, 0.1 s base, 2× factor, 5 s cap) that retries **only** on `IcapServerException` (5xx). 4xx, parse errors, connection errors, cancellation propagate after the first attempt.
+
+### Added — transport / wire framing
+- **Encapsulated-aware response framing** via the new `Ndrstmr\Icap\Transport\ResponseFrameReader`. The transport now knows when an ICAP response ends from the bytes themselves (head separator + Encapsulated-derived body offset + chunked terminator) instead of relying on the server closing the socket. Removes the v2-pre-release `Connection: close` request-side hack and unblocks keep-alive pooling for v2.1.
+- DoS limits enforced inside the framing reader as well as in the parser, so a hostile server can't push us off a cliff before the head is even complete.
 
 ### Added — exception taxonomy
 - New marker interface `Ndrstmr\Icap\Exception\IcapExceptionInterface`. Every concrete exception implements it.
@@ -59,9 +67,11 @@ v1.0.0 had several RFC-3507-blocking bugs that no real ICAP server (c-icap, Syma
 ### Added — test infrastructure
 - `tests/Wire/RequestFormatterWireTest.php` and `tests/Wire/ResponseParserWireTest.php` with hand-computed RFC-3507 byte fixtures.
 - `tests/Security/FailSecureAndValidationTest.php` and `tests/Security/ParserDosLimitsTest.php` covering every branch of the new status matrix and DoS limits.
-- `tests/Integration/IcapServerSmokeTest.php` against a real ICAP server (skips gracefully when `ICAP_HOST` is unset).
+- `tests/CancellationTest.php`, `tests/OptionsCacheTest.php`, `tests/RetryingIcapClientTest.php`, `tests/Transport/ResponseFrameReaderTest.php` covering the M3 follow-up surface.
+- `tests/Integration/IcapServerSmokeTest.php` against a real ICAP server (skips gracefully when `ICAP_HOST` is unset). Verified end-to-end against `mnemoshare/clamav-icap` — OPTIONS, EICAR detection (via `X-Violations-Found`), clean-file verdict.
 - `docker-compose.yml` for local integration runs against `mnemoshare/clamav-icap:0.14.5`.
 - CI matrix expanded to PHP 8.4 + 8.5; new integration job; `roave/security-advisories` in dev-deps; PHPStan upgraded to 2.x; `beStrictAboutCoverageMetadata` and a separate Integration testsuite in `phpunit.xml.dist`.
+- Final unit-suite count: **84 passed, 167 assertions** at v2.0.0 release.
 
 ### Removed
 - v1 `mixed $body` on `IcapRequest`.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,15 @@ An async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.4+, 
 - **Multi-vendor virus headers** — Config takes an ordered list (`X-Virus-Name`, `X-Infection-Found`, `X-Violations-Found`, `X-Virus-ID`).
 - **PSR-3 logger** optional, structured events on every request.
 - **Custom request headers** (`X-Client-IP`, `X-Authenticated-User`) on `scanFile()` / `scanFileWithPreview()`.
-- **PHP 8.4** minimum; **PHP 8.5** in CI.
+- **External cancellation** — every public method takes an optional `Amp\Cancellation`.
+- **OPTIONS-response cache** with `Options-TTL` honour.
+- **`RetryingIcapClient`** decorator with exponential backoff for 5xx.
+- **Encapsulated-aware response framing** — no dependency on `Connection: close`; servers may keep the socket open.
+- **PHP 8.4** minimum; **PHP 8.5** in CI; integration tested end-to-end against `mnemoshare/clamav-icap` (c-icap 0.6.3 + ClamAV).
 
 The migration guide is [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). The full per-finding closure list is in [`docs/review/consolidated_task-list.md`](docs/review/consolidated_task-list.md).
+
+> Roadmap: **v2.1.0** adds connection pooling in `AsyncAmpTransport` (the framing prerequisite landed in v2.0.0).
 
 ## Installation
 

--- a/docs/review/consolidated_task-list.md
+++ b/docs/review/consolidated_task-list.md
@@ -1,6 +1,23 @@
 # Konsolidierte Task-Liste — v2.0.0 RFC-Compliance & Hardening
 
-> **Status (24.04.2026):** M0 (#36) ✅, M1 (#37) ✅, M2 (#38) ✅, M3-Core (#39) ✅, M4 (#40) ✅. M5 in Arbeit (dieser PR). M3-Follow-ups (Cancellation, OPTIONS-Cache, 503-Retry, Keep-Alive-Pooling) sind als dedizierte Folge-PRs nach v2.0.0 vorgemerkt. **Alle P0-Findings A–N sind geschlossen** — der Integration-Lauf gegen `mnemoshare/clamav-icap` (c-icap 0.6.3 + ClamAV) erkennt EICAR und attestiert Clean-Files korrekt.
+> **Status (25.04.2026):** ✅ **v2.0.0 ready to tag.** Alle ursprünglichen P0/P1-Findings (A–N) und alle vier M3-Follow-ups (Cancellation, OPTIONS-Cache, 503-Retry, Response-Framing) sind geschlossen.
+>
+> | Block | PR |
+> |---|---|
+> | M0 Foundation | #36 |
+> | M1 RFC Wire-Format | #37 |
+> | M2 Security Hardening | #38 |
+> | M3 Core (Logger, Multi-Vendor, Custom-Headers) | #39 |
+> | M4 Test Infrastructure | #40 |
+> | M5 Docs + AI Disclaimer | #41 |
+> | M3-ext Cancellation | #42 |
+> | M3-ext OPTIONS Cache | #43 |
+> | M3-ext 503 Retry Decorator | #44 |
+> | M3-ext Response Framing (drops `Connection: close`) | #45 |
+>
+> **Verifiziert end-to-end** gegen `mnemoshare/clamav-icap` Integration-Stack (OPTIONS, EICAR-Detection via `X-Violations-Found`, Clean-File). Final unit suite: **84 passed, 167 assertions**, PHPStan L9 + bleedingEdge clean, CS-Fixer clean.
+>
+> **Geplant für v2.1.0:** Keep-Alive Connection-Pooling in `AsyncAmpTransport` (Framing-Voraussetzung ist mit M3-ext erledigt; jetzt reines Transport-Refactor).
 
 **Ziel:** `ndrstmr/icap-flow` zum quasi-Standard PHP-ICAP-Client ausbauen — RFC-3507-konform, fail-secure, streaming-sicher, Symfony-ready.
 


### PR DESCRIPTION
## Context

Release-prep PR for **v2.0.0**. No source code changes — just rolls the four merged M3 follow-ups (Cancellation, OPTIONS cache, 503 retry decorator, response framing) into the documentation as part of the v2.0.0 release rather than the [Unreleased] / v2.1 line.

After this lands, the next step is `git tag -a v2.0.0` on the merge commit and a `git push origin v2.0.0`.

## CHANGELOG.md

- `[Unreleased]` reset to a v2.1.0 forward-look (pooling + strict single-connection preview-continue).
- `[2.0.0]` dated **2026-04-25**.
- New "Added — ecosystem fit" bullets for Cancellation, OPTIONS cache, `RetryingIcapClient`.
- New "Added — transport / wire framing" section covering `ResponseFrameReader` and the removal of the `Connection: close` workaround.
- "Added — test infrastructure" picks up the four new test files and notes the integration verification.
- Final unit count recorded: **84 passed, 167 assertions**.

## README.md

- "What changed in v2" picks up Cancellation, OPTIONS cache, `RetryingIcapClient`, response framing, and the integration bake-out against `mnemoshare/clamav-icap`.
- Roadmap blockquote points to v2.1 connection pooling.

## docs/review/consolidated_task-list.md

Status block restated as **"v2.0.0 ready to tag"** with the full PR table mapping every milestone block to its merged PR (#36..#45). Pooling explicitly deferred to v2.1.

## Verification

- [x] `composer test` — 84 passed (unchanged).
- [x] `composer stan` — clean.
- [x] `composer cs-check` — clean.

## Next

After merge:
1. `git tag -a v2.0.0 -m "v2.0.0 — RFC-3507 wire format, security hardening, ecosystem fit"`
2. `git push origin v2.0.0` (Packagist picks it up automatically).
3. Open v2.1 branch for connection-pooling work.