### PR TITLE
docs: v2.1.0 release prep — CHANGELOG entry, README roadmap update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Planned for v2.1.0
-- Keep-alive connection pooling in `AsyncAmpTransport` (the response-framing prerequisite landed in v2.0.0; this is now a tractable transport-only refactor).
-- Single-connection preview-continue per RFC 3507 §4.5 strict reading.
+_No changes since v2.1.0._
+
+## [2.1.0] - 2026-04-25
+
+### Added — keep-alive transport
+- **Connection pooling** in `AsyncAmpTransport`. New
+  `Ndrstmr\Icap\Transport\ConnectionPoolInterface` with default
+  `AmpConnectionPool` (LIFO stack per `host:port[:tls]` key,
+  configurable cap, drops closed sockets on acquire and on release).
+  Transport accepts an optional pool argument and reuses sockets
+  across requests; without a pool the v2.0 single-shot behaviour is
+  preserved unchanged. Closed (rather than released) on framing
+  errors or `Connection: close` from the server.
+- **`SessionAwareTransport`** capability surface plus
+  `TransportSession` and the `AmpTransportSession` implementation —
+  open one socket, run several write/read round-trips before
+  release/close. Used by the new strict preview-continue path.
+- **Strict RFC 3507 §4.5 preview-continue** in
+  `IcapClient::scanFileWithPreview()`. When the transport supports
+  sessions (the default async transport does), preview and
+  continuation travel on the **same** socket as one logical ICAP
+  request: the client sends only the chunked body remainder after
+  the `100 Continue`, no second `RESPMOD` head. The synchronous
+  transport keeps the v2.0 two-request approximation.
+- `ChunkedBodyEncoder` extracted from `RequestFormatter::chunkBody`;
+  reused by both the formatter and the §4.5 continuation path.
+
+### Tests
+- `tests/Transport/AmpConnectionPoolTest.php` — six pool-internals
+  cases driven by `Amp\Socket\createSocketPair`.
+- `tests/PreviewContinueStrictTest.php` — fake-server pair asserts
+  that the connector is invoked **exactly once** for preview +
+  continuation, that phase 1 is a real `RESPMOD` and phase 2 is
+  body-only.
+- Final unit-suite count at v2.1.0: **91 passed, 187 assertions**.
 
 ## [2.0.0] - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.4+, 
 
 The migration guide is [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). The full per-finding closure list is in [`docs/review/consolidated_task-list.md`](docs/review/consolidated_task-list.md).
 
-> Roadmap: **v2.1.0** adds connection pooling in `AsyncAmpTransport` (the framing prerequisite landed in v2.0.0).
+> **v2.1.0** added keep-alive connection pooling and strict RFC 3507 §4.5 preview-continue (preview + continuation on the same socket). See [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Installation
 


### PR DESCRIPTION
## Context

Release-prep for **v2.1.0**. No source code changes — closes the v2.1 documentation cycle.

## CHANGELOG.md

- New `[2.1.0] - 2026-04-25` entry covering both v2.1 PRs (#47 connection pool, #48 strict §4.5 preview-continue), with the new tests called out and the final unit-suite count (**91 passed, 187 assertions**).
- `[Unreleased]` reset to a placeholder.

## README.md

Roadmap blockquote rewritten in past tense for v2.1.

## Verification

- [x] `composer test` — 91 passed, 187 assertions.
- [x] `composer stan` — clean.
- [x] CI matrix.

## Next

After merge:
1. `git tag -a v2.1.0 -m "v2.1.0 — keep-alive pooling + strict RFC 3507 §4.5 preview-continue"` on the merge commit.
2. `git push origin v2.1.0` (Packagist picks it up).