### PR TITLE
feat(v2.1): strict RFC 3507 §4.5 preview-continue on a single socket

### DIFF
--- a/src/ChunkedBodyEncoder.php
+++ b/src/ChunkedBodyEncoder.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+/**
+ * HTTP/1.1 chunked-transfer encoder used by both the {@see
+ * RequestFormatter} (for the encapsulated body inside an ICAP request)
+ * and by the strict RFC 3507 §4.5 preview-continue path (where the
+ * client sends the rest of the body on the same socket after the
+ * server's `100 Continue` response).
+ *
+ * Strings are emitted as a single chunk; resources are read in
+ * {@see self::CHUNK_SIZE} blocks so a multi-gigabyte body never needs
+ * to reside in memory.
+ */
+final class ChunkedBodyEncoder
+{
+    public const int CHUNK_SIZE = 8192;
+
+    /**
+     * @param  string|resource  $body
+     * @return iterable<string>
+     */
+    public function encode(mixed $body, bool $previewIsComplete = false): iterable
+    {
+        $terminator = $previewIsComplete ? "0; ieof\r\n\r\n" : "0\r\n\r\n";
+
+        if (is_string($body)) {
+            if ($body !== '') {
+                yield dechex(strlen($body)) . "\r\n" . $body . "\r\n";
+            }
+            yield $terminator;
+            return;
+        }
+
+        if (!is_resource($body)) {
+            throw new \InvalidArgumentException(
+                'Encapsulated HTTP body must be a string or a readable stream resource.',
+            );
+        }
+
+        rewind($body);
+        while (!feof($body)) {
+            $chunk = fread($body, self::CHUNK_SIZE);
+            if ($chunk === false || $chunk === '') {
+                break;
+            }
+            yield dechex(strlen($chunk)) . "\r\n" . $chunk . "\r\n";
+        }
+        yield $terminator;
+    }
+}

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -32,6 +32,7 @@ use Ndrstmr\Icap\Exception\IcapProtocolException;
 use Ndrstmr\Icap\Exception\IcapResponseException;
 use Ndrstmr\Icap\Exception\IcapServerException;
 use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+use Ndrstmr\Icap\Transport\SessionAwareTransport;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
 use Ndrstmr\Icap\Transport\TransportInterface;
 use Psr\Log\LoggerInterface;
@@ -289,58 +290,100 @@ final class IcapClient implements IcapClientInterface
                 throw new \RuntimeException('Unable to open file: ' . $filePath);
             }
 
-            $previewBytes = fread($stream, $previewSize);
-            if ($previewBytes === false) {
+            try {
+                if ($this->transport instanceof SessionAwareTransport) {
+                    // Strict RFC 3507 §4.5 path — preview + continuation
+                    // on the same socket, one logical ICAP request.
+                    return $this->scanFileWithPreviewStrict(
+                        $service,
+                        $stream,
+                        $fileSize,
+                        $previewSize,
+                        $extraHeaders,
+                        $cancellation,
+                    );
+                }
+                // Legacy two-request approximation for non-session
+                // transports (synchronous, custom impls).
+                return $this->scanFileWithPreviewLegacy(
+                    $service,
+                    $stream,
+                    $fileSize,
+                    $previewSize,
+                    $extraHeaders,
+                    $cancellation,
+                );
+            } finally {
                 fclose($stream);
-                throw new \RuntimeException('Unable to read preview: ' . $filePath);
             }
+        });
 
-            $previewIsComplete = $fileSize <= $previewSize;
+        return $future;
+    }
 
-            $previewEnvelope = new HttpResponse(
-                statusCode: 200,
-                headers: [
-                    'Content-Type'   => ['application/octet-stream'],
-                    'Content-Length' => [(string) $fileSize],
-                ],
-                body: $previewBytes,
-            );
+    /**
+     * Strict RFC 3507 §4.5 preview-continue: the preview and the
+     * continuation travel on the same socket as one logical ICAP
+     * request. Requires a {@see SessionAwareTransport}.
+     *
+     * @param resource                       $stream
+     * @param array<string, string|string[]> $extraHeaders
+     */
+    private function scanFileWithPreviewStrict(
+        string $service,
+        mixed $stream,
+        int $fileSize,
+        int $previewSize,
+        array $extraHeaders,
+        ?Cancellation $cancellation,
+    ): ScanResult {
+        \assert($this->transport instanceof SessionAwareTransport);
+        \assert($previewSize >= 1);
 
-            // Merge caller-supplied headers, but library-managed headers
-            // MUST win: letting the caller override Preview/Allow would
-            // put the protocol exchange into an inconsistent state.
-            $headers = $this->mergeHeaders($extraHeaders, [
-                'Preview' => [(string) $previewSize],
-                'Allow'   => ['204'],
-            ]);
+        $previewBytes = fread($stream, $previewSize);
+        if ($previewBytes === false) {
+            throw new \RuntimeException('Unable to read preview from file stream.');
+        }
+        $previewIsComplete = $fileSize <= $previewSize;
 
-            $previewRequest = new IcapRequest(
-                method: 'RESPMOD',
-                uri: $this->buildServiceUri($service),
-                headers: $headers,
-                encapsulatedResponse: $previewEnvelope,
-                previewIsComplete: $previewIsComplete,
-            );
+        $previewEnvelope = new HttpResponse(
+            statusCode: 200,
+            headers: [
+                'Content-Type'   => ['application/octet-stream'],
+                'Content-Length' => [(string) $fileSize],
+            ],
+            body: $previewBytes,
+        );
+        $headers = $this->mergeHeaders($extraHeaders, [
+            'Preview' => [(string) $previewSize],
+            'Allow'   => ['204'],
+        ]);
+        $previewRequest = new IcapRequest(
+            method: 'RESPMOD',
+            uri: $this->buildServiceUri($service),
+            headers: $headers,
+            encapsulatedResponse: $previewEnvelope,
+            previewIsComplete: $previewIsComplete,
+        );
 
-            // Preview round: bypass interpretResponse() so a legitimate
-            // 100 Continue from the server doesn't trip the fail-secure
-            // guard that only applies outside preview context.
-            $previewIcapResponse = $this->executeRaw($previewRequest, $cancellation)->await();
+        $session = $this->transport->openSession($this->config, $cancellation);
+        try {
+            $session->write($this->formatter->format($previewRequest));
+            $previewIcapResponse = $this->parser->parse($session->readResponse());
 
             if ($previewIsComplete) {
-                fclose($stream);
+                $session->release();
                 return $this->interpretResponse($previewIcapResponse, $this->config);
             }
 
             $decision = $this->previewStrategy->handlePreviewResponse($previewIcapResponse);
 
             if ($decision !== PreviewDecision::CONTINUE_SENDING) {
-                fclose($stream);
-                // The strategy has made the final call. Build a
-                // ScanResult directly from its verdict rather than
-                // running interpretResponse() over the preview-stage
-                // status code (which is 100 in a typical abort path
-                // and would otherwise trip the fail-secure guard).
+                // Server's intermediate response is the verdict — nothing
+                // to send on this socket. Release back to the pool;
+                // sockets that have only seen a 100 are still in good
+                // protocol state.
+                $session->release();
                 return new ScanResult(
                     isInfected: $decision === PreviewDecision::ABORT_INFECTED,
                     virusName: $decision === PreviewDecision::ABORT_INFECTED
@@ -350,35 +393,105 @@ final class IcapClient implements IcapClientInterface
                 );
             }
 
-            // The server wants the rest. Stream the full file in a fresh
-            // RESPMOD; this is the pragmatic approximation of the
-            // RFC-3507 §4.5 "continue after preview" flow on a persistent
-            // connection — proper single-connection continuation is
-            // tracked for a later milestone.
-            rewind($stream);
-            $fullResponse = new HttpResponse(
-                statusCode: 200,
-                headers: [
-                    'Content-Type'   => ['application/octet-stream'],
-                    'Content-Length' => [(string) $fileSize],
-                ],
-                body: $stream,
-            );
-            $fullRequest = new IcapRequest(
-                method: 'RESPMOD',
-                uri: $this->buildServiceUri($service),
-                headers: $extraHeaders,
-                encapsulatedResponse: $fullResponse,
-            );
-
-            try {
-                return $this->request($fullRequest, $cancellation)->await();
-            } finally {
-                fclose($stream);
+            // §4.5 continuation: ONLY the chunked body remainder, no
+            // new ICAP head. The original RESPMOD envelope still wraps
+            // the entire scan.
+            $remainder = stream_get_contents($stream);
+            if ($remainder === false) {
+                $remainder = '';
             }
-        });
+            $session->write((new ChunkedBodyEncoder())->encode($remainder));
 
-        return $future;
+            $finalIcapResponse = $this->parser->parse($session->readResponse());
+            $session->release();
+            return $this->interpretResponse($finalIcapResponse, $this->config);
+        } catch (\Throwable $e) {
+            // The exchange went off-script — never offer this socket
+            // back to the pool, the next user could see misaligned
+            // bytes.
+            $session->close();
+            throw $e;
+        }
+    }
+
+    /**
+     * Two-request approximation of RFC 3507 §4.5 used when the
+     * transport doesn't expose a {@see SessionAwareTransport} surface
+     * (synchronous transport, custom implementations). Works against
+     * permissive servers but spends a second TCP/TLS handshake.
+     *
+     * @param resource                       $stream
+     * @param array<string, string|string[]> $extraHeaders
+     */
+    private function scanFileWithPreviewLegacy(
+        string $service,
+        mixed $stream,
+        int $fileSize,
+        int $previewSize,
+        array $extraHeaders,
+        ?Cancellation $cancellation,
+    ): ScanResult {
+        \assert($previewSize >= 1);
+
+        $previewBytes = fread($stream, $previewSize);
+        if ($previewBytes === false) {
+            throw new \RuntimeException('Unable to read preview from file stream.');
+        }
+        $previewIsComplete = $fileSize <= $previewSize;
+
+        $previewEnvelope = new HttpResponse(
+            statusCode: 200,
+            headers: [
+                'Content-Type'   => ['application/octet-stream'],
+                'Content-Length' => [(string) $fileSize],
+            ],
+            body: $previewBytes,
+        );
+        $headers = $this->mergeHeaders($extraHeaders, [
+            'Preview' => [(string) $previewSize],
+            'Allow'   => ['204'],
+        ]);
+        $previewRequest = new IcapRequest(
+            method: 'RESPMOD',
+            uri: $this->buildServiceUri($service),
+            headers: $headers,
+            encapsulatedResponse: $previewEnvelope,
+            previewIsComplete: $previewIsComplete,
+        );
+
+        $previewIcapResponse = $this->executeRaw($previewRequest, $cancellation)->await();
+
+        if ($previewIsComplete) {
+            return $this->interpretResponse($previewIcapResponse, $this->config);
+        }
+
+        $decision = $this->previewStrategy->handlePreviewResponse($previewIcapResponse);
+        if ($decision !== PreviewDecision::CONTINUE_SENDING) {
+            return new ScanResult(
+                isInfected: $decision === PreviewDecision::ABORT_INFECTED,
+                virusName: $decision === PreviewDecision::ABORT_INFECTED
+                    ? $this->extractVirusName($previewIcapResponse, $this->config)
+                    : null,
+                originalResponse: $previewIcapResponse,
+            );
+        }
+
+        rewind($stream);
+        $fullResponse = new HttpResponse(
+            statusCode: 200,
+            headers: [
+                'Content-Type'   => ['application/octet-stream'],
+                'Content-Length' => [(string) $fileSize],
+            ],
+            body: $stream,
+        );
+        $fullRequest = new IcapRequest(
+            method: 'RESPMOD',
+            uri: $this->buildServiceUri($service),
+            headers: $extraHeaders,
+            encapsulatedResponse: $fullResponse,
+        );
+        return $this->request($fullRequest, $cancellation)->await();
     }
 
     private function buildServiceUri(string $service): string

--- a/src/RequestFormatter.php
+++ b/src/RequestFormatter.php
@@ -41,8 +41,6 @@ use Ndrstmr\Icap\DTO\IcapRequest;
  */
 final class RequestFormatter implements RequestFormatterInterface
 {
-    private const int CHUNK_SIZE = 8192;
-
     #[\Override]
     public function format(IcapRequest $request): iterable
     {
@@ -200,41 +198,16 @@ final class RequestFormatter implements RequestFormatterInterface
     }
 
     /**
-     * Emit the body as HTTP/1.1 chunked transfer encoding.
-     *
-     * Strings are sent as a single chunk; resources are read in
-     * self::CHUNK_SIZE blocks so a multi-gigabyte body never needs to
-     * reside in memory.
+     * Emit the body as HTTP/1.1 chunked transfer encoding. Delegates
+     * to {@see ChunkedBodyEncoder} so the strict RFC 3507 §4.5
+     * preview-continue path on the same socket can reuse the exact
+     * same encoding rules.
      *
      * @param string|resource $body
      * @return iterable<string>
      */
     private function chunkBody(mixed $body, bool $previewIsComplete): iterable
     {
-        $terminator = $previewIsComplete ? "0; ieof\r\n\r\n" : "0\r\n\r\n";
-
-        if (is_string($body)) {
-            if ($body !== '') {
-                yield dechex(strlen($body)) . "\r\n" . $body . "\r\n";
-            }
-            yield $terminator;
-            return;
-        }
-
-        if (!is_resource($body)) {
-            throw new \InvalidArgumentException(
-                'Encapsulated HTTP body must be a string or a readable stream resource.',
-            );
-        }
-
-        rewind($body);
-        while (!feof($body)) {
-            $chunk = fread($body, self::CHUNK_SIZE);
-            if ($chunk === false || $chunk === '') {
-                break;
-            }
-            yield dechex(strlen($chunk)) . "\r\n" . $chunk . "\r\n";
-        }
-        yield $terminator;
+        return (new ChunkedBodyEncoder())->encode($body, $previewIsComplete);
     }
 }

--- a/src/Transport/AmpTransportSession.php
+++ b/src/Transport/AmpTransportSession.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Amp\Cancellation;
+use Amp\Socket\Socket as SocketInterface;
+use Ndrstmr\Icap\Config;
+
+/**
+ * One-acquired-socket binding used for multi-round-trip flows like
+ * the strict RFC 3507 §4.5 preview-continue exchange.
+ *
+ * Lifecycle:
+ *   - {@see AsyncAmpTransport::openSession()} acquires a socket from
+ *     the pool (or opens a fresh one).
+ *   - The caller writes / reads as many times as the protocol
+ *     requires.
+ *   - The caller calls {@see release()} on success (returns to the
+ *     pool when one is configured) or {@see close()} on failure.
+ */
+final class AmpTransportSession implements TransportSession
+{
+    private bool $disposed = false;
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly SocketInterface $socket,
+        private readonly Cancellation $cancellation,
+        private readonly int $maxResponseSize,
+        private readonly int $maxHeaderLineLength,
+        private readonly ?ConnectionPoolInterface $pool,
+    ) {
+    }
+
+    #[\Override]
+    public function write(iterable $chunks): void
+    {
+        $this->assertActive();
+        foreach ($chunks as $chunk) {
+            if ($chunk !== '') {
+                $this->socket->write($chunk);
+            }
+        }
+    }
+
+    #[\Override]
+    public function readResponse(): string
+    {
+        $this->assertActive();
+        $reader = new ResponseFrameReader(
+            maxResponseSize: $this->maxResponseSize,
+            maxHeaderLineLength: $this->maxHeaderLineLength,
+        );
+        $cancellation = $this->cancellation;
+        $socket = $this->socket;
+        return $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
+    }
+
+    #[\Override]
+    public function release(): void
+    {
+        if ($this->disposed) {
+            return;
+        }
+        $this->disposed = true;
+
+        if ($this->pool !== null) {
+            $this->pool->release($this->config, $this->socket);
+            return;
+        }
+        $this->socket->close();
+    }
+
+    #[\Override]
+    public function close(): void
+    {
+        if ($this->disposed) {
+            return;
+        }
+        $this->disposed = true;
+        $this->socket->close();
+    }
+
+    private function assertActive(): void
+    {
+        if ($this->disposed) {
+            throw new \LogicException('TransportSession has already been released or closed.');
+        }
+    }
+}

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -59,8 +59,13 @@ use function Amp\async;
  *     §6.1) — we honour the close intent.
  * Without a pool the transport opens a fresh socket per request and
  * closes it after — identical to the v2.0 behaviour.
+ *
+ * **Sessions (v2.1+).** Implements {@see SessionAwareTransport} so
+ * callers that need to send + receive multiple times on the same
+ * connection (strict RFC 3507 §4.5 preview-continue, ICAP request
+ * pipelining, …) can call {@see openSession()}.
  */
-final class AsyncAmpTransport implements TransportInterface
+final class AsyncAmpTransport implements SessionAwareTransport
 {
     public function __construct(
         private ?ConnectionPoolInterface $pool = null,
@@ -76,40 +81,48 @@ final class AsyncAmpTransport implements TransportInterface
     {
         /** @var \Amp\Future<string> $future */
         $future = async(function () use ($config, $rawRequest, $cancellation): string {
-            $timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
-            $cancellation = $cancellation === null
-                ? $timeoutCancellation
-                : new CompositeCancellation($cancellation, $timeoutCancellation);
-
-            $socket = $this->acquireSocket($config, $cancellation);
-            $disposeBy = 'close';
-
+            $session = $this->openSession($config, $cancellation);
+            $closeForced = false;
             try {
-                foreach ($rawRequest as $chunk) {
-                    if ($chunk !== '') {
-                        $socket->write($chunk);
-                    }
+                $session->write($rawRequest);
+                $response = $session->readResponse();
+                if ($this->serverWantsClose($response)) {
+                    $closeForced = true;
                 }
-
-                $reader = new ResponseFrameReader(
-                    maxResponseSize: $config->getMaxResponseSize(),
-                    maxHeaderLineLength: $config->getMaxHeaderLineLength(),
-                );
-                $response = $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
-
-                // Honour `Connection: close` from the server (RFC 7230
-                // §6.1). The pooled path reuses the socket only when
-                // both sides agree to keep it alive; without a pool
-                // every socket is closed regardless.
-                $disposeBy = $this->serverWantsClose($response) ? 'close' : 'release';
-
                 return $response;
+            } catch (\Throwable $e) {
+                $closeForced = true;
+                throw $e;
             } finally {
-                $this->disposeSocket($config, $socket, $disposeBy);
+                if ($closeForced) {
+                    $session->close();
+                } else {
+                    $session->release();
+                }
             }
         });
 
         return $future;
+    }
+
+    #[\Override]
+    public function openSession(Config $config, ?Cancellation $cancellation = null): TransportSession
+    {
+        $timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
+        $effective = $cancellation === null
+            ? $timeoutCancellation
+            : new CompositeCancellation($cancellation, $timeoutCancellation);
+
+        $socket = $this->acquireSocket($config, $effective);
+
+        return new AmpTransportSession(
+            config: $config,
+            socket: $socket,
+            cancellation: $effective,
+            maxResponseSize: $config->getMaxResponseSize(),
+            maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+            pool: $this->pool,
+        );
     }
 
     private function acquireSocket(Config $config, Cancellation $cancellation): SocketInterface
@@ -139,15 +152,6 @@ final class AsyncAmpTransport implements TransportInterface
         }
     }
 
-    private function disposeSocket(Config $config, SocketInterface $socket, string $disposeBy): void
-    {
-        if ($this->pool === null || $disposeBy === 'close') {
-            $socket->close();
-            return;
-        }
-        $this->pool->release($config, $socket);
-    }
-
     /**
      * Cheap heuristic for `Connection: close` in the ICAP head. We
      * don't fully reparse here — the response parser does that — but
@@ -156,7 +160,6 @@ final class AsyncAmpTransport implements TransportInterface
      */
     private function serverWantsClose(string $response): bool
     {
-        // Limit the search to the head block; case-insensitive match.
         $headEnd = strpos($response, "\r\n\r\n");
         $head = $headEnd === false ? $response : substr($response, 0, $headEnd);
         return preg_match('/^Connection:\s*close\s*$/im', $head) === 1;

--- a/src/Transport/SessionAwareTransport.php
+++ b/src/Transport/SessionAwareTransport.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Amp\Cancellation;
+use Ndrstmr\Icap\Config;
+
+/**
+ * Optional capability surface for transports that can hand out a
+ * {@see TransportSession}. The default async transport
+ * ({@see AsyncAmpTransport}) implements both this and
+ * {@see TransportInterface}; the synchronous transport intentionally
+ * does not — sync is for CLI usage where strict RFC 3507 §4.5
+ * preview-continue isn't worth the added complexity.
+ *
+ * Callers (typically {@see \Ndrstmr\Icap\IcapClient}) check for this
+ * interface via `instanceof` before opting into multi-round flows.
+ */
+interface SessionAwareTransport extends TransportInterface
+{
+    /**
+     * Open a session against the host described by $config. The
+     * caller MUST eventually call {@see TransportSession::release()}
+     * or {@see TransportSession::close()} on the returned session.
+     */
+    public function openSession(Config $config, ?Cancellation $cancellation = null): TransportSession;
+}

--- a/src/Transport/TransportSession.php
+++ b/src/Transport/TransportSession.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+/**
+ * A bound socket that can carry more than one write/read round-trip
+ * before being released.
+ *
+ * The strict RFC 3507 §4.5 preview-continue flow needs this: the
+ * client sends the preview, reads the server's `100 Continue`, then
+ * sends the rest of the body — all on the same connection, all part
+ * of one logical ICAP request. The plain
+ * {@see TransportInterface::request()} method is one-shot and can't
+ * model that.
+ *
+ * Sessions are obtained from
+ * {@see SessionAwareTransport::openSession()}. Callers MUST call
+ * either {@see release()} (return to the pool when configured, close
+ * otherwise) or {@see close()} (force-close), exactly once.
+ */
+interface TransportSession
+{
+    /**
+     * Push request bytes onto the socket. Honours the cancellation
+     * token the session was opened with.
+     *
+     * @param iterable<string> $chunks
+     */
+    public function write(iterable $chunks): void;
+
+    /**
+     * Read one fully-framed ICAP response from the socket. The
+     * underlying {@see ResponseFrameReader} stops as soon as the
+     * message is complete, leaving any trailing bytes in the kernel
+     * buffer for the next call.
+     */
+    public function readResponse(): string;
+
+    /**
+     * Return the socket to the underlying pool when one is configured;
+     * otherwise close it. Idempotent in the sense that further calls
+     * are no-ops.
+     */
+    public function release(): void;
+
+    /**
+     * Force-close the socket without offering it back to a pool.
+     * Required when the protocol exchange went off the rails (parse
+     * error, server-side `Connection: close`, exception inside the
+     * request flow).
+     */
+    public function close(): void;
+}

--- a/tests/PreviewContinueStrictTest.php
+++ b/tests/PreviewContinueStrictTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+uses(AsyncTestCase::class);
+
+/**
+ * Strict RFC 3507 §4.5 preview-continue: when the server answers
+ * `100 Continue`, the client sends ONLY the chunked body remainder
+ * on the same socket — no second ICAP request. This test wires a
+ * Socket pair into the connection pool, drives a fake server on the
+ * far end, and asserts the client never opens a second connection.
+ */
+
+it('sends preview, reads 100, then writes only the body remainder on the same socket', function () {
+    [$serverEnd, $clientEnd] = Socket\createSocketPair();
+
+    // Inject our pre-paired client socket via the pool's connector.
+    $connectorCalls = 0;
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use ($clientEnd, &$connectorCalls) {
+            $connectorCalls++;
+            return $clientEnd;
+        },
+    );
+    $config = new Config('icap.example');
+    $client = new IcapClient(
+        $config,
+        new AsyncAmpTransport($pool),
+        new RequestFormatter(),
+        new ResponseParser(),
+    );
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, str_repeat('A', 100));
+
+    $observed = ['phase1' => '', 'phase2' => ''];
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use (
+        $client,
+        $tmp,
+        $serverEnd,
+        &$observed,
+    ) {
+        // Drive the fake server on a parallel fiber.
+        $server = \Amp\async(static function () use ($serverEnd, &$observed): void {
+            // Phase 1 — read until we see the preview's 0\\r\\n\\r\\n
+            // terminator, then answer 100 Continue.
+            $buf = '';
+            while (!str_contains($buf, "0\r\n\r\n")) {
+                $chunk = $serverEnd->read();
+                if ($chunk === null) {
+                    return;
+                }
+                $buf .= $chunk;
+            }
+            $observed['phase1'] = $buf;
+            $serverEnd->write("ICAP/1.0 100 Continue\r\n\r\n");
+
+            // Phase 2 — read the chunked-body continuation (also
+            // ending in 0\\r\\n\\r\\n), then answer 204 Clean.
+            $buf = '';
+            while (!str_contains($buf, "0\r\n\r\n")) {
+                $chunk = $serverEnd->read();
+                if ($chunk === null) {
+                    return;
+                }
+                $buf .= $chunk;
+            }
+            $observed['phase2'] = $buf;
+            $serverEnd->write("ICAP/1.0 204 No Content\r\nEncapsulated: null-body=0\r\n\r\n");
+            $serverEnd->close();
+        });
+
+        $result = $client->scanFileWithPreview('/svc', $tmp, 32)->await();
+        $server->await();
+
+        expect($result->isInfected())->toBeFalse();
+    });
+
+    // The pool's connector was called exactly once: preview and
+    // continuation share a socket.
+    expect($connectorCalls)->toBe(1);
+
+    // Phase 1 must be a real RESPMOD with the Preview / Allow:204
+    // headers and a 0\\r\\n\\r\\n terminator.
+    expect($observed['phase1'])->toStartWith('RESPMOD ')
+        ->and($observed['phase1'])->toContain('Preview: 32')
+        ->and($observed['phase1'])->toContain('Allow: 204')
+        ->and($observed['phase1'])->toContain("0\r\n\r\n");
+
+    // Phase 2 must NOT be a new ICAP request — it's only the
+    // chunked body continuation, terminated by 0\\r\\n\\r\\n.
+    expect($observed['phase2'])->not->toContain('RESPMOD ')
+        ->and($observed['phase2'])->not->toContain('ICAP/1.0')
+        ->and($observed['phase2'])->toContain("0\r\n\r\n");
+
+    unlink($tmp);
+});


### PR DESCRIPTION
## Context

Second v2.1 feature, completing the preview pipeline. With the connection pool from #47 in place, `scanFileWithPreview` now sends the body remainder on the **same socket** that carried the preview — a single logical ICAP request, exactly as RFC 3507 §4.5 prescribes. The previous v2.0 / v2.1.0 behaviour (open a fresh `RESPMOD` with the full file after a `100 Continue`) was a working approximation; this PR replaces it whenever the transport can hand out a session.

## API

New under `Ndrstmr\Icap\Transport`:
- **`TransportSession`** — bound socket usable for multiple write/read round-trips before release/close.
- **`SessionAwareTransport extends TransportInterface`** — optional capability surface for transports that can open sessions.
- **`AmpTransportSession`** — the concrete amphp implementation.

`AsyncAmpTransport` now implements `SessionAwareTransport`. Its existing `request()` method has been refactored to internally use `openSession() + write + readResponse + release` for backwards compatibility — no semantics change for one-shot callers.

`SynchronousStreamTransport` intentionally does **not** implement `SessionAwareTransport`; sync usage falls back to the legacy two-request path. Strict §4.5 is an async-only feature.

## Behaviour

`scanFileWithPreview()` splits along transport capability:

**SessionAwareTransport branch** (new, default for `AsyncAmpTransport`):
1. Open session on a pooled socket.
2. Write the preview `RESPMOD` (chunked body + `0\r\n\r\n`, no `ieof` since more is coming).
3. Read the framed `100 Continue` response.
4. Consult `PreviewStrategyInterface` as before. On `CONTINUE_SENDING`, write **only** the chunked body remainder (no second ICAP head!) terminated by `0\r\n\r\n`.
5. Read the final framed response.
6. Release the session — the socket goes back to the pool ready for the next request.

On any exception inside the exchange the session is **closed** rather than released; we never offer a possibly-misaligned socket back to the pool.

**Legacy branch** (unchanged): fresh `RESPMOD` with the full file after a 100. Used by the synchronous transport and any custom impl that doesn't implement `SessionAwareTransport`.

## Refactoring

`ChunkedBodyEncoder` extracted from `RequestFormatter::chunkBody`. Both the formatter and the strict §4.5 continuation share the same chunked-encoding rules (string vs. resource, optional `ieof` terminator). `RequestFormatter::chunkBody` is now a thin proxy.

## Tests

`tests/PreviewContinueStrictTest.php` — drives a fake server through `Amp\Socket\createSocketPair` injected into the pool's connector. Asserts:
- the connector is invoked **exactly once** (single socket for both preview and continuation),
- phase 1 carries a real `RESPMOD` with `Preview` / `Allow: 204` and a `0\r\n\r\n` terminator,
- phase 2 contains **no** new `RESPMOD` line — only the chunked body remainder.

All existing tests still pass under the refactor (`request()` internally goes through `openSession()` now).

## Verification

- [x] `composer test` — 91 passed (was 90), 187 assertions.
- [x] `composer stan` — PHPStan 2.1 Level 9 + bleedingEdge clean.
- [x] `composer cs-check` — clean.
- [x] CI matrix (8.4 + 8.5).

## Status

This closes the v2.1 follow-up roadmap. After merge, `v2.1.0` is ready to tag.