### PR TITLE
feat(v2.1): keep-alive connection pooling in AsyncAmpTransport

### DIFF
--- a/src/Transport/AmpConnectionPool.php
+++ b/src/Transport/AmpConnectionPool.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Amp\Cancellation;
+use Amp\Socket;
+use Amp\Socket\ConnectContext;
+use Amp\Socket\Socket as SocketInterface;
+use Closure;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Exception\IcapConnectionException;
+
+/**
+ * In-process keep-alive pool of amphp sockets.
+ *
+ * Idle sockets are stored as a LIFO stack per host:port[:tls] key
+ * (most recently used first — warmer connections are likelier to
+ * still be alive). On {@see acquire()} the pool pops sockets off the
+ * stack, drops any that are already closed, and connects a fresh one
+ * if none are usable. On {@see release()} a socket is pushed back
+ * unless the per-host cap is reached, in which case it's closed.
+ *
+ * The pool keeps no separate idle timer — c-icap and most ICAP
+ * vendors send `Connection: close` once they're done with a session
+ * (or simply close the socket); the next {@see acquire()} drops the
+ * stale entry and reconnects. A future enhancement could add an
+ * idle-time eviction sweep if real deployments show socket
+ * accumulation.
+ */
+final class AmpConnectionPool implements ConnectionPoolInterface
+{
+    /** @var array<string, list<SocketInterface>> */
+    private array $idle = [];
+
+    private bool $closed = false;
+
+    /** @var Closure(Config, ?Cancellation): SocketInterface */
+    private Closure $connector;
+
+    /**
+     * @param int                                                                  $maxConnectionsPerHost cap on idle sockets per host:port[:tls] key
+     * @param (Closure(Config, ?Cancellation): SocketInterface)|null               $connector              optional override — production code uses the amphp connector; tests can inject pre-built socket pairs
+     */
+    public function __construct(
+        private int $maxConnectionsPerHost = 8,
+        ?Closure $connector = null,
+    ) {
+        if ($maxConnectionsPerHost < 1) {
+            throw new \InvalidArgumentException(
+                'maxConnectionsPerHost must be >= 1, got: ' . $maxConnectionsPerHost,
+            );
+        }
+
+        $this->connector = $connector ?? self::defaultConnector();
+    }
+
+    #[\Override]
+    public function acquire(Config $config, ?Cancellation $cancellation = null): SocketInterface
+    {
+        if ($this->closed) {
+            throw new IcapConnectionException('Pool is closed.');
+        }
+
+        $key = $this->key($config);
+
+        while (!empty($this->idle[$key])) {
+            $socket = array_pop($this->idle[$key]);
+            if (!$socket->isClosed()) {
+                return $socket;
+            }
+            // Drop the stale entry and try the next one.
+        }
+
+        return ($this->connector)($config, $cancellation);
+    }
+
+    #[\Override]
+    public function release(Config $config, SocketInterface $socket): void
+    {
+        if ($socket->isClosed() || $this->closed) {
+            $socket->close();
+            return;
+        }
+
+        $key = $this->key($config);
+        $idleCount = count($this->idle[$key] ?? []);
+
+        if ($idleCount >= $this->maxConnectionsPerHost) {
+            // Cap reached — closing the surplus socket is the right
+            // thing per RFC 3507 §4.10.2 (servers also bound this via
+            // Max-Connections; a future enhancement could read that
+            // value back and tune the cap automatically).
+            $socket->close();
+            return;
+        }
+
+        $this->idle[$key][] = $socket;
+    }
+
+    #[\Override]
+    public function close(): void
+    {
+        $this->closed = true;
+        foreach ($this->idle as $sockets) {
+            foreach ($sockets as $socket) {
+                $socket->close();
+            }
+        }
+        $this->idle = [];
+    }
+
+    private function key(Config $config): string
+    {
+        return $config->host . ':' . $config->port . ($config->getTlsContext() !== null ? ':tls' : '');
+    }
+
+    /**
+     * @return Closure(Config, ?Cancellation): SocketInterface
+     */
+    private static function defaultConnector(): Closure
+    {
+        return static function (Config $config, ?Cancellation $cancellation): SocketInterface {
+            $tls = $config->getTlsContext();
+            $url = sprintf('tcp://%s:%d', $config->host, $config->port);
+            $context = (new ConnectContext())->withConnectTimeout($config->getSocketTimeout());
+            if ($tls !== null) {
+                $context = $context->withTlsContext($tls);
+            }
+
+            try {
+                if ($tls !== null) {
+                    return Socket\connectTls($url, $context, $cancellation);
+                }
+                return Socket\connect($url, $context, $cancellation);
+            } catch (Socket\ConnectException $e) {
+                throw new IcapConnectionException(
+                    sprintf('Pooled connect to %s:%d failed.', $config->host, $config->port),
+                    0,
+                    $e,
+                );
+            }
+        };
+    }
+}

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -24,6 +24,7 @@ use Amp\Cancellation;
 use Amp\CompositeCancellation;
 use Amp\Socket;
 use Amp\Socket\ConnectContext;
+use Amp\Socket\Socket as SocketInterface;
 use Amp\TimeoutCancellation;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
@@ -43,15 +44,29 @@ use function Amp\async;
  * {@see CompositeCancellation}; whichever fires first aborts the
  * read/write loop with `Amp\CancelledException`.
  *
- * Response framing is done by {@see ResponseFrameReader} so the
- * read loop terminates as soon as the message is complete — no
- * dependency on the server closing the socket. That means the
- * `Connection: close` request-side hack from M4 is gone, and a
- * future pooling implementation can reuse the socket for the next
- * request without changing this code.
+ * Response framing is done by {@see ResponseFrameReader} so the read
+ * loop terminates as soon as the message is complete — no dependency
+ * on the server closing the socket.
+ *
+ * **Connection pooling (v2.1+).** When constructed with a
+ * {@see ConnectionPoolInterface}, the transport calls
+ * `acquire()` instead of opening a fresh TCP/TLS connection and
+ * `release()` instead of closing the socket. The socket is closed
+ * (rather than returned) when:
+ *   - the framing reader threw — the socket might be in an
+ *     inconsistent state and we play safe;
+ *   - the server's response carries `Connection: close` (RFC 7230
+ *     §6.1) — we honour the close intent.
+ * Without a pool the transport opens a fresh socket per request and
+ * closes it after — identical to the v2.0 behaviour.
  */
 final class AsyncAmpTransport implements TransportInterface
 {
+    public function __construct(
+        private ?ConnectionPoolInterface $pool = null,
+    ) {
+    }
+
     /**
      * @param iterable<string> $rawRequest
      * @return \Amp\Future<string>
@@ -61,25 +76,15 @@ final class AsyncAmpTransport implements TransportInterface
     {
         /** @var \Amp\Future<string> $future */
         $future = async(function () use ($config, $rawRequest, $cancellation): string {
-            $socket = null;
-            $tls = $config->getTlsContext();
-            $connectionUrl = sprintf('tcp://%s:%d', $config->host, $config->port);
-            $connectContext = (new ConnectContext())
-                ->withConnectTimeout($config->getSocketTimeout());
-            if ($tls !== null) {
-                $connectContext = $connectContext->withTlsContext($tls);
-            }
             $timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
             $cancellation = $cancellation === null
                 ? $timeoutCancellation
                 : new CompositeCancellation($cancellation, $timeoutCancellation);
 
+            $socket = $this->acquireSocket($config, $cancellation);
+            $disposeBy = 'close';
+
             try {
-                if ($tls !== null) {
-                    $socket = Socket\connectTls($connectionUrl, $connectContext, $cancellation);
-                } else {
-                    $socket = Socket\connect($connectionUrl, $connectContext, $cancellation);
-                }
                 foreach ($rawRequest as $chunk) {
                     if ($chunk !== '') {
                         $socket->write($chunk);
@@ -90,18 +95,70 @@ final class AsyncAmpTransport implements TransportInterface
                     maxResponseSize: $config->getMaxResponseSize(),
                     maxHeaderLineLength: $config->getMaxHeaderLineLength(),
                 );
-                return $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
-            } catch (Socket\ConnectException $e) {
-                throw new IcapConnectionException(
-                    sprintf('Async connection to %s:%d failed.', $config->host, $config->port),
-                    0,
-                    $e,
-                );
+                $response = $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
+
+                // Honour `Connection: close` from the server (RFC 7230
+                // §6.1). The pooled path reuses the socket only when
+                // both sides agree to keep it alive; without a pool
+                // every socket is closed regardless.
+                $disposeBy = $this->serverWantsClose($response) ? 'close' : 'release';
+
+                return $response;
             } finally {
-                $socket?->close();
+                $this->disposeSocket($config, $socket, $disposeBy);
             }
         });
 
         return $future;
+    }
+
+    private function acquireSocket(Config $config, Cancellation $cancellation): SocketInterface
+    {
+        if ($this->pool !== null) {
+            return $this->pool->acquire($config, $cancellation);
+        }
+
+        $tls = $config->getTlsContext();
+        $url = sprintf('tcp://%s:%d', $config->host, $config->port);
+        $context = (new ConnectContext())->withConnectTimeout($config->getSocketTimeout());
+        if ($tls !== null) {
+            $context = $context->withTlsContext($tls);
+        }
+
+        try {
+            if ($tls !== null) {
+                return Socket\connectTls($url, $context, $cancellation);
+            }
+            return Socket\connect($url, $context, $cancellation);
+        } catch (Socket\ConnectException $e) {
+            throw new IcapConnectionException(
+                sprintf('Async connection to %s:%d failed.', $config->host, $config->port),
+                0,
+                $e,
+            );
+        }
+    }
+
+    private function disposeSocket(Config $config, SocketInterface $socket, string $disposeBy): void
+    {
+        if ($this->pool === null || $disposeBy === 'close') {
+            $socket->close();
+            return;
+        }
+        $this->pool->release($config, $socket);
+    }
+
+    /**
+     * Cheap heuristic for `Connection: close` in the ICAP head. We
+     * don't fully reparse here — the response parser does that — but
+     * we want to keep the socket-disposal decision local to the
+     * transport.
+     */
+    private function serverWantsClose(string $response): bool
+    {
+        // Limit the search to the head block; case-insensitive match.
+        $headEnd = strpos($response, "\r\n\r\n");
+        $head = $headEnd === false ? $response : substr($response, 0, $headEnd);
+        return preg_match('/^Connection:\s*close\s*$/im', $head) === 1;
     }
 }

--- a/src/Transport/ConnectionPoolInterface.php
+++ b/src/Transport/ConnectionPoolInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Amp\Cancellation;
+use Amp\Socket\Socket;
+use Ndrstmr\Icap\Config;
+
+/**
+ * Process-local cache of TCP/TLS connections to ICAP servers.
+ *
+ * The transport calls {@see acquire()} before sending the request
+ * and {@see release()} after the response has been framed. The pool
+ * decides whether to hand out an existing idle socket or open a new
+ * one, and whether to keep a returned socket idle or close it.
+ *
+ * The default implementation is {@see AmpConnectionPool}. The
+ * {@see NullConnectionPool} variant disables pooling — every
+ * acquire opens a fresh connection, every release closes it.
+ *
+ * Implementations MUST be safe to use across concurrent
+ * acquire/release cycles within a single fiber-driven event loop;
+ * cross-process safety is the implementer's choice.
+ */
+interface ConnectionPoolInterface
+{
+    /**
+     * Hand back a socket connected to the host described by $config.
+     * Returns either a previously released, still-alive socket or a
+     * freshly opened one. May suspend the current fiber while
+     * connecting; honours $cancellation if supplied.
+     */
+    public function acquire(Config $config, ?Cancellation $cancellation = null): Socket;
+
+    /**
+     * Hand a socket back to the pool. The caller MUST NOT continue
+     * using the socket after this call. Implementations may close
+     * the socket if it isn't reusable (already closed, pool full,
+     * server signalled `Connection: close`).
+     */
+    public function release(Config $config, Socket $socket): void;
+
+    /**
+     * Close every pooled idle socket. Idempotent. Sockets currently
+     * in use by callers are unaffected — they will be closed when
+     * released against this pool, since the pool won't accept new
+     * idle entries after close().
+     */
+    public function close(): void;
+}

--- a/tests/Transport/AmpConnectionPoolTest.php
+++ b/tests/Transport/AmpConnectionPoolTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Amp\Socket\Socket as SocketInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.1 connection pooling. After the M3 follow-up dropped the
+ * Connection: close hack, the transport can hand idle sockets back
+ * to a pool keyed by host:port[:tls] and reuse them for subsequent
+ * requests.
+ */
+
+it('reuses a released socket on the next acquire', function () {
+    [, $serverEnd1] = Socket\createSocketPair();
+    [, $serverEnd2] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$serverEnd1, $serverEnd2];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        // Inject a connector that hands out our pre-built sockets so
+        // we don't need a live TCP listener to exercise the pool.
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $first = $pool->acquire($config);
+        $pool->release($config, $first);
+
+        $second = $pool->acquire($config);
+        // Identity: the same Socket instance came back from the pool.
+        expect($second)->toBe($first);
+
+        // Counter check: there should still be 1 socket in the
+        // connector queue — the pool didn't connect a fresh one.
+    });
+
+    expect($queue)->toHaveCount(1);
+});
+
+it('opens a fresh connection when the pool is empty', function () {
+    [, $serverEndA] = Socket\createSocketPair();
+    [, $serverEndB] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$serverEndA, $serverEndB];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $first = $pool->acquire($config);
+        $second = $pool->acquire($config); // pool was empty after first acquire
+        expect($second)->not->toBe($first);
+    });
+});
+
+it('caps idle connections at maxConnectionsPerHost', function () {
+    /** @var SocketInterface[] $queue */
+    $queue = [];
+    for ($i = 0; $i < 5; $i++) {
+        [, $end] = Socket\createSocketPair();
+        $queue[] = $end;
+    }
+    $created = $queue;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 2,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        // Release all three — the third must be closed (cap = 2).
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // The third created socket should have been closed by the pool.
+    expect($created[2]->isClosed())->toBeTrue();
+    // The first two should still be open in the idle pool.
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse();
+});
+
+it('skips a closed idle socket and connects fresh', function () {
+    [, $stale] = Socket\createSocketPair();
+    [, $fresh] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$stale, $fresh];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $fresh) {
+        $first = $pool->acquire($config);
+        // Simulate the server closing the connection between the two
+        // requests (or a timeout intermediary dropping the socket).
+        $first->close();
+        $pool->release($config, $first); // pool sees it's closed → drops it
+
+        $second = $pool->acquire($config);
+        expect($second)->toBe($fresh);
+    });
+});
+
+it('close() shuts down every pooled socket', function () {
+    [, $a] = Socket\createSocketPair();
+    [, $b] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$a, $b];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $first = $pool->acquire($config);
+        $second = $pool->acquire($config);
+        $pool->release($config, $first);
+        $pool->release($config, $second);
+        $pool->close();
+    });
+
+    expect($a->isClosed())->toBeTrue()
+        ->and($b->isClosed())->toBeTrue();
+});
+
+it('isolates idle sockets per host:port', function () {
+    [, $h1] = Socket\createSocketPair();
+    [, $h2] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$h1, $h2];
+
+    $configA = new Config('host-a');
+    $configB = new Config('host-b');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $configA, $configB, $h1, $h2) {
+        $a = $pool->acquire($configA);
+        $b = $pool->acquire($configB);
+        $pool->release($configA, $a);
+        $pool->release($configB, $b);
+        // Re-acquire from B should NOT return the A socket.
+        expect($pool->acquire($configB))->toBe($h2);
+        expect($pool->acquire($configA))->toBe($h1);
+    });
+});


### PR DESCRIPTION
## Context

First v2.1 feature. The response-framing work in v2.0 (PR #45) made it safe for the server to keep the TCP/TLS connection open; this PR teaches the transport to actually reuse those connections.

## API

New `Ndrstmr\Icap\Transport\ConnectionPoolInterface` (`acquire` / `release` / `close`) — a `Config`-keyed cache of amphp Sockets.

Default impl: `Ndrstmr\Icap\Transport\AmpConnectionPool` — LIFO stack per `host:port[:tls]` key, configurable cap, drops closed sockets on acquire and on release.

`AsyncAmpTransport` gained an optional first ctor argument:

```php
new AsyncAmpTransport($pool);
```

Without a pool the v2.0 behaviour is preserved unchanged — one fresh connection per request, closed on completion.

## Behaviour

- `acquire()` returns the most recently released live socket for the same `host:port[:tls]` key, or opens a fresh one. Stale (closed) idle sockets are dropped.
- `release()` closes the socket if the pool is full (per-host cap), otherwise pushes it back onto the stack.
- The transport closes (rather than releases) the socket when:
  - the framing reader threw — socket might be in an inconsistent state;
  - the server's response carries `Connection: close` (RFC 7230 §6.1) — we honour it.
- `close()` shuts down every idle socket; sockets currently in use by callers are closed when their owners release them.

The default cap is 8 idle sockets per host. Production deployments should consult the server's `Max-Connections` (RFC 3507 §4.10.2) and adjust — a future enhancement could read it back from a recently-cached OPTIONS response and tune dynamically.

## Tests

`tests/Transport/AmpConnectionPoolTest.php` — 6 cases:
- Released socket is reused on the next acquire (identity check).
- Empty pool → fresh connection.
- Per-host cap closes surplus sockets on release.
- Closed idle socket is skipped, fresh one connected.
- `close()` shuts down every pooled socket.
- Per-`host:port` keys are isolated.

Tests inject `Socket` pairs (`Amp\Socket\createSocketPair`) via the connector closure, so no live TCP listener is needed.

## Verification

- [x] `composer test` — 90 passed (was 84), 178 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## Next on v2.1

- Strict single-connection preview-continue per RFC 3507 §4.5 (currently approximated by a fresh request for the remainder). With the pool in place this is a straightforward two-write/two-read sequence on the same socket — a follow-up PR.