### PR TITLE
docs(claude): add CLAUDE.md, agent skill suite, and PR template

### DIFF
--- a/.claude/skills/icap-flow-php/SKILL.md
+++ b/.claude/skills/icap-flow-php/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: icap-flow-php
+description: Use when working in the ndrstmr/icap-flow library — PHP 8.4/8.5, amphp v3, Pest 3, RFC 3507 ICAP wire format. Activates fail-secure semantics, BC-stable interface design, PHPStan level 9 + bleedingEdge, EUPL-1.2 file headers, SOLID/TDD discipline. Anwenden bei Arbeit an icap-flow — also bei Transport-Code, IcapClient-Facade, Preview-Strategy, ConnectionPool, Wire-Formatter/Parser, RetryingIcapClient, DTOs, OPTIONS-Cache oder dem geplanten Symfony-7.4-Bundle in v2.3.0.
+license: EUPL-1.2
+metadata:
+  author: https://github.com/ndrstmr
+  version: "1.0.0"
+  domain: language
+  triggers: PHP, PHP 8.4, PHP 8.5, ICAP, RFC 3507, amphp, Revolt, Pest, PHPStan, PSR-12, EUPL, fail-secure, RESPMOD, REQMOD, OPTIONS, Preview, Encapsulated, Connection Pool, Symfony 7.4, Bundle, readonly, value object, Fail-Secure, Strategy, Decorator, Facade, ChunkedBodyEncoder, ResponseFrameReader
+  role: specialist
+  scope: implementation
+  output-format: code
+---
+
+# icap-flow PHP Pro
+
+Senior-PHP-Engineer für die `ndrstmr/icap-flow`-Library: state-of-the-art PHP 8.4/8.5, RFC 3507 ICAP-Wire-Format, amphp/Revolt-Async, Fail-Secure-Disziplin und BC-stabile Library-API. Deutsche Kommunikation, englische Identifier und Code-Kommentare — exakt wie der Rest der Codebase.
+
+## Kern-Workflow
+
+1. **Lage prüfen** — Roadmap-Anker ist `docs/review/review_v2-1/consolidated_v2.1_task-list.md`. Vor jeder substanziellen Änderung in `src/`, `tests/`, `examples/cookbook/` oder `.github/workflows/` dort den passenden Eintrag suchen (Milestone v2.1.1 / v2.1.2 / v2.2.0 / v3.0.0). Steht das Vorhaben dort nicht, mit dem User abklären, bevor Code wandert.
+2. **Test zuerst** — Bei jeder Verhaltensänderung erst Pest-Test schreiben, der heute rot ist (Wire/Transport/Security/Integration je nach Schicht). Erst dann Implementierung.
+3. **Designen** — Fail-Secure-Semantik in `IcapClient::interpretResponse()` halten. Public-API-Signaturen sind v2-BC-stabil; BC-Breaks gehen in den v3.0.0-Bucket der Task-Liste, nicht in einen Patch- oder Minor-Release.
+4. **Implementieren** — `final class`, `final readonly class` für DTOs, `declare(strict_types=1)`, `#[\Override]` auf jeder Interface-Implementierung. Header-/URI-Eingaben am Boundary validieren (`validateServicePath`, `validateIcapHeaders`). Keine Bodys puffern — Streaming via `RequestFormatter::format(): iterable<string>` und `ChunkedBodyEncoder`.
+5. **Verifizieren** — Vor Übergabe alle vier Gates clean:
+   ```bash
+   composer cs-check                 # PSR-12 + EUPL-Header (php-cs-fixer dry-run)
+   composer stan                     # PHPStan Level 9 + bleedingEdge — null Fehler, keine Baseline
+   composer test                     # Pest Unit-Suite grün
+   composer test:integration         # nur wenn Docker-ICAP läuft; sonst self-skip
+   ```
+   Mutation-Tests (`composer mutation`) auf neuen Code-Hotspots laufen lassen, sobald die Suite grün ist.
+
+## Wann welche Reference
+
+| Thema | Referenz | Laden, wenn … |
+|---|---|---|
+| PHP 8.4 / 8.5 Features | `references/modern-php-features.md` | readonly classes, enums, property hooks, asymmetric visibility, never type, attributes anstehen |
+| SOLID, TDD & Architektur-Patterns | `references/architecture-patterns.md` | Strategy / Decorator / Facade / Factory / Pool / DI in dieser Codebase angefasst werden |
+| amphp v3 / Revolt / Async | `references/async-amphp.md` | `Future<T>`, `Cancellation`, `\Amp\async()`, Sockets, Sessions oder Connection-Pool berührt werden |
+| icap-flow-spezifische Invarianten | `references/icap-flow-patterns.md` | Fail-Secure, Wire-Format, Preview-§4.5, Header-/URI-Validation, Pool-Key-TLS, OPTIONS-Cache |
+| Pest 3, Mockery, PHPStan, Mutation | `references/testing-pest.md` | Tests, Mocks, Coverage-Hotspots, PHPStan-Level-9-Hürden anstehen |
+| Symfony 7.4 Bundle (v2.3.0-Vorbereitung) | `references/symfony-bundle.md` | DI / Configuration-Tree / Profiler / Console-Commands für das geplante `ndrstmr/icap-flow-bundle`-Repo entworfen werden |
+
+## Constraints
+
+### MUSS
+- `declare(strict_types=1)` in jeder PHP-Datei.
+- EUPL-1.2-Dateiheader als Klassen-Docblock direkt nach `<?php` — `composer cs-fix` setzt ihn aus `.php-cs-fixer.dist.php` neu.
+- `final class` auf allen Klassen in `src/` (Library-Code, kein versehentliches Erben).
+- `final readonly class` auf jedem DTO / Value Object (`Config`, `IcapRequest`, `IcapResponse`, `HttpRequest`, `HttpResponse`, `ScanResult`, `PreviewDecision`-Wrapper).
+- `#[\Override]` auf jeder Interface-Implementierung — PHPStan flagt fehlende Annotation.
+- Vollständige Type-Hints auf Properties, Parametern, Return-Types; PHPDoc nur für Generic-Constraints (`list<string>`, `array<string, string[]>`).
+- PHPStan Level 9 + bleedingEdge ohne Baseline. Fehler werden gefixt, nicht ignoriert.
+- PSR-12 via `composer cs-fix`. Kein Hand-Format.
+- Fail-Secure-Statuscode-Auswertung **ausschließlich** in `IcapClient::interpretResponse()`. Externe Aufrufer rufen `request()` / `scanFile*()`, niemals direkt `executeRaw()`.
+- Header- und URI-Eingaben durch `validateServicePath()` und `validateIcapHeaders()` schicken, bevor irgendein Byte das Socket erreicht.
+- Library-verwaltete Header (`Encapsulated`, `Host`, `Connection`, `Preview`, `Allow`) gewinnen in `mergeHeaders()` immer — Caller-Werte werden nicht durchgelassen.
+- BC-Promise: Public-API von `IcapClient`, `SynchronousIcapClient`, `Config`, `IcapClientInterface`, `TransportInterface`, `PreviewStrategyInterface`, `OptionsCacheInterface`, `ConnectionPoolInterface` und alle Exception-Klassen sind v2-stabil. BC-Breaks gehen in den v3.0.0-Bucket.
+
+### DARF NICHT
+- `mixed` ohne `@var`/`@param`-Eingrenzung in PHPDoc.
+- `@phpstan-ignore`, Baseline-Einträge oder `assert()`-Workarounds, um PHPStan-Findings stillzulegen — Root-Cause fixen.
+- Encapsulated-Bodies in einen einzigen String puffern. `RequestFormatter::format()` liefert ein iterierbares Chunk-Array; das ist kein Implementations-Detail.
+- Stille Fallbacks in `interpretResponse()` für unbekannte Statuscodes — alles, was nicht 204 / 200 / 206 ohne Virus-Header ist, wirft eine typisierte Exception.
+- Einen Socket nach Framing-Fehler oder Exception in den Pool zurückgeben. `AsyncAmpTransport` schließt ihn dann hart.
+- Generische `\RuntimeException` in den Hot-Path. Stattdessen `IcapConnectionException`, `IcapTimeoutException`, `IcapProtocolException`, `IcapMalformedResponseException`, `IcapClientException` (4xx), `IcapServerException` (5xx), `IcapResponseException` (Fallback). Alle implementieren `IcapExceptionInterface`.
+- Neue Codepfade in v1-Compat-Layern. v1 ist deprecated.
+- Symfony-Komponenten in `src/`. Optional bleibt `psr/log`. Symfony-7.4-Integration kommt erst in v2.3.0 als separates Repo `ndrstmr/icap-flow-bundle`.
+
+## Output-Reihenfolge bei Feature-Implementierung
+
+1. Pest-Test (rot) in der passenden Suite (`Wire/`, `Transport/`, `Security/`, ggf. `Integration/`).
+2. Interface, falls neu (z. B. `OptionsCacheInterface`-Erweiterung um ISTag).
+3. DTO / Value Object (`final readonly class`).
+4. Implementierungsklasse mit `#[\Override]`.
+5. Exception-Subtyp, falls neu — immer Sub von `IcapExceptionInterface`-Implementierung.
+6. Eintrag in `CHANGELOG.md` (Unreleased-Block, Keep-a-Changelog-Format).
+7. Wenn das Item aus der v2.1-Task-Liste kam: kurzer Verweis auf Tabellenzeile + Reviewer-Quelle in der Commit-Message.
+
+## Wissens-Stack
+
+- **Sprache:** PHP 8.4 (Min) / 8.5 (CI). Property Hooks, Asymmetric Visibility, `never`, DNF-Types, First-Class-Callables, Match-Expressions, Enums-mit-Methoden, Readonly-Klassen, `\Override`.
+- **Async:** amphp v3 (`amphp/socket`), Revolt EventLoop, `Amp\Future`, `Amp\Cancellation`, `Amp\CompositeCancellation`, `Amp\TimeoutCancellation`. Fibers indirekt via amphp.
+- **Wire:** RFC 3507 (ICAP), RFC 7230 §4.1 (Chunked Transfer), TLS 1.2/1.3 via `Amp\Socket\ClientTlsContext`. Wire-Tests rechnen Byte-Streams von Hand vor — keine Mock-Shortcuts.
+- **Tests:** Pest 3 (PHPUnit 11 darunter), Mockery (Intersection-Type-Hints `Foo&\Mockery\MockInterface`), `pestphp/pest --mutate`.
+- **Quality:** PHPStan 2 Level 9 + bleedingEdge, PHP-CS-Fixer 3 mit eigenem `@PSR12`-Setup + EUPL-Header, `composer audit` + `roave/security-advisories`.
+- **Logging:** PSR-3 (`Psr\Log\LoggerInterface`), strukturierte Log-Events mit `method`, `uri`, `host`, `port`, `statusCode`, `infected`.
+- **Vendoring:** c-icap, ClamAV (Referenz-Server), Symantec, Trend Micro, McAfee Web Gateway, Sophos, Kaspersky (Header-Liste in `Config::withVirusFoundHeaders()`).
+- **Lizenz:** EUPL-1.2 (OpenCoDE-kompatibel).

--- a/.claude/skills/icap-flow-php/references/architecture-patterns.md
+++ b/.claude/skills/icap-flow-php/references/architecture-patterns.md
@@ -1,0 +1,194 @@
+# Architektur-Patterns & SOLID/TDD — icap-flow
+
+icap-flow ist eine Library, kein Framework. Die Architektur folgt strikt SOLID, ist test-getrieben und nutzt eine kleine, scharf geschnittene Menge an Design-Patterns. Diese Datei zeigt, **wie** sie eingesetzt werden — am konkreten Code, nicht an Lehrbuch-Beispielen.
+
+## SOLID, kompakt am icap-flow-Code
+
+### Single Responsibility
+Jede Klasse hat genau eine Aufgabe — daran erkennt man die Schichtung im Repo:
+
+| Klasse | Verantwortung |
+|---|---|
+| `RequestFormatter` | bytes-out: `IcapRequest` → iterable<string> RFC-3507-Wire |
+| `ResponseParser` | bytes-in: `string` → `IcapResponse`, mit DoS-Limits |
+| `ChunkedBodyEncoder` | RFC-7230-Chunked-Encoding einer einzelnen Body-Quelle |
+| `TransportInterface` | Socket-I/O, kein Protokollwissen |
+| `AmpConnectionPool` | Keep-Alive-Sockets pro `host:port[:tls]`-Key |
+| `PreviewStrategyInterface` | Entscheidung „weitermachen / abbrechen" nach Preview |
+| `IcapClient` | Orchestrierung; Fail-Secure-Statuscode-Auswertung |
+| `RetryingIcapClient` | Decorator: Backoff-Retry für 5xx |
+
+Wenn eine neue Aufgabe nicht in eine der bestehenden Klassen fällt, **mach eine neue** — kein Erweitern bestehender Klassen "weil die Datei schon offen war".
+
+### Open/Closed
+Erweiterung läuft über Interfaces, nicht Subklassen:
+
+- Neuer Vendor-Header? `Config::withVirusFoundHeaders([...])`, kein Subclass-`IcapClient`.
+- Vendor-spezifische Preview-Interpretation? Eigene `PreviewStrategyInterface`-Impl, in den Konstruktor des `IcapClient` reichen.
+- Anderes Caching-Backend? Eigene `OptionsCacheInterface`-Impl (PSR-16-Adapter ist auf der v2.2-Roadmap).
+- Anderes Pool-Backend? `ConnectionPoolInterface`-Impl. `NullConnectionPool` ist das v2.2-Item, das diesen Slot offiziell macht.
+
+### Liskov Substitution
+Alle `TransportInterface`-Implementierungen müssen denselben Wire-Vertrag erfüllen — was `AsyncAmpTransport` zurückgibt, muss byte-identisch `SynchronousStreamTransport` zurückgeben können (gleicher Server vorausgesetzt). Tests in `tests/Transport/TransportInterfaceTest.php` prüfen genau das.
+
+### Interface Segregation
+Beispiel: `SessionAwareTransport` ist ein zusätzliches Interface neben `TransportInterface`, nicht eine Methode, die jede Impl erfüllen müsste. Der Synchronous-Transport implementiert nur `TransportInterface` — er kann keine Sessions, also gibt's auch keinen No-Op-Stub. `IcapClient::scanFileWithPreview()` prüft `instanceof SessionAwareTransport` und wählt den Pfad.
+
+```php
+if ($this->transport instanceof SessionAwareTransport) {
+    return $this->scanFileWithPreviewStrict(...);
+}
+return $this->scanFileWithPreviewLegacy(...);
+```
+
+### Dependency Inversion
+`IcapClient` hängt **ausschließlich** an Interfaces:
+
+```php
+public function __construct(
+    private Config $config,
+    private TransportInterface $transport,
+    private RequestFormatterInterface $formatter,
+    private ResponseParserInterface $parser,
+    ?PreviewStrategyInterface $previewStrategy = null,
+    ?LoggerInterface $logger = null,
+    private ?OptionsCacheInterface $optionsCache = null,
+) { ... }
+```
+
+Die `static create()` / `static forServer()` Factories verdrahten konkrete Defaults — Konsumenten ohne DI-Container haben so einen einfachen Einstieg. Neue Konsumenten, die Tuning brauchen, instanziieren `IcapClient` direkt.
+
+## TDD-Workflow in dieser Repo
+
+1. **Test schreiben**, der heute fehlschlägt — in der passenden Suite:
+   - `tests/Wire/` für RFC-3507-Byte-Format-Änderungen.
+   - `tests/Transport/` für Socket-/Pool-Verhalten.
+   - `tests/Security/` für Fail-Secure-, DoS- und Validator-Invarianten.
+   - `tests/Integration/` für End-to-End-Smoke gegen echten ICAP-Server (env-gated).
+   - Restliche Behavior-Tests bleiben in `tests/` Top-Level (`IcapClientTest.php`, `RetryingIcapClientTest.php`, …).
+2. **Implementieren**, bis der Test grün ist — minimal, ohne Speculative Generality.
+3. **Refactor mit Sicherheitsnetz** (alle vier Gates: `composer cs-check && composer stan && composer test && composer test:integration` falls Docker da ist).
+4. **Mutation-Test auf neuen Hotspots** (`composer mutation`, `--min=65`). Wenn Mutation-Score unter Schwelle: schwacher Test, nicht "PHP-Quirk" — Test verschärfen.
+
+Wire-Tests rechnen Byte-Streams **per Hand** vor. Beispiel-Muster aus `tests/Wire/RequestFormatterWireTest.php`:
+
+```php
+function wire(iterable $chunks): string
+{
+    $s = '';
+    foreach ($chunks as $c) {
+        $s .= $c;
+    }
+    return $s;
+}
+
+it('emits RFC 3507 §4.4.1 Encapsulated offsets for RESPMOD with body', function () {
+    $request = new IcapRequest(/* ... */);
+    $bytes = wire((new RequestFormatter())->format($request));
+
+    expect($bytes)->toContain("Encapsulated: res-hdr=0, res-body=");
+    expect($bytes)->toEndWith("0\r\n\r\n");
+});
+```
+
+Nie `Mockery` für die Wire-Tests verwenden — die ganze Idee ist, dass **echte** Bytes aus dem **echten** Formatter kommen.
+
+## Eingesetzte Patterns — und wo sie liegen
+
+### Strategy
+- `PreviewStrategyInterface` → `DefaultPreviewStrategy` (+ Cookbook 02 zeigt Vendor-Custom-Strategie).
+- v2.1.1-Hotfix erweitert die Default-Strategie um den 200/206-Branch (Virus-Header → `ABORT_INFECTED`).
+
+### Decorator
+- `RetryingIcapClient` wickelt einen `IcapClientInterface` und retried 5xx mit Exponential-Backoff.
+- Geplant für v2.2: `OtelTracingIcapClient` als weiterer Decorator (OpenTelemetry-Spans). **Niemals** den Retry- oder Tracing-Code in `IcapClient` selbst einbauen — das wäre eine SRP-Verletzung.
+
+```php
+final class RetryingIcapClient implements IcapClientInterface
+{
+    public function __construct(
+        private IcapClientInterface $inner,
+        private int $maxRetries = 3,
+        private float $baseDelaySeconds = 0.5,
+    ) {
+    }
+
+    #[\Override]
+    public function request(IcapRequest $request, ?Cancellation $cancellation = null): Future
+    {
+        return \Amp\async(function () use ($request, $cancellation): ScanResult {
+            $attempt = 0;
+            while (true) {
+                try {
+                    return $this->inner->request($request, $cancellation)->await();
+                } catch (IcapServerException $e) {
+                    if (++$attempt > $this->maxRetries) {
+                        throw $e;
+                    }
+                    delay($this->baseDelaySeconds * (2 ** ($attempt - 1)));
+                }
+            }
+        });
+    }
+}
+```
+
+Decorator-Regel: **gleiches Interface, kein erweitertes Interface**. Wer `RetryingIcapClient` einsetzt, muss kein Wissen über das Wrapping haben.
+
+### Facade
+- `SynchronousIcapClient` ist eine Facade auf `IcapClient`, die `await()` aufruft und Framework-lose Aufrufer von Revolt-EventLoop abschirmt.
+- `IcapClient` selbst ist Facade für die vier Worker-Klassen `RequestFormatter`, `ResponseParser`, `TransportInterface`, `PreviewStrategyInterface`.
+
+### Factory
+- `IcapClient::create()`, `IcapClient::forServer($host, $port = 1344)`, `SynchronousIcapClient::create()` — Convenience-Factories mit Default-Verdrahtung.
+- Geplante v2.3.0-Bundle nutzt eine echte `IcapClientFactory` (siehe `references/symfony-bundle.md`).
+
+### Session-Object
+- `TransportSession` (Interface) + `AmpTransportSession` (Impl) für Strict-§4.5-Preview-Continue.
+- Lifecycle: `openSession()` → `write()` → `readResponse()` → entweder `release()` (zurück in den Pool) oder `close()` (hartes Schließen bei Fehler).
+
+### Object-Pool
+- `AmpConnectionPool` mit LIFO-Stack pro `host:port[:tls]`-Key.
+- Pool-Key-Bug ist **v2.1.1 P0**: heute fehlt der TLS-Context-Fingerprint, deshalb können sich Multi-Tenant-TLS-Configs gegenseitig den Socket klauen. Fix in `src/Transport/AmpConnectionPool.php:130-133` + Cross-TLS-Test.
+- Geplant v2.2: `maxIdleAge` (Default 30 s) und Eviction-Sweep.
+
+### Null-Object
+- v2.2-Item: `NullConnectionPool` als expliziter Opt-Out. Heute reicht `null` — das soll explizit werden, wenn das Bundle-Repo den Slot in DI-Configs braucht.
+
+## Anti-Patterns, die hier nicht reinkommen
+
+- **Service-Locator** — keine globale Registry. Alles per Constructor-DI.
+- **Static State** in `src/` — auch nicht für Caches. `OptionsCacheInterface` ist ein Konstruktor-Argument.
+- **Template-Method-Subclassing** — wir haben keine Abstract-Base-Klassen. Alles ist `final`.
+- **God-Objects** — `IcapClient` ist 638 Zeilen, ist aber Orchestrator. Wenn er größer als ~700 Zeilen wird, ein neues Helper-Object extrahieren (z. B. `PreviewExchange` für die Strict-§4.5-Logik).
+- **Mutable DTOs** — `Config::withFoo()` muss eine neue Instanz liefern, nicht `$this` mutieren.
+- **Exception-Mapping in der Mitte** — Exceptions werden dort geworfen, wo der semantische Kontext liegt (Wire-Layer wirft `IcapMalformedResponseException`, Transport-Layer `IcapConnectionException`). `IcapClient` mappt nur Statuscodes, nichts anderes.
+
+## BC-Stabilität
+
+Public-API-Liste, die v2-stabil ist und **bis v3.0.0** nicht angefasst wird:
+
+- `IcapClientInterface`
+- `IcapClient`-Public-Methoden inklusive `executeRaw()` (v3-Item: `protected` oder ins Interface heben)
+- `SynchronousIcapClient`
+- `Config` und ihre `with*()`-Methoden
+- `TransportInterface`, `SessionAwareTransport`, `TransportSession`
+- `PreviewStrategyInterface`, `PreviewDecision`
+- `RequestFormatterInterface`, `ResponseParserInterface`
+- `OptionsCacheInterface`, `ConnectionPoolInterface`
+- Alle Exception-Klassen unter `Ndrstmr\Icap\Exception\` plus `IcapExceptionInterface`
+- Alle DTOs unter `Ndrstmr\Icap\DTO\`
+
+| Aktion | Erlaubt? |
+|---|---|
+| Neue Klasse in `src/` ergänzen | ✅ |
+| Neuer optionaler Konstruktor-Param ans Ende einer `final`-Klasse | ✅ (Caller geben Named Args) |
+| Neue Methode in einem **konkreten** `final class` (nicht im Interface) | ✅ |
+| Neue Methode in einem `Interface` | ❌ Breaking |
+| Neuer optionaler Param in einer Interface-Methode | ❌ Breaking |
+| Exception-Message-Text ändern | ✅ |
+| Geworfene Exception-Klasse ändern | ❌ Breaking |
+| Public-Method entfernen | ❌ Breaking |
+| Return-Type spezialisieren | ❌ Breaking |
+
+Alle ❌-Items kommen in den **v3.0.0-Bucket der `consolidated_v2.1_task-list.md`**. Trigger v3.0.0 ist explizit: erst wenn mindestens zwei der drei dort gelisteten BC-Breaks durch User-Feedback erzwungen werden.

--- a/.claude/skills/icap-flow-php/references/async-amphp.md
+++ b/.claude/skills/icap-flow-php/references/async-amphp.md
@@ -1,0 +1,203 @@
+# Async — amphp v3 / Revolt — icap-flow
+
+icap-flow nutzt **amphp v3** (`amphp/socket: ^2.3`) und **Revolt EventLoop**. Symfony HttpClient kommt **nicht** zum Einsatz — der Vergleichscode aus dem Lotse-Workspace gilt hier ausdrücklich nicht. Diese Datei erklärt die Patterns, die in `src/` aktiv sind.
+
+## Mental-Model
+
+- `Amp\Future<T>` ist das Promise-Äquivalent — `await()` blockiert die aktuelle Fiber, bis der Wert da ist.
+- `\Amp\async(fn (): T => ...)` startet eine neue Fiber und gibt ein `Future<T>` zurück. So entstehen alle public-async-Methoden im `IcapClient`.
+- `Amp\Cancellation` ist der zentrale Abbruch-Mechanismus. Jede public Methode des `IcapClient` nimmt ein optionales `?Cancellation` als letzten Parameter — Patches müssen dieses Muster halten.
+- `CompositeCancellation` kombiniert User-Cancellation und Library-internes `TimeoutCancellation`; was zuerst feuert, gewinnt.
+
+## Standardsignatur einer öffentlichen Async-Methode
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+use Amp\Cancellation;
+use Amp\Future;
+
+#[\Override]
+public function options(string $service, ?Cancellation $cancellation = null): Future
+{
+    /** @var Future<ScanResult> $future */
+    $future = \Amp\async(function () use ($service, $cancellation): ScanResult {
+        // ... Orchestrierung, await(), interpretResponse()
+        return $result;
+    });
+
+    return $future;
+}
+```
+
+Drei Regeln, die bei jeder neuen Async-Methode greifen:
+1. **Return-Type-Annotation `Future<X>` per PHPDoc**, da PHP keine generischen Native-Types kennt — PHPStan Level 9 mahnt sonst.
+2. **Logging-Sandwich**: `info` beim Start, `warning` im `catch`, `info` beim Erfolg. Keys `method`, `uri`, `host`, `port`, `statusCode`, `infected`. Vorbild: `IcapClient::request()` Z. 100-134.
+3. **Try/Finally für Resource-Lifecycle** — Streams schließen, Sessions zurückgeben (`release()`) oder hart schließen (`close()`).
+
+## Cancellation richtig durchreichen
+
+`Cancellation` reicht **immer** bis zum Socket runter. Niemals abschneiden, weil die Methode "nur kurz" ist.
+
+```php
+public function executeRaw(IcapRequest $request, ?Cancellation $cancellation = null): Future
+{
+    /** @var Future<IcapResponse> $future */
+    $future = \Amp\async(function () use ($request, $cancellation): IcapResponse {
+        $chunks         = $this->formatter->format($request);
+        $responseString = $this->transport->request($this->config, $chunks, $cancellation)->await();
+
+        return $this->parser->parse($responseString);
+    });
+
+    return $future;
+}
+```
+
+In `AsyncAmpTransport::openSession()` werden User-Cancellation und `TimeoutCancellation` zu einem `CompositeCancellation` verschmolzen — das ist die Stelle, an der Library-Timeout und User-Abbruch zusammenfließen:
+
+```php
+$timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
+$effective = $cancellation === null
+    ? $timeoutCancellation
+    : new CompositeCancellation($cancellation, $timeoutCancellation);
+
+$socket = $this->acquireSocket($config, $effective);
+```
+
+**v2.2-Caveat (Item #19):** Im Strict-§4.5-Pfad ist dieses Timeout heute Session-Lifetime, nicht Per-IO. Beim Touch dieser Stelle entweder Per-IO-Reset einbauen **oder** den Caveat in der PHPDoc dokumentieren.
+
+## Sessions — Strict-§4.5-Preview-Continue
+
+`SessionAwareTransport` ist die Voraussetzung dafür, dass Preview und Continuation auf demselben Socket leben. Lebenszyklus einer Session:
+
+```php
+$session = $this->transport->openSession($this->config, $cancellation);
+try {
+    $session->write($this->formatter->format($previewRequest));
+    $previewIcapResponse = $this->parser->parse($session->readResponse());
+
+    if ($previewIsComplete) {
+        $session->release();   // sauber zurück in den Pool
+        return $this->interpretResponse($previewIcapResponse, $this->config);
+    }
+
+    $decision = $this->previewStrategy->handlePreviewResponse($previewIcapResponse);
+
+    if ($decision !== PreviewDecision::CONTINUE_SENDING) {
+        $session->release();   // 100/204-Pfad: Socket protokoll-sauber
+        return new ScanResult(
+            isInfected: $decision === PreviewDecision::ABORT_INFECTED,
+            virusName: /* ... */,
+            originalResponse: $previewIcapResponse,
+        );
+    }
+
+    // §4.5 continuation: NUR die Chunked-Body-Reste, kein neuer ICAP-Head.
+    $session->write((new ChunkedBodyEncoder())->encode($remainder));
+
+    $finalIcapResponse = $this->parser->parse($session->readResponse());
+    $session->release();
+    return $this->interpretResponse($finalIcapResponse, $this->config);
+} catch (\Throwable $e) {
+    $session->close();   // off-script — Socket darf NIE in den Pool
+    throw $e;
+}
+```
+
+Faustregeln:
+- `release()` nur, wenn der Austausch protokoll-sauber war **und** der Server kein `Connection: close` gesendet hat.
+- Jeder `\Throwable`-Pfad endet in `close()`. Ein halb gesprochener Socket darf den nächsten Pool-User nicht sehen.
+
+## Streaming, kein Buffering
+
+`RequestFormatter::format(): iterable<string>` liefert drei Phasen:
+1. ICAP-Head + Encapsulated-Offsets
+2. encapsulated HTTP-Header-Block
+3. Chunked-Body (HTTP/1.1) inkl. Terminator (`0\r\n\r\n` regulär, `0; ieof\r\n\r\n` bei Preview-Complete).
+
+Niemals den Body in einen einzigen String puffern. Das `scanFile()`-Beispiel reicht den `fopen($path, 'rb')`-Stream als `body` in den `HttpResponse` und lässt den Encoder daraus Chunks ziehen.
+
+**v2.1.2-Bug (Item #7):** Die heutige Strict-§4.5-Continuation in `IcapClient.php:399` macht `stream_get_contents($stream)` und puffert dadurch die Datei nach Preview komplett in RAM. Fix: `ChunkedBodyEncoder::encodeRemainderFromStream($stream)` ergänzen und den `stream_get_contents`-Call ersetzen. Memory-Watermark-Test (2-GB-Stream unter `php -d memory_limit=128M`) gehört in den gleichen PR.
+
+## TLS — `icaps://`
+
+`Config::withTlsContext(new ClientTlsContext($host))` schaltet auf TLS um. `AsyncAmpTransport` ruft dann `Socket\connectTls()` statt `Socket\connect()`:
+
+```php
+$context = (new ConnectContext())->withConnectTimeout($config->getSocketTimeout());
+if ($tls !== null) {
+    $context = $context->withTlsContext($tls);
+    return Socket\connectTls($url, $context, $cancellation);
+}
+return Socket\connect($url, $context, $cancellation);
+```
+
+**v2.1.1-Bug (Item #2):** Der Pool-Key in `AmpConnectionPool::key()` enthält **nicht** den TLS-Context. Multi-Tenant mit unterschiedlichen Cert-Chains teilen sich heute den Stack — das ist eine Cross-Tenant-Leakage. Übergangs-Fix: `spl_object_hash($tls)` als Suffix; deterministischer Hash kommt v2.2.
+
+## Connection-Pool
+
+```php
+final class AmpConnectionPool implements ConnectionPoolInterface
+{
+    /** @var array<string, list<SocketInterface>> */
+    private array $idle = [];
+
+    public function acquire(Config $config, Cancellation $cancellation): SocketInterface { /* ... */ }
+
+    public function release(Config $config, SocketInterface $socket): void { /* ... */ }
+}
+```
+
+Verhalten heute:
+- LIFO pro Key (warmer Socket zuerst).
+- `acquire()` verwirft offline-Sockets und macht ggf. einen frischen.
+- `release()` schließt den Socket, wenn die Per-Host-Cap erreicht ist.
+
+v2.2-Erweiterungen, die auf der Roadmap stehen:
+- TLS-Fingerprint im Key (Hotfix in v2.1.1)
+- `maxIdleAge` (Default 30 s) + Eviction-Sweep
+- `Config::autoTunePoolFromOptions` — `effectiveCap = min(localCap, serverMaxConnections)` aus dem OPTIONS-Header
+
+## Concurrency-Primitiven aus amphp
+
+- `\Amp\async(fn (): T): Future<T>` — neuer Fiber-Job, sofort gestartet.
+- `\Amp\delay(float $seconds, ?Cancellation): void` — Sleep, der Cancellation respektiert. Vorbild: `RetryingIcapClient`-Backoff.
+- `Future::complete($value)` — bereits-gelöstes Future. Sinnvoll für Cache-Hits in `options()`.
+- `Future::await()` — blockiert die aktuelle Fiber bis Resolve.
+- `Amp\async()`-Closures dürfen **nicht** auf `$this->state` schreiben, ohne sich der Fiber-Re-Entrancy bewusst zu sein. In icap-flow sind alle Async-Methoden re-entrant-safe, weil `IcapClient` selbst stateless ist (`$transport`, `$formatter`, `$parser` werden nur gelesen).
+
+## Synchroner Pfad
+
+`SynchronousStreamTransport` nutzt `stream_socket_client` und blockt direkt. `SynchronousIcapClient` ist nur ein `await()`-Wrapper:
+
+```php
+public function scanFile(
+    string $service,
+    string $filePath,
+    array $extraHeaders = [],
+    ?Cancellation $cancellation = null,
+): ScanResult {
+    return $this->asyncClient->scanFile($service, $filePath, $extraHeaders, $cancellation)->await();
+}
+```
+
+Der synchrone Pfad ist **nicht** `SessionAwareTransport`, also fällt `scanFileWithPreview()` dort auf `scanFileWithPreviewLegacy` zurück (zwei TCP-Handshakes, weniger effizient — aber RFC-konform für permissive Server).
+
+## Quick-Reference
+
+| Tool | Use case | Vorkommen in icap-flow |
+|---|---|---|
+| `\Amp\async()` | Public-Async-Methode | `IcapClient::request()`, `options()`, `scanFileWithPreview()` |
+| `Future<T>::await()` | In Fiber blockierend warten | Fast alle async-Methoden |
+| `Cancellation` Param | Externes Abbrechen | Pflicht-Last-Param public-API |
+| `CompositeCancellation` | User + Lib-Timeout kombinieren | `AsyncAmpTransport::openSession()` |
+| `TimeoutCancellation` | Lib-internes Streaming-Timeout | `AsyncAmpTransport`, `Config::getStreamTimeout()` |
+| `SessionAwareTransport` | Multi-IO auf einem Socket | Strict-§4.5-Pfad |
+| `Socket\connect()` / `connectTls()` | Plain / TLS | `AsyncAmpTransport::acquireSocket()` |
+| `\Amp\delay()` | Cancellation-aware Sleep | `RetryingIcapClient`-Backoff |
+| Symfony HttpClient | — | **nicht verwendet** in icap-flow |
+| ReactPHP / Swoole | — | **nicht verwendet** |

--- a/.claude/skills/icap-flow-php/references/icap-flow-patterns.md
+++ b/.claude/skills/icap-flow-php/references/icap-flow-patterns.md
@@ -1,0 +1,240 @@
+# icap-flow-spezifische Invarianten
+
+Die folgenden Regeln sind sicherheitskritisch oder protokoll-blockierend. Wer sie aufweicht, bricht entweder eine Audit-Erkenntnis aus `docs/review/review_v2-1/` oder eine RFC-3507-Vorschrift. Sie sind die Stellen, an denen Reviewer als erstes hinschauen.
+
+## Fail-Secure-Statuscode-Auswertung
+
+**Regel:** Jeder Statuscode, der nicht eindeutig „Clean" bedeutet, wird zu einer typisierten Exception. Niemals stiller Fallback auf „Clean".
+
+Was als Clean zählt:
+- `204 No Content` — explizit „keine Modifikation, kein Befund".
+- `200 OK` / `206 Partial Content` **ohne** Vendor-Virus-Header → Clean. Mit Header → `ScanResult(isInfected=true, virusName=…)`.
+
+Was als Fehler zählt:
+- `100 Continue` außerhalb des Preview-Flows → `IcapProtocolException`. (Finding G der v2-Konsolidierung.)
+- `4xx` → `IcapClientException` mit Status als Code.
+- `5xx` → `IcapServerException` mit Status als Code.
+- Alles andere → `IcapResponseException`.
+
+Die Logik lebt in **einer** Methode: `IcapClient::interpretResponse()`. Der Preview-Flow umgeht sie absichtlich (`executeRaw()`), weil `100 Continue` dort legitim ist — die Interpretation passiert nach dem Preview erneut über `interpretResponse()`.
+
+```php
+// Falsch — stille Klassifikation
+if ($code !== 204 && $code !== 200) {
+    return new ScanResult(false, null, $response);   // ❌ Fail-Open
+}
+
+// Richtig — typisierte Exception
+throw new IcapResponseException('Unexpected ICAP status: ' . $code, $code);
+```
+
+## Preview-Flow — `executeRaw()` ist intern
+
+`executeRaw()` ist heute `public`, weil der Preview-Flow ihn braucht. Externe Aufrufer rufen ihn **nicht** — sie nehmen `request()`, `scanFile()`, `scanFileWithPreview()`, `options()`. v3.0.0 hebt ihn entweder ins Interface oder macht ihn `protected` (Item #34 der v2.1-Liste). Bis dahin: in jedem PR, der `executeRaw()` von außen aufruft, einen Skill-Check auslösen.
+
+## Strict RFC 3507 §4.5 vs. Legacy-Approximation
+
+| Pfad | Wann | Wo |
+|---|---|---|
+| `scanFileWithPreviewStrict` | `transport instanceof SessionAwareTransport` | `IcapClient.php:332-415` |
+| `scanFileWithPreviewLegacy` | sonst (synchroner Transport, Custom-Impl) | `IcapClient.php:426-495` |
+
+Strict-Pfad: Preview + Continuation auf demselben Socket, **ein** logischer ICAP-Request, kein zweiter HTTP-Head. Legacy-Pfad: zwei Requests, Vollkörper im zweiten Request — funktioniert gegen permissive Server, kostet einen TCP/TLS-Handshake.
+
+Die beiden Pfade nicht zusammenlegen. Tests in `tests/PreviewContinueStrictTest.php` (Strict) und `tests/IcapClientTest.php` (Legacy) prüfen sie unabhängig.
+
+## Header- und URI-Injection-Schutz
+
+`validateServicePath()` und `validateIcapHeaders()` rejecten CR/LF/NUL/Steuerzeichen, **bevor** der erste Byte das Socket erreicht. Findings H der v2-Konsolidierung.
+
+```php
+private function validateServicePath(string $service): void
+{
+    if (preg_match('/[\x00-\x20\x7F]/', $service) === 1) {
+        throw new \InvalidArgumentException(
+            'Service path contains control characters, whitespace or NUL: '
+            . var_export($service, true),
+        );
+    }
+}
+
+private function validateIcapHeaders(array $headers): void
+{
+    foreach ($headers as $name => $value) {
+        if (preg_match('/[\x00-\x1F\x7F:]/', $name) === 1) {
+            throw new \InvalidArgumentException(
+                'ICAP header name contains control characters or separator: '
+                . var_export($name, true),
+            );
+        }
+        foreach ((array) $value as $v) {
+            if (preg_match('/[\x00\r\n]/', $v) === 1) {
+                throw new \InvalidArgumentException(
+                    sprintf('ICAP header %s carries CR/LF/NUL.', $name),
+                );
+            }
+        }
+    }
+}
+```
+
+**Korrektur zu Jules' Befund:** Das `foreach ((array) $value as $v)` iteriert pro Array-Element. Jules' Behauptung, dass Array-Werte umgangen werden, ist faktisch falsch — **nicht** in den Plan aufnehmen.
+
+**v2.2-Item (#22):** Header-Namen strenger gegen RFC-7230-§3.2.6-Token-Set prüfen. Nice-to-have, nicht sicherheitsblockierend.
+
+## Header-Merge — Library gewinnt immer
+
+`mergeHeaders($caller, $managed)` schreibt zuerst Caller-Werte, dann Library-Werte. Library-Header können nicht überschrieben werden:
+
+- `Encapsulated` — wird vom Formatter gerechnet.
+- `Host` — wird aus `Config::host:port` gesetzt.
+- `Connection` — Library steuert Keep-Alive.
+- Im Preview-Flow zusätzlich: `Preview`, `Allow`.
+
+Wer einen `extraHeaders`-Param mit `Encapsulated` ankommt, sieht seinen Wert nicht im Wire — das ist **gewollt**.
+
+## DoS-Limits
+
+Drei Konfigurationswerte in `Config`, durchgesetzt von `ResponseParser` und `AsyncAmpTransport`:
+
+- `maxResponseSize` (Default 10 MiB) — Gesamt-Bytes pro ICAP-Response.
+- `maxHeaderCount` (Default 100) — Anzahl Header-Lines.
+- `maxHeaderLineLength` (Default 8192) — Bytes pro Line.
+
+Wer den `ResponseParser` per Hand instanziiert, übergibt die Limits **aus derselben Config**, die der Transport sieht — sonst hängen Transport- und Parser-Limits auseinander:
+
+```php
+$parser = new ResponseParser(
+    maxHeaderCount: $config->getMaxHeaderCount(),
+    maxHeaderLineLength: $config->getMaxHeaderLineLength(),
+);
+```
+
+Tests in `tests/Security/ParserDosLimitsTest.php` prüfen die Grenzen.
+
+## Vendor-Virus-Header — geordnete Liste
+
+`Config::getVirusFoundHeaders()` liefert `list<string>`, `IcapClient::extractVirusName()` liefert den ersten in der Response vorhandenen. Default ist `['X-Virus-Name']` für Back-Compat; Production wird typisch auf
+
+```php
+$config->withVirusFoundHeaders([
+    'X-Virus-Name',          // ClamAV / c-icap
+    'X-Infection-Found',     // ISS Proventia
+    'X-Violations-Found',    // Trend Micro
+    'X-Virus-ID',            // Symantec
+]);
+```
+
+konfiguriert. Neue Vendor-Header **immer** in die Liste, **nicht** als Sonderfall in `extractVirusName()`.
+
+## Connection-Pool — Pool-Key (v2.1.1 P0)
+
+Heute (verbuggt):
+```php
+private function key(Config $config): string
+{
+    return $config->host . ':' . $config->port;
+}
+```
+
+Multi-Tenant mit verschiedenen TLS-Configs teilen sich denselben Stack — das ist Cross-Tenant-Leakage. Übergangs-Fix für v2.1.1:
+```php
+private function key(Config $config): string
+{
+    $key = $config->host . ':' . $config->port;
+    $tls = $config->getTlsContext();
+    if ($tls !== null) {
+        $key .= ':' . spl_object_hash($tls);
+    }
+    return $key;
+}
+```
+
+`spl_object_hash` ist ein bewusster Übergang — `AmpConnectionPool` muss in v2.2 auf einen deterministischen Hash umsteigen (Cert-PEM oder Konfigfingerprint). Der Cross-TLS-Isolations-Test in `tests/Transport/AmpConnectionPoolTest.php` muss **vor** dem Fix rot, **nach** dem Fix grün sein.
+
+## Socket-Disposal nach Austausch
+
+```php
+try {
+    $session->write($rawRequest);
+    $response = $session->readResponse();
+
+    if ($this->serverWantsClose($response)) {
+        $closeForced = true;
+    }
+
+    return $response;
+} catch (\Throwable $e) {
+    $closeForced = true;
+    throw $e;
+} finally {
+    if ($closeForced) {
+        $session->close();
+    } else {
+        $session->release();
+    }
+}
+```
+
+Auslöser für hartes `close()`:
+- `Connection: close` im ICAP-Head.
+- Beliebige `\Throwable` während `write()` oder `readResponse()`.
+- Framing-Fehler (`ResponseFrameReader` wirft).
+
+Alles andere → `release()` — der Socket geht zurück in den Pool.
+
+## OPTIONS-Cache
+
+`OptionsCacheInterface` lebt in `src/Cache/`, Default-Impl ist `InMemoryOptionsCache`. TTL kommt aus dem `Options-TTL`-Header (`RFC 3507 §4.10.2`); fehlt der Header, kein Caching:
+
+```php
+$ttl = (int) ($response->headers['Options-TTL'][0] ?? '0');
+$this->optionsCache->set($cacheKey, $response, $ttl);
+```
+
+v2.2-Erweiterungen aus der Task-Liste:
+- ISTag-Invalidation (`OptionsCacheInterface::set(?string $istag = null)`) — Item #12.
+- PSR-20 `ClockInterface` für deterministische TTL-Tests — Item #13.
+- PSR-6/PSR-16-Adapter als Optional-Deps — Item #15.
+
+## DefaultPreviewStrategy — der 200/206-Branch (v2.1.1 P0)
+
+Heute:
+```php
+return match ($previewResponse->statusCode) {
+    204     => PreviewDecision::ABORT_CLEAN,
+    100     => PreviewDecision::CONTINUE_SENDING,
+    default => throw new IcapResponseException('Unexpected preview status code: ' . $previewResponse->statusCode),
+};
+```
+
+Problem: c-icap antwortet auf einen Eicar-Treffer im Preview mit `200 OK + X-Virus-Name` statt erst `100 Continue` zu geben. Heute fliegt das als uncatchable `IcapResponseException` raus, statt als `ScanResult(isInfected=true)`. Der `ABORT_INFECTED`-Branch in `IcapClient.php:388` ist deshalb toter Code.
+
+Fix für v2.1.1 (Item #3):
+```php
+return match (true) {
+    $previewResponse->statusCode === 204 => PreviewDecision::ABORT_CLEAN,
+    $previewResponse->statusCode === 100 => PreviewDecision::CONTINUE_SENDING,
+    $previewResponse->statusCode === 200 || $previewResponse->statusCode === 206
+        => $this->classifyPossiblyInfected($previewResponse),
+    default => throw new IcapResponseException(
+        'Unexpected preview status code: ' . $previewResponse->statusCode,
+    ),
+};
+```
+
+`classifyPossiblyInfected()` schaut die `Config::getVirusFoundHeaders()`-Liste durch — Hit → `ABORT_INFECTED`, sonst `ABORT_CLEAN`. Damit das funktioniert, braucht die Strategy einen Verweis auf `Config` (oder die Headerliste wird in den Konstruktor reingereicht — letzteres ist BC-freundlicher, weil es das `PreviewStrategyInterface` nicht ändert).
+
+## Encapsulated-Aware Response-Framing
+
+`ResponseFrameReader` erkennt das Ende einer Response anhand des `Encapsulated`-Headers, **nicht** anhand `Connection: close`. Damit funktioniert Keep-Alive auch gegen Server, die den Socket weiter offen halten.
+
+**v2.2-Item (#21):** obs-fold (RFC 7230 — Header über mehrere Zeilen mit Whitespace-Continuation) wird im Encapsulated-Header derzeit nicht beachtet. Wer den Frame-Reader anfasst, sollte auch das mitnehmen.
+
+## Stale-Claims, die zu fixen sind (v2.1.1)
+
+Aus der Task-Liste:
+- `SECURITY.md:73-75` behauptet, Cache/Pool/Retry seien geplant — sind seit v2.0/2.1 implementiert. Item #1.
+- `examples/cookbook/03-options-request.php:11-13` referenziert „next milestone after v2.0.0" — zu entfernen. Item #5.
+- `examples/cookbook/02-custom-preview-strategy.php` zeigt eine McAfee-Strategy, die das 200-Verhalten nicht abdeckt — Item #6.
+- `src/Transport/ConnectionPoolInterface.php:36` Phpdoc verweist auf `NullConnectionPool`, das es noch nicht gibt — Item #4. Phpdoc-Drop oder Klasse anlegen (letzteres ist Item #14, v2.2).

--- a/.claude/skills/icap-flow-php/references/modern-php-features.md
+++ b/.claude/skills/icap-flow-php/references/modern-php-features.md
@@ -1,0 +1,248 @@
+# Modern PHP 8.4 / 8.5 — icap-flow-Konventionen
+
+Quelle für Versions-Minimum: `composer.json` (`"php": "^8.4"`), CI-Matrix in `.github/workflows/ci.yml` (PHP 8.4 + 8.5). Was hier gezeigt wird, ist in der Codebase bereits aktiv oder darf in neuem Code verwendet werden.
+
+## Strikte Typen & Datei-Header
+
+Jede PHP-Datei in `src/` und `tests/` startet mit dem EUPL-1.2-Klassen-Docblock direkt nach `<?php` und einem `declare(strict_types=1)`. `composer cs-fix` setzt den Header aus `.php-cs-fixer.dist.php` neu — **nicht** von Hand bearbeiten.
+
+```php
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * ...
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+```
+
+In Skill-Beispielen unten lasse ich den Header der Lesbarkeit halber weg und schreibe `// [EUPL-Header]`. Im echten Code ist er Pflicht.
+
+## `final readonly class` für DTOs
+
+Alle Werte, die durch das System reisen (Requests, Responses, Config, Result), sind unveränderlich.
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\DTO;
+
+final readonly class ScanResult
+{
+    public function __construct(
+        public bool $isInfected,
+        public ?string $virusName,
+        public IcapResponse $originalResponse,
+    ) {
+    }
+
+    public function isInfected(): bool
+    {
+        return $this->isInfected;
+    }
+
+    public function getVirusName(): ?string
+    {
+        return $this->virusName;
+    }
+}
+```
+
+`Config` ist `final readonly`, mutiert via `with*()`-Methoden, die neue Instanzen liefern (`withTlsContext`, `withVirusFoundHeaders`, `withLimits`). Keine Setter.
+
+## Enums mit Methoden — Strategy-Entscheidungen
+
+Verwende einen Backed-Enum statt Konstanten oder Strings, sobald eine endliche Menge von Zuständen mit eigener Logik existiert. Beispiel aus `src/PreviewDecision.php`:
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap;
+
+enum PreviewDecision: string
+{
+    case ABORT_CLEAN     = 'abort_clean';
+    case ABORT_INFECTED  = 'abort_infected';
+    case CONTINUE_SENDING = 'continue_sending';
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::CONTINUE_SENDING;
+    }
+}
+```
+
+Im v2.1.1-Hotfix wird `DefaultPreviewStrategy::handlePreviewResponse()` um den 200/206-Branch erweitert, der `ABORT_INFECTED` / `ABORT_CLEAN` zurückgibt — das ist genau die Stelle, an der der Enum seine Existenzberechtigung beweist.
+
+## Match statt Switch — Statuscode-Auswertung
+
+```php
+// In IcapClient::interpretResponse()
+return match (true) {
+    $code === 204                    => new ScanResult(false, null, $response),
+    $code === 200 || $code === 206   => $this->scanResultFromMaybeInfected($response, $config),
+    $code === 100                    => throw new IcapProtocolException(
+        'ICAP 100 Continue is only valid during a preview exchange.',
+        $code,
+    ),
+    $code >= 400 && $code < 500      => throw new IcapClientException(
+        sprintf('ICAP client error (%d).', $code),
+        $code,
+    ),
+    $code >= 500 && $code < 600      => throw new IcapServerException(
+        sprintf('ICAP server error (%d).', $code),
+        $code,
+    ),
+    default                          => throw new IcapResponseException(
+        'Unexpected ICAP status: ' . $code,
+        $code,
+    ),
+};
+```
+
+Die heutige Implementierung in `IcapClient.php:540ff` nutzt noch `if`-Ketten. Refactor auf `match (true)` ist v2.2-würdig, kein BC-Break — aber bitte mit identischen Tests in `tests/IcapClientTest.php` und `tests/Security/FailSecureAndValidationTest.php` flankieren.
+
+## `#[\Override]` — überall Pflicht
+
+Auf jeder Methode, die ein Interface oder eine Parent-Methode implementiert. PHPStan Level 9 + bleedingEdge meldet jedes Fehlen.
+
+```php
+final class DefaultPreviewStrategy implements PreviewStrategyInterface
+{
+    #[\Override]
+    public function handlePreviewResponse(IcapResponse $previewResponse): PreviewDecision
+    {
+        // ...
+    }
+}
+```
+
+## Named Arguments — Pflicht bei Konstruktoren mit ≥3 Parametern
+
+`Config`, `IcapRequest`, `HttpResponse`, `ScanResult` haben alle ≥3 Parameter. Tests und Cookbook-Beispiele rufen sie ausschließlich mit Named Arguments auf — das macht Diffs lesbar und überlebt Parameter-Reorder.
+
+```php
+$envelope = new HttpResponse(
+    statusCode: 200,
+    headers: [
+        'Content-Type'   => ['application/octet-stream'],
+        'Content-Length' => [(string) $fileSize],
+    ],
+    body: $previewBytes,
+);
+```
+
+## First-Class Callables
+
+Für `array_map`, `array_filter`, Decorator-Wrapping und Pool-Factories.
+
+```php
+$models = array_map(
+    ModelInfo::fromHeader(...),
+    $response->headers['Methods'] ?? [],
+);
+```
+
+## `never` für Throw-Helfer
+
+```php
+private function rejectInjection(string $service): never
+{
+    throw new \InvalidArgumentException(
+        'Service path contains control characters: ' . var_export($service, true),
+    );
+}
+```
+
+## Property Hooks (PHP 8.4)
+
+Können sinnvoll sein, wenn `IcapResponse`-Header in normalisierter Form bereitgestellt werden müssen. Heute löst `ResponseParser` das eager beim Bauen. Wenn ein neuer DTO mit lazy-normalisiertem View-State entsteht, nutze Property Hooks statt einer Getter-Methode.
+
+```php
+final class HeaderBag
+{
+    /** @var array<string, list<string>> */
+    private array $raw = [];
+
+    /** @var array<string, list<string>> */
+    public array $normalized {
+        get => array_change_key_case($this->raw, CASE_LOWER);
+    }
+}
+```
+
+## Asymmetric Visibility (PHP 8.4)
+
+Ideal für interne Counter / Idle-Timestamps in `AmpConnectionPool`, die von außen lesbar, aber nur von innen schreibbar sein sollen — ist im v2.2-Idle-Eviction-Item (`maxIdleAge`) ein guter Kandidat:
+
+```php
+final class PooledSocket
+{
+    public private(set) int $checkoutCount = 0;
+    public private(set) float $lastReleasedAt;
+
+    public function markCheckedOut(): void
+    {
+        ++$this->checkoutCount;
+    }
+
+    public function markReleased(float $now): void
+    {
+        $this->lastReleasedAt = $now;
+    }
+}
+```
+
+## DNF-Types & Intersection-Types
+
+Wir nutzen Intersections vor allem in Mockery-Tests:
+
+```php
+/** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+$formatter = m::mock(RequestFormatterInterface::class);
+```
+
+DNF-Types (`(A&B)|null`) sind verfügbar, kommen aber bisher nicht in `src/` vor. Wenn nötig, in PHPDoc und nativem Type-Hint identisch halten.
+
+## Attribute (Custom)
+
+Für Cookbook-Beispiele rund um v2.2-OPTIONS-Auto-Tuning und v2.3-Bundle nützlich, in `src/` selten. Beispiel aus dem geplanten Bundle-Repo:
+
+```php
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final readonly class IcapClean
+{
+    public function __construct(
+        public string $service = '/avscan',
+        public int $previewSize = 1024,
+    ) {
+    }
+}
+```
+
+## Quick-Reference
+
+| Feature | PHP | Wo in icap-flow |
+|---|---|---|
+| `final readonly class` | 8.2+ | Alle DTOs, `Config` |
+| Backed Enums + Methoden | 8.1+ | `PreviewDecision` |
+| `#[\Override]` | 8.3+ | Pflicht auf jeder Interface-Impl |
+| Named Arguments | 8.0+ | Konstruktoren mit ≥3 Params |
+| `match` (Statement + Expression) | 8.0+ | `DefaultPreviewStrategy`, geplanter `interpretResponse`-Refactor |
+| First-Class Callables | 8.1+ | Header-Map-Builder, Pool-Factories |
+| `never` | 8.1+ | Throw-Helfer in Validatoren |
+| Property Hooks | 8.4 | Kandidat für Lazy-Normalisierungs-Bags |
+| Asymmetric Visibility | 8.4 | Pool-Stats, v2.2-Idle-Eviction |
+| Intersection-Types | 8.1+ | Mockery-Test-Hints |
+| DNF-Types | 8.2+ | Verfügbar, in `src/` derzeit ungenutzt |
+| `\Throwable` als param | überall | `try/catch/finally` mit `\Throwable` (siehe `IcapClient::request()`) |

--- a/.claude/skills/icap-flow-php/references/symfony-bundle.md
+++ b/.claude/skills/icap-flow-php/references/symfony-bundle.md
@@ -1,0 +1,444 @@
+# Symfony 7.4 Bundle — Vorbereitung für v2.3.0
+
+> **Wichtig:** In **dieser** Repo (`ndrstmr/icap-flow`) gibt es **keine** Symfony-Komponenten. `src/` bleibt framework-neutral; einzige Optional-Dep ist `psr/log`. Die hier beschriebenen Patterns gehören in das **separate** Repo `ndrstmr/icap-flow-bundle`, das laut `consolidated_v2.1_task-list.md` Milestone v2.3.0 (8–12 Wochen nach v2.2.0) ist.
+>
+> Diese Datei lädt man, wenn man **das Bundle** entwirft oder einer Symfony-7.4-Anwendung zeigen will, **wie** sie icap-flow korrekt einbindet.
+
+## Symfony 7.4 — Stand der Technik (April 2026)
+
+- **Symfony 7.4 ist die aktuelle LTS-Vorbereitung** (LTS-Status zur 7.4-Release im November 2025). PHP-Minimum 8.4, identisch zu icap-flow.
+- DI-Container-Konfiguration vorzugsweise in **PHP** (`config/services.php`) — nicht mehr in YAML/XML, sofern keine Bundle-Recipe-Vorgaben dagegen sprechen.
+- Service-Definitionen mit **`autowire: true`**, **`autoconfigure: true`**, **`public: false`** als Default.
+- Monolog-Channel pro Sub-System (`icap`).
+- Console-Commands mit `#[AsCommand(...)]`, niemals mehr Class-Properties `protected static $defaultName`.
+- Profiler-Datacollectors via `#[AutoconfigureTag(...)]`.
+
+## Bundle-Skelett (`ndrstmr/icap-flow-bundle`)
+
+```
+ndrstmr/icap-flow-bundle/
+├── src/
+│   ├── IcapFlowBundle.php
+│   ├── DependencyInjection/
+│   │   ├── IcapFlowExtension.php
+│   │   └── Configuration.php
+│   ├── DataCollector/
+│   │   └── IcapFlowDataCollector.php
+│   ├── Command/
+│   │   ├── ScanCommand.php           # icap:scan
+│   │   ├── OptionsCommand.php        # icap:options
+│   │   └── HealthCommand.php         # icap:health
+│   ├── Validator/
+│   │   ├── IcapClean.php             # #[IcapClean] Constraint
+│   │   └── IcapCleanValidator.php
+│   └── Resources/
+│       ├── config/
+│       │   └── services.php
+│       └── views/
+│           └── Collector/
+│               └── icap_flow.html.twig
+├── composer.json                     # require: ndrstmr/icap-flow:^2.2
+├── phpunit.xml.dist
+└── README.md
+```
+
+## composer.json (Bundle)
+
+```json
+{
+  "name": "ndrstmr/icap-flow-bundle",
+  "type": "symfony-bundle",
+  "license": "EUPL-1.2",
+  "require": {
+    "php": "^8.4",
+    "ndrstmr/icap-flow": "^2.2",
+    "symfony/config": "^7.4",
+    "symfony/dependency-injection": "^7.4",
+    "symfony/http-kernel": "^7.4",
+    "symfony/console": "^7.4",
+    "symfony/validator": "^7.4 | *",
+    "symfony/framework-bundle": "^7.4"
+  }
+}
+```
+
+`ndrstmr/icap-flow` selbst hat **niemals** ein `symfony/*`-Require.
+
+## Bundle-Klasse (Symfony 6.1+ Stil)
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle;
+
+use Ndrstmr\IcapFlow\Bundle\DependencyInjection\IcapFlowExtension;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+final class IcapFlowBundle extends Bundle
+{
+    #[\Override]
+    public function getContainerExtension(): ?IcapFlowExtension
+    {
+        return $this->extension ??= new IcapFlowExtension();
+    }
+}
+```
+
+## Configuration-Tree
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+final class Configuration implements ConfigurationInterface
+{
+    #[\Override]
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('icap_flow');
+
+        $treeBuilder->getRootNode()
+            ->children()
+                ->scalarNode('host')->isRequired()->cannotBeEmpty()->end()
+                ->integerNode('port')->defaultValue(1344)->min(1)->max(65535)->end()
+                ->floatNode('socket_timeout')->defaultValue(10.0)->end()
+                ->floatNode('stream_timeout')->defaultValue(30.0)->end()
+                ->arrayNode('virus_headers')
+                    ->scalarPrototype()->cannotBeEmpty()->end()
+                    ->defaultValue([
+                        'X-Virus-Name', 'X-Infection-Found',
+                        'X-Violations-Found', 'X-Virus-ID',
+                    ])
+                ->end()
+                ->arrayNode('limits')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('max_response_size')->defaultValue(10 * 1024 * 1024)->end()
+                        ->integerNode('max_header_count')->defaultValue(100)->end()
+                        ->integerNode('max_header_line_length')->defaultValue(8192)->end()
+                    ->end()
+                ->end()
+                ->arrayNode('tls')
+                    ->canBeEnabled()
+                    ->children()
+                        ->scalarNode('ca_file')->defaultNull()->end()
+                        ->booleanNode('verify_peer')->defaultTrue()->end()
+                    ->end()
+                ->end()
+                ->arrayNode('retry')
+                    ->canBeEnabled()
+                    ->children()
+                        ->integerNode('max_attempts')->defaultValue(3)->min(1)->end()
+                        ->floatNode('base_delay_seconds')->defaultValue(0.5)->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}
+```
+
+## Extension — services.php als Loader
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\DependencyInjection;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+final class IcapFlowExtension extends Extension
+{
+    #[\Override]
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+        $config = $this->processConfiguration(new Configuration(), $configs);
+
+        $loader = new PhpFileLoader(
+            $container,
+            new FileLocator(__DIR__ . '/../Resources/config'),
+        );
+        $loader->load('services.php');
+
+        $container->setParameter('icap_flow.config', $config);
+    }
+}
+```
+
+## services.php — DI mit Auto-Wiring & Decorators
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Ndrstmr\Icap\Cache\InMemoryOptionsCache;
+use Ndrstmr\Icap\Cache\OptionsCacheInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\IcapClientInterface;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\RetryingIcapClient;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+use Ndrstmr\Icap\Transport\ConnectionPoolInterface;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+return static function (ContainerConfigurator $container): void {
+    $services = $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+            ->private()
+    ;
+
+    // Config kommt aus dem Configuration-Tree
+    $services->set(Config::class)
+        ->factory([Config::class, 'fromArray'])  // Helper, liest icap_flow.config
+        ->arg('$config', '%icap_flow.config%')
+    ;
+
+    $services->set(ConnectionPoolInterface::class, AmpConnectionPool::class);
+    $services->set(TransportInterface::class, AsyncAmpTransport::class);
+    $services->set(RequestFormatter::class);
+    $services->set(ResponseParser::class);
+    $services->set(OptionsCacheInterface::class, InMemoryOptionsCache::class);
+
+    // Inner-Client
+    $services->set('icap_flow.inner_client', IcapClient::class);
+
+    // Decorator: Retry on top, falls retry.enabled = true
+    $services->set(IcapClientInterface::class, RetryingIcapClient::class)
+        ->decorate('icap_flow.inner_client')
+        ->arg('$inner', service('.inner'))
+    ;
+};
+```
+
+## Validator-Constraint `#[IcapClean]`
+
+Die zugkräftige UX-Komponente: Symfony-Validator-Constraint, die ein hochgeladenes File via icap-flow scannt und bei Treffer eine Validation-Violation produziert.
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+final class IcapClean extends Constraint
+{
+    public function __construct(
+        public string $service = '/avscan',
+        public int $previewSize = 1024,
+        public string $message = 'The uploaded file was flagged by virus scanner: {{ virus }}.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct([], $groups, $payload);
+    }
+}
+```
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\Validator;
+
+use Ndrstmr\Icap\IcapClientInterface;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class IcapCleanValidator extends ConstraintValidator
+{
+    public function __construct(
+        private readonly IcapClientInterface $icap,
+    ) {
+    }
+
+    #[\Override]
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof IcapClean) {
+            throw new UnexpectedTypeException($constraint, IcapClean::class);
+        }
+        if ($value === null) {
+            return;
+        }
+        if (!$value instanceof File) {
+            throw new UnexpectedValueException($value, File::class);
+        }
+
+        $result = $this->icap
+            ->scanFileWithPreview($constraint->service, $value->getPathname(), $constraint->previewSize)
+            ->await();
+
+        if ($result->isInfected()) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ virus }}', $result->getVirusName() ?? 'unknown')
+                ->addViolation();
+        }
+    }
+}
+```
+
+## Console-Commands
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\Command;
+
+use Ndrstmr\Icap\IcapClientInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'icap:scan', description: 'Scan a file via the configured ICAP service')]
+final class ScanCommand extends Command
+{
+    public function __construct(
+        private readonly IcapClientInterface $icap,
+    ) {
+        parent::__construct();
+    }
+
+    #[\Override]
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('service', InputArgument::REQUIRED, 'ICAP service path, e.g. /avscan')
+            ->addArgument('file', InputArgument::REQUIRED, 'Local file path')
+        ;
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $service = (string) $input->getArgument('service');
+        $file    = (string) $input->getArgument('file');
+
+        $result = $this->icap->scanFile($service, $file)->await();
+
+        if ($result->isInfected()) {
+            $io->error(sprintf('Infected: %s', $result->getVirusName() ?? 'unknown'));
+            return Command::FAILURE;
+        }
+
+        $io->success('File is clean.');
+        return Command::SUCCESS;
+    }
+}
+```
+
+## DataCollector (Profiler-Panel)
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+namespace Ndrstmr\IcapFlow\Bundle\DataCollector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
+final class IcapFlowDataCollector extends DataCollector
+{
+    #[\Override]
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+        // Daten kommen aus einem Tracing-Decorator, nicht direkt aus IcapClient
+        // (siehe v2.2-Item #28 OtelTracingIcapClient — der DataCollector kann an dasselbe
+        // Span-Hub andocken, wenn er existiert).
+    }
+
+    #[\Override]
+    public function getName(): string
+    {
+        return 'icap_flow';
+    }
+
+    #[\Override]
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+}
+```
+
+## Multi-Client (Tagged-Services)
+
+Wenn eine App gegen zwei ICAP-Server gleichzeitig läuft (z. B. ClamAV + Symantec):
+
+```php
+$services->set('icap_flow.client.clamav', IcapClient::class)
+    ->args([service('icap_flow.config.clamav'), /* ... */])
+    ->tag('icap_flow.client', ['name' => 'clamav']);
+
+$services->set('icap_flow.client.symantec', IcapClient::class)
+    ->args([service('icap_flow.config.symantec'), /* ... */])
+    ->tag('icap_flow.client', ['name' => 'symantec']);
+```
+
+Konsumenten injecten dann via Service-Subscriber oder via `#[Autowire(service: 'icap_flow.client.clamav')]`.
+
+## Was im Bundle **nicht** gehört
+
+- **Wire-Format-Code, Validatoren, Strategy-Logik** — gehört in die Library `ndrstmr/icap-flow`. Das Bundle ist nur Verdrahtung.
+- **Eigene Exception-Hierarchie** — die Bundle nutzt die Library-Exceptions, höchstens dünne Wrapper für Validator-Violation-Mapping.
+- **Custom Async-Loop** — Symfony rennt synchron; das Bundle nutzt deshalb in der Regel `SynchronousIcapClient` oder ruft `await()` auf einem `IcapClientInterface`.
+
+## Symfony 7.4 — was sich gegenüber 6.4 geändert hat (relevant für das Bundle)
+
+- `#[AsCommand]`-Konstruktor erlaubt jetzt sauber DI ohne `parent::__construct()`-Boilerplate (war bereits 6.x).
+- `Symfony\Bridge\PhpUnit` ist auf PHPUnit 11 gehoben — das Bundle nutzt aber Pest 3 wie die Library.
+- Lazy-Service-Subscriber via Attributes (`#[SubscribedService]`) statt `getSubscribedServices()`.
+- Asset-Mapper-Recipes ersetzen Webpack-Encore in neuen Setups — für ein backend-fokussiertes Validator-Bundle nicht relevant.
+
+## Test-Strategie für das Bundle
+
+```
+tests/
+├── Functional/
+│   ├── BundleBootTest.php           # Container kompiliert, Services aufrufbar
+│   ├── ConfigurationTest.php        # Tree-Builder gegen YAML/PHP-Snippets
+│   └── ValidatorTest.php            # MockedIcap injecten, Constraint testen
+└── Unit/
+    └── DataCollectorTest.php
+```
+
+Functional-Tests bootstrappen einen Mini-Kernel, der nur das Bundle und ein Mock-`IcapClientInterface` lädt. Echte ICAP-Calls bleiben in der Library — das Bundle muss sie nicht erneut testen.
+
+## Release-Choreographie (laut v2.1-Plan)
+
+1. **v2.2.0** der Library (icap-flow) inkl. `NullConnectionPool`, OTel-Decorator, `Config::autoTunePoolFromOptions`, ISTag-Cache. Ohne diese Bausteine ist das Bundle unscharf.
+2. **v0.1.0** des Bundle-Repos — startet bei Null, nicht synchron mit der Library-Version.
+3. **Flex-Recipe** in `symfony/recipes-contrib` einreichen, sobald die Konfigurations-Form stabil ist.
+4. **Adapter** für VichUploaderBundle / OneupUploaderBundle als optionale Sub-Pakete oder in einem separaten `icap-flow-uploader-adapter`-Repo.

--- a/.claude/skills/icap-flow-php/references/testing-pest.md
+++ b/.claude/skills/icap-flow-php/references/testing-pest.md
@@ -1,0 +1,246 @@
+# Testing & Quality — Pest 3, Mockery, PHPStan, Mutation
+
+icap-flow ist test-getrieben: jede Verhaltensänderung beginnt mit einem **roten** Pest-Test. Diese Datei zeigt den Stack, der in der Repo aktiv ist.
+
+## Vier Gates vor Übergabe
+
+```bash
+composer cs-check                 # PSR-12 + EUPL-Header (php-cs-fixer dry-run)
+composer stan                     # PHPStan Level 9 + bleedingEdge — null Fehler, keine Baseline
+composer test                     # Pest Unit-Suite grün
+composer test:integration         # Pest Integration-Suite — env-gated, self-skip ohne ICAP_HOST
+```
+
+`composer audit` läuft im CI auch — lokal sinnvoll, wenn `composer.lock` angefasst wurde.
+
+## Pest 3 — Teststil in dieser Repo
+
+Der Stil ist **Funktional-Pest** (`it()` / `test()` / `expect()`), nicht der Class-Stil. Class-Mixins via `uses()` für Setup/Tear-Down werden eingesetzt.
+
+```php
+// [EUPL-Header]
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\TransportInterface;
+
+uses(AsyncTestCase::class);
+
+it('rejects status 100 outside the preview flow as protocol error', function () {
+    [$config, , $transport, , , $client] = makeClient();
+
+    /** @var \Mockery\Expectation $tx */
+    $tx = $transport->shouldReceive('request');
+    $tx->once()->andReturn(\Amp\Future::complete("ICAP/1.0 100 Continue\r\n\r\n"));
+
+    expect(fn () => $client->request(new IcapRequest('RESPMOD', 'icap://example/avscan'))->await())
+        ->toThrow(IcapProtocolException::class);
+});
+```
+
+**Konventionen:**
+- Datei-Suffix `*Test.php`. Pest sammelt sie über `phpunit.xml.dist`.
+- `it('verb …')` für Behavior, `test('description')` für Setup-/Edge-Case-Notationen — beides erlaubt, durchgängig wie der Rest des Verzeichnisses bleiben.
+- `expect($x)->toBe($y)` / `->toEqual()` / `->toThrow()` / `->toContain()`. Kein `assertSame()` mischen.
+- `uses(AsyncTestCase::class)` immer, wenn der Test `await()` aufruft oder Fibers betritt.
+
+## Test-Verzeichnis-Layout
+
+```
+tests/
+├── AsyncTestCase.php
+├── Pest.php                          # Bootstrap; Mockery::close() in afterEach
+├── DTO/                              # Value-Object-Verhalten
+├── Exception/                        # Exception-Hierarchie / -Codes
+├── Wire/                             # RFC-3507-Bytes (Formatter / Parser)
+├── Transport/                        # Socket-/Pool-/Session-Verhalten
+├── Security/                         # Fail-Secure, DoS-Limits, Validators
+├── Integration/                      # echte Server (Docker), env-gated
+├── IcapClientTest.php
+├── RetryingIcapClientTest.php
+├── PreviewContinueStrictTest.php
+├── … weitere Behavior-Tests im Top-Level
+```
+
+Faustregel: **dort hinzufügen, wo gleichartige Tests schon liegen**. Eine neue Datei macht man nur, wenn die behandelte Klasse keinen Test-Pendant hat.
+
+## Mockery — Intersection-Type-Hints
+
+Pest 3 spielt mit Mockery, sobald ein `m::mock()` einen Type kreuzt. Wir nutzen Intersection-Hints, damit PHPStan beide Typen (das Interface **und** das Mock-Interface) sieht:
+
+```php
+/** @var TransportInterface&\Mockery\MockInterface $transport */
+$transport = m::mock(TransportInterface::class);
+
+/** @var \Mockery\Expectation $tx */
+$tx = $transport->shouldReceive('request');
+$tx->once()->with(/* ... */)->andReturn(\Amp\Future::complete($body));
+```
+
+Der Cast in `\Mockery\Expectation` ist nötig, weil PHPStan bleedingEdge sonst auf der return-Type-Lücke hängen bleibt. Vorbild: `tests/IcapClientTest.php:42-58`.
+
+`Mockery::close()` läuft im `afterEach`-Hook in `tests/Pest.php` — die Tests müssen es nicht aufrufen.
+
+## Wire-Tests — keine Mocks
+
+Wire-Suite testet den Formatter mit echten Bytes:
+
+```php
+function wire(iterable $chunks): string
+{
+    $s = '';
+    foreach ($chunks as $c) {
+        $s .= $c;
+    }
+    return $s;
+}
+
+it('emits 0; ieof terminator on preview-complete', function () {
+    $request = new IcapRequest(
+        method: 'RESPMOD',
+        uri: 'icap://h/avscan',
+        headers: ['Preview' => ['1024'], 'Allow' => ['204']],
+        encapsulatedResponse: new HttpResponse(200, ['Content-Length' => ['12']], body: 'hello world!'),
+        previewIsComplete: true,
+    );
+
+    $bytes = wire((new RequestFormatter())->format($request));
+
+    expect($bytes)->toEndWith("0; ieof\r\n\r\n");
+});
+```
+
+Niemals den `RequestFormatter` mocken, wenn die Wire-Schicht geprüft werden soll — der Sinn dieser Tests ist genau, dass echte Bytes rauskommen.
+
+## Security-Tests — Fail-Secure-Invarianten
+
+`tests/Security/FailSecureAndValidationTest.php` enthält:
+
+- `100 Continue` außerhalb Preview → `IcapProtocolException`.
+- 5xx → `IcapServerException` mit Code als HTTP-Status.
+- 4xx → `IcapClientException` mit Code.
+- Header mit CR/LF → `\InvalidArgumentException`.
+- Service-Pfad mit Steuerzeichen → `\InvalidArgumentException`.
+
+Jedes neue Fail-Secure-Verhalten kommt **hier** als Test rein. v2.1.1 fügt z. B. einen Test für `200 + X-Virus-Name im Preview` hinzu (`DefaultPreviewStrategyTest::testInfectedDuringPreview`).
+
+## Integration-Tests — env-gated Self-Skip
+
+```php
+it('detects EICAR via the ClamAV ICAP service', function () {
+    $host = getenv('ICAP_HOST');
+    $service = getenv('ICAP_CLAMAV_SERVICE');
+
+    if ($host === false || $host === '' || $service === false) {
+        test()->markTestSkipped('Set ICAP_HOST and ICAP_CLAMAV_SERVICE to enable.');
+    }
+
+    $client = SynchronousIcapClient::create()->withConfig(new Config($host));
+    $result = $client->scanFile($service, fixture('eicar.com'));
+
+    expect($result->isInfected())->toBeTrue();
+});
+```
+
+`composer test` lässt diese Suite weg (`<exclude>./tests/Integration</exclude>` in `phpunit.xml.dist`). Wer sie laufen lässt: Docker-Compose hochziehen, env-Variablen setzen, `composer test:integration`.
+
+## PHPStan Level 9 + bleedingEdge
+
+```neon
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+
+parameters:
+    level: 9
+    paths:
+        - src
+        - tests
+    ignoreErrors:
+        # Pest 3 Mixin-Klasse ist @internal — das ist gewollt
+        - identifier: method.internalClass
+          path: tests/*
+          message: '#Pest\\Mixins\\Expectation#'
+```
+
+**Keine neue Baseline.** Findings werden gefixt — wenn das nicht geht, kurz erläutern und im Issue-Tracker dokumentieren, **bevor** ein `ignoreErrors`-Eintrag kommt. Heutige Repo hat exakt zwei zugelassene Pest-/PHPStan-Reibungspunkte (siehe `phpstan.neon`); neue dürfen nicht hinzukommen.
+
+### Häufige Level-9-Hürden in dieser Codebase
+
+```php
+// ❌ Cannot access offset 0 on array<string, array<string>>|null
+$virus = $response->headers['X-Virus-Name'][0];
+
+// ✅ Mit Null-Coalesce + isset-Check
+$virus = $response->headers['X-Virus-Name'][0] ?? null;
+```
+
+```php
+// ❌ Parameter $previewSize expects int<1, max>, int given
+$strategy->handle($previewSize);
+
+// ✅ Schmale int-Range über PHPDoc
+/** @var int<1, max> $previewSize */
+```
+
+```php
+// ❌ Method has no return type
+public function buildKey($config) { ... }
+
+// ✅ Volle Signatur — Level 9 will sie sehen
+public function buildKey(Config $config): string { ... }
+```
+
+## PHP-CS-Fixer — eigenes Setup
+
+`.php-cs-fixer.dist.php` setzt `@PSR12` und einen `header_comment` mit dem EUPL-1.2-Block. Anders als der Lotse-Setup nutzen wir **nicht** `@Symfony` — die Library bleibt framework-neutral.
+
+```bash
+composer cs-fix         # apply
+composer cs-check       # dry-run, im CI
+```
+
+Wer einen Test schreibt: **niemals** den Header von Hand kopieren. `composer cs-fix` setzt ihn nach dem ersten Save automatisch.
+
+## Mutation-Testing
+
+```bash
+composer mutation
+# = pest --mutate --testsuite=Unit --parallel --covered-only --min=65
+```
+
+`--covered-only` hält die Laufzeit handhabbar: nur Lines, die ohnehin Coverage haben, werden mutiert. Schwelle 65 % ist heute der untere Mindestrahmen — v2.2 plant einen Required-Status auf PR-Branches (Item #16 der v2.1-Task-Liste).
+
+Wer einen Mutation-Drop bemerkt, fragt sich:
+- Ist der existierende Test zu schwach (z. B. asserts nur `toBeTruthy()`, statt `toBe(true)` mit Wert)?
+- Ist der Codepfad einfach unerreichbar — dann den toten Code löschen, nicht den Test stärken.
+
+## Coverage-Hotspots aus Jules' v2.1-Audit
+
+Für v2.2 sind folgende Module konkret zu pushen (Item #18):
+
+| Modul | heute | Ziel v2.2 |
+|---|---|---|
+| `AmpConnectionPool` | 54 % | ≥ 90 % |
+| `SynchronousStreamTransport` | 41 % | ≥ 85 % |
+| Async-Socket-Error-Pfade | 63 % | ≥ 85 % |
+
+Konkrete fehlende Cases: Cross-TLS-Pool-Isolation (kommt schon in v2.1.1), Concurrent-Acquire-Race (Fiber), `0; ieof`-Recv-Pfad, Multi-Section-Encapsulated, Cancellation mid-write/mid-read/Composite, `Options-TTL=0`, `SynchronousIcapClient::scanFileWithPreview`, Logger-Sensitive-Header-Regression.
+
+## Composer-Skript-Quickref
+
+| Befehl | Zweck |
+|---|---|
+| `composer test` | Pest Unit (default; CI-Job „Quality Checks") |
+| `composer test:integration` | Pest Integration — braucht `ICAP_HOST` etc. |
+| `composer test:all` | beide Suites |
+| `composer stan` | PHPStan Level 9 + bleedingEdge |
+| `composer cs-check` | php-cs-fixer dry-run, im CI verwendet |
+| `composer cs-fix` | php-cs-fixer apply |
+| `composer mutation` | Pest mutation, Schwelle 65 % |
+| `composer audit` | composer audit + roave/security-advisories |
+| `vendor/bin/pest tests/IcapClientTest.php` | einzelne Datei |
+| `vendor/bin/pest --filter='returns infected'` | einzelner Test über Description-Substring |
+| `vendor/bin/phpstan analyse src/IcapClient.php` | PHPStan auf einer Datei |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!--
+PR-Body folgt dem in dieser Repo etablierten Stil
+(siehe z. B. PR #48, #49). Sektionen weglassen, die nicht passen.
+Sprache: Englisch (öffentliche Library-Doku). Conventional-Commit-Subject im PR-Titel.
+-->
+
+## Context
+
+<!--
+Was wird gelöst und warum? Hintergrund, Motivation, Bezug zu vorigen PRs.
+Bei Items aus docs/review/review_v2-1/consolidated_v2.1_task-list.md die Item-Nummer + Reviewer-Quelle nennen
+(z. B. "v2.1.1 #2, 4/4 reviewers — cross-tenant TLS leakage in AmpConnectionPool").
+-->
+
+## API
+
+<!--
+Neue oder geänderte Public-API (Klassen, Interfaces, Methoden, Konstruktor-Parameter).
+"none" wenn rein interne Änderung. BC-Breaks IMMER hier kennzeichnen.
+-->
+
+## Behaviour
+
+<!--
+Was beobachtet der Anwender anders? Branches, Status-Code-Pfade, Fail-Secure-Wirkung,
+Pool/Session-Lifecycle, Wire-Format-Auswirkungen.
+-->
+
+## Refactoring
+
+<!--
+Interne Umbauten ohne Verhaltensänderung (Extract-Class, Encoder-Split, Parser-Cleanup, …).
+"none" wenn nicht relevant.
+-->
+
+## Tests
+
+<!--
+Welche Tests dazu gekommen sind, in welcher Suite (Wire/Transport/Security/Integration/…),
+welche Edge-Cases sie absichern, ob Mutation-Score betroffen ist.
+-->
+
+## Verification
+
+- [ ] `composer cs-check`
+- [ ] `composer stan` — PHPStan Level 9 + bleedingEdge clean
+- [ ] `composer test` — Pest Unit-Suite grün
+- [ ] `composer test:integration` — gegen `docker compose up -d` (falls relevant)
+- [ ] CI-Matrix (PHP 8.4 + 8.5)
+
+## Status
+
+<!--
+Was passiert nach Merge? Tag-Pflege, Folge-PR, Roadmap-Item geschlossen, Release-Notes.
+-->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> Sprache: **Deutsch.** Antworte, dokumentiere und committe in dieser Repo auf Deutsch (Code, Identifier und Wire-Format-Konstanten bleiben englisch).
+
+## Projekt
+
+`ndrstmr/icap-flow` — async-fähiger ICAP-Client (RFC 3507) für PHP 8.4+, veröffentlicht auf Packagist. Library, keine Anwendung.
+
+Die Library scannt Uploads gegen einen ICAP-Server (typischerweise c-icap + ClamAV oder eine Vendor-Appliance: Symantec, Trend Micro, Sophos, McAfee, Kaspersky) und liegt damit auf dem sicherheitskritischen Pfad jeder aufrufenden Anwendung. Jede Änderung in `src/` ist sicherheitsrelevant; siehe Disclaimer im `README.md` und die Reviews unter `docs/review/review_v2-1/`.
+
+## Häufig genutzte Befehle
+
+Alle Workflows laufen über Composer-Skripte (definiert in `composer.json`):
+
+```bash
+composer test               # Pest, nur Unit-Suite (Default lokal & im CI-Quality-Job)
+composer test:integration   # Pest, Integration-Suite — braucht echten ICAP-Server
+composer test:all           # beide Suites
+composer stan               # PHPStan Level 9 + bleedingEdge, scannt src/ und tests/
+composer cs-check           # PSR-12 via php-cs-fixer (dry-run)
+composer cs-fix             # PSR-12-Fixes anwenden
+composer audit              # composer audit + roave/security-advisories
+composer mutation           # Pest-Mutation-Tests (Unit, parallel, --min=65)
+```
+
+Einzelner Test / einzelne Datei:
+
+```bash
+vendor/bin/pest tests/IcapClientTest.php
+vendor/bin/pest --filter='returns infected when virus header present'
+```
+
+PHPStan auf einem einzelnen Pfad:
+
+```bash
+vendor/bin/phpstan analyse src/IcapClient.php
+```
+
+### Integrationstests
+
+Die `Integration`-Suite ist aus `composer test` ausgenommen. Sie spricht einen echten ICAP-Server und überspringt sich selbst, wenn die Env-Variablen nicht gesetzt sind — Contributors ohne Docker bekommen also weiterhin einen grünen Lauf. Für die End-to-End-Wire-Format-Prüfung:
+
+```bash
+docker compose up -d                               # mnemoshare/clamav-icap auf :1344
+ICAP_HOST=127.0.0.1 ICAP_PORT=1344 \
+  ICAP_ECHO_SERVICE=/avscan \
+  ICAP_CLAMAV_SERVICE=/avscan \
+  composer test:integration
+```
+
+Beim ersten Start lädt das ClamAV-Image die Signaturdatenbank (~200 MB, mehrere Minuten). Der Healthcheck im Compose-File und der CI-Job in `.github/workflows/ci.yml` warten deshalb auf eine echte `ICAP/1.0`-Antwort, nicht nur auf einen offenen Port — dieses Muster bitte übernehmen, wenn du Integration-Skripte schreibst.
+
+## Architektur
+
+Schichtung (jede Schicht hängt nur von darunter liegenden ab):
+
+```
+SynchronousIcapClient ─┐
+                       ├─► IcapClient (Facade) ──► PreviewStrategy   ──► PreviewDecision
+RetryingIcapClient ────┘                       ──► RequestFormatter  ──► ChunkedBodyEncoder
+                                                ──► ResponseParser
+                                                ──► TransportInterface (+ SessionAwareTransport)
+                                                       │
+                                                       ├─ AsyncAmpTransport      (amphp/socket, Default)
+                                                       │     └─ AmpTransportSession + AmpConnectionPool
+                                                       └─ SynchronousStreamTransport (stream_socket_client)
+                                                Cache: OptionsCacheInterface (InMemoryOptionsCache)
+                                                DTOs:  IcapRequest, IcapResponse, HttpRequest, HttpResponse, ScanResult
+```
+
+Tragende Designregeln — Abweichungen brauchen einen guten Grund:
+
+- **Fail-Secure-Statuscode-Auswertung lebt in `IcapClient::interpretResponse()`.** Jeder Status, der kein eindeutiges Clean-Signal ist (204, 200/206 ohne Virus-Header), wirft eine typisierte Exception. `100 Continue` außerhalb des Preview-Flows ist ein Protokollfehler, kein Clean-Scan — Finding G der v2-Konsolidierung. Hier dürfen keine stillen Fallbacks rein.
+- **Der Preview-Flow nutzt `executeRaw()`** (ohne Fail-Secure-Interpretation), weil `100 Continue` mitten im Austausch legitim ist. Externe Aufrufer verwenden `request()` / `scanFile*()`, niemals direkt `executeRaw()`.
+- **Strict RFC 3507 §4.5 Preview-Continue setzt `SessionAwareTransport` voraus.** `IcapClient::scanFileWithPreview()` verzweigt: session-fähige Transports laufen über `scanFileWithPreviewStrict` (Preview + Continuation auf demselben Socket, ein logischer ICAP-Request), andere fallen auf `scanFileWithPreviewLegacy` zurück (Zwei-Request-Approximation, kostet einen zusätzlichen TCP/TLS-Handshake). Diese beiden Pfade nicht zusammenlegen.
+- **Sockets, die irgendetwas Untypisches gesehen haben, werden geschlossen, nicht gepoolt.** `AsyncAmpTransport` gibt einen Socket nur über `release()` zurück, wenn der Austausch sauber war und der Server kein `Connection: close` gesendet hat. Framing-Fehler oder geworfene Exceptions erzwingen `close()`, damit der nächste Pool-User keine ausgerichteten Bytes sieht.
+- **Header-/URI-Injection wird abgewiesen, bevor irgendein Byte den Socket erreicht.** `IcapClient::validateServicePath()` und `validateIcapHeaders()` lehnen CR/LF/NUL/Steuerzeichen in vom Aufrufer übergebenen Service-Pfaden und `extraHeaders` ab. Library-verwaltete Header (`Encapsulated`, `Host`, `Connection` und im Preview-Flow `Preview` / `Allow`) gewinnen in `mergeHeaders()` immer — Aufrufer können sie nicht überschreiben.
+- **DTOs und `Config` sind immutable** (`final readonly class` / `readonly`-Properties). Mutatoren liefern neue Instanzen (`Config::withTlsContext`, `withVirusFoundHeaders`, `withLimits`). Keine Setter ergänzen.
+- **`RequestFormatter::format()` liefert ein iterierbares Chunk-Array.** Encapsulated-Bodies werden als HTTP/1.1-Chunks gestreamt; Preview-Requests, die bereits den vollständigen Payload tragen, terminieren mit `0; ieof\r\n\r\n`. Bodies nicht in einen einzigen String puffern.
+- **`ResponseParser` setzt DoS-Limits durch** (`maxResponseSize`, `maxHeaderCount`, `maxHeaderLineLength`) und holt sie aus `Config`. Wer den Parser per Hand instanziiert, übergibt die Limits aus derselben `Config`, die der Transport sieht.
+- **Vendor-Virus-Header sind eine geordnete Liste.** `Config::getVirusFoundHeaders()` liefert `list<string>`, `IcapClient::extractVirusName()` gibt den ersten vorhandenen zurück. Neue Vendor-Header in die Liste aufnehmen, nicht per Sonderfall behandeln.
+
+Öffentliche Einstiegspunkte:
+
+- `IcapClient::create()` / `IcapClient::forServer($host)` — Async/Sync-Convenience-Factories mit Default-Verdrahtung. Gut für Beispiele; produktiver Code konstruiert `IcapClient` explizit mit getunter `Config` und `LoggerInterface`.
+- `SynchronousIcapClient::create()` — dünner `await()`-Wrapper um `IcapClient`; existiert, damit Framework-lose Aufrufer `Revolt\EventLoop` nicht selbst kennen müssen.
+- `RetryingIcapClient` — Decorator (keine Subklasse), retried 5xx mit Exponential-Backoff. Einen `IcapClient` einwickeln, nicht ableiten.
+
+## Konventionen
+
+- **PHP 8.4 Minimum** (CI fährt 8.4 + 8.5). PHPStan Level 9 + bleedingEdge, keine Baseline — Issues fixen, nicht unterdrücken. Überall `final class`, `readonly` wo Daten unveränderlich sind.
+- **`#[\Override]`** auf jeder Interface-Implementierung. PHPStan flagt fehlende Annotationen.
+- **EUPL-1.2-Dateiheader** ist Pflicht in jeder PHP-Datei in `src/` und `tests/`. `composer cs-fix` setzt ihn aus `.php-cs-fixer.dist.php` neu — den Header-Block nicht von Hand editieren.
+- **PSR-4-Namespace** `Ndrstmr\Icap\` (src) / `Ndrstmr\Icap\Tests\` (tests). PSR-12-Coding-Style wird von php-cs-fixer durchgesetzt.
+- **Tests laufen unter Pest 3** (PHPUnit 11 darunter). Mockery steht für Transport-Doubles bereit. Testdateien liegen neben der Schicht, die sie prüfen: `tests/Wire/` für Formatter/Parser, `tests/Transport/` für Transports, `tests/Security/` für Fail-Secure- und DoS-Limit-Invarianten, `tests/Integration/` für Smoke-Tests gegen echte Server. Diese Aufteilung beim Hinzufügen neuer Tests beibehalten.
+- **Logging ist PSR-3 und strukturiert.** `IcapClient` schreibt `info` beim Start und Abschluss sowie `warning` bei Fehlschlag, mit den Keys `method`, `uri`, `host`, `port`, `statusCode`, `infected`. Neue Log-Stellen sollen dieses Schema treffen.
+
+## Commits & Pull Requests
+
+Diese Repo folgt **strikt** [Conventional Commits 1.0](https://www.conventionalcommits.org/de/v1.0.0/). Bestehende Historie zeigt das Muster (`docs:`, `feat(v2.1):`, `docs(review):`) — neue Commits halten dieses Schema.
+
+### Commit-Format
+
+```
+<type>(<scope>): <subject>
+
+<body — Pflicht, keine reinen Subject-Commits>
+
+<footer — optional: BREAKING CHANGE, Refs, Closes>
+```
+
+- **Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`. Eigene Types nicht erfinden.
+- **Scope:** wenn sinnvoll, in Klammern. Übliche Scopes hier: `transport`, `wire`, `preview`, `pool`, `cache`, `security`, `review`, `v2.1`, `v2.2` … oder ein Klassenname (`IcapClient`).
+- **Subject:** Imperativ, kleinbuchstaben, kein Punkt am Ende, max. ~70 Zeichen.
+- **Body:** Pflicht. Erklärt **warum**, nicht **was** — der Diff zeigt das Was. Bei Items aus `docs/review/review_v2-1/consolidated_v2.1_task-list.md` die Tabellenzeile + Reviewer-Quelle nennen.
+- **Footer:**
+  - `BREAKING CHANGE: <Beschreibung>` für jeden BC-Break (gehören in den v3.0.0-Bucket, nicht in Patch/Minor).
+  - `Refs #<issue>` / `Closes #<issue>` für Verlinkung zur GitHub-Issue.
+
+### Was nicht in Commits / PRs gehört
+
+- **Keine Co-Authored-By-Trailer für Claude / Anthropic / Generated-with-Claude-Code-Werbung.** Auch keine 🤖-Emoji-Footer. Commits sind authored vom Repo-Maintainer; Tooling-Provenance gehört nicht in die Git-Historie.
+- **Keine Werbe- oder Generator-Hinweise** in PR-Beschreibungen, Issue-Bodies oder Commit-Messages.
+- **Keine `--no-verify`** — wenn pre-commit-Hooks fehlschlagen, Root-Cause fixen und neuen Commit anlegen (nicht amend).
+
+### Pull Requests
+
+- **PR-Titel** ist eine Conventional-Commit-Subject-Zeile (≤ 70 Zeichen). Kein `[WIP]`-Präfix; Drafts sind GitHub-nativ.
+- **PR-Body** mit zwei Sektionen:
+  - `## Summary` — 1–3 Bullets, was sich ändert und warum.
+  - `## Test plan` — Checkliste, wie der Reviewer das Verhalten prüft (`composer test`, einzelner Pest-Filter, Integration-Run gegen Docker, manueller Eicar-Probe-Lauf, …).
+- **Verweise auf Roadmap-Items** aus `docs/review/review_v2-1/consolidated_v2.1_task-list.md` mit Item-Nummer und Reviewer-Quellen-Tabelle, wenn der PR ein gelistetes Finding schließt.
+- **CI muss grün sein** vor Merge: `cs-check`, `stan`, `test`, `audit`. Integration-Tests sind aktuell `continue-on-error: true` (Item #17 der v2.2-Liste hebt das); ein roter Integration-Step blockiert den Merge **noch nicht**, sollte aber im PR adressiert werden.
+
+### CHANGELOG-Eintrag
+
+Jeder funktionale PR (`feat`, `fix`, `perf`, `refactor` mit User-sichtbarer Wirkung) ergänzt einen Bullet im `[Unreleased]`-Block der `CHANGELOG.md` (Keep-a-Changelog-Format). `docs:`, `test:`, `ci:`, `chore:` brauchen das nicht.
+
+## Roadmap & Reviews — die maßgebliche Quelle
+
+Der **aktuelle Plan** für die Weiterentwicklung steht in **`docs/review/review_v2-1/consolidated_v2.1_task-list.md`**. Vor jeder substanziellen Änderung in `src/`, `tests/`, `examples/cookbook/` oder `.github/workflows/` zuerst diese Datei prüfen — sie sortiert die Findings aus den vier Deep-Research-Audits (Konsens TRL-7, Scores 74–77/100) nach Release-Milestones und benennt pro Item die kritischen Dateien.
+
+Vier unabhängige Audits unter `docs/review/review_v2-1/`:
+
+- `claude_deep-research-audit-icap-flow-v2.1.0.md`
+- `codex_deep-research-v2.1.0-audit.md`
+- `codex_v2.1.0-production-readiness-audit-2026-04-25.md`
+- `jules_deep_research_report_2-1.md`
+
+### Aktueller Release-Plan (Stand: aus der konsolidierten Task-Liste)
+
+- **v2.1.1 — Critical Hotfix** (kein BC-Break, höchste Priorität):
+  - `AmpConnectionPool::key()` um TLS-Context-Fingerprint erweitern (Cross-Tenant-Leakage, CVE-würdig im Multi-Tenant-Deployment) — `src/Transport/AmpConnectionPool.php:130-133`.
+  - `DefaultPreviewStrategy` für 200/206 erweitern: Virus-Header → `ABORT_INFECTED`, sonst `ABORT_CLEAN`. Der Branch in `IcapClient.php:388` ist heute unerreichbar — Virus-Treffer im Preview kommen als uncatchable Exception zurück.
+  - `SECURITY.md:73-75` von Stale-Claims befreien (Cache/Pool/Retry sind seit v2.0/2.1 implementiert).
+  - Kleine Doku-Korrekturen in Cookbook + `ConnectionPoolInterface`-Phpdoc.
+- **v2.1.2 — CI-Quality-Patch** (kein BC-Break): Strict-§4.5-Streaming-Fix (`stream_get_contents()` durch `ChunkedBodyEncoder::encodeRemainderFromStream()` ersetzen) plus `failOnRisky=true` im Phpunit-Setup und PHPStan-Memory-Limit-Stabilisierung.
+- **v2.2.0 — Minor, additiv:** OPTIONS-getriebenes Preview-/Pool-Tuning, `NullConnectionPool`, Mutation-Tests als Required-CI, Coverage-Push (`AmpConnectionPool` 54 → ≥90 %, `SynchronousStreamTransport` 41 → ≥85 %), 4 zusätzliche Cookbook-Beispiele, OpenTelemetry-Decorator, PHPBench-Suite.
+- **v2.3.0** — separates Repo `ndrstmr/icap-flow-bundle` (Symfony-Bundle), nicht in dieser Repo.
+- **v3.0.0** — gesammelte BC-Breaks: `executeRaw()` `protected`/Interface, `options()` zu `Future<IcapResponse>`, `IcapResponseException` entfernen.
+
+Konkrete Korrekturen aus der konsolidierten Liste, die beim Code-Lesen auffallen können:
+
+- **Jules' Befund zur Header-Array-Validierung ist faktisch falsch** — `IcapClient::validateIcapHeaders()` Z. 600-613 iteriert per `foreach ((array) $value as $v)` über jeden Array-Eintrag. Diesen Punkt **nicht** als offen behandeln.
+- Der Strict-§4.5-Streaming-Bug ist von 3 von 4 Reviewern erfasst (Jules nicht).
+
+### Historische Reviews
+
+`docs/review/` (Top-Level, ohne `review_v2-1/`-Unterordner) enthält die drei v1-Audits, die das v2-Redesign getrieben haben, sowie deren `consolidated_task-list.md`. Diese Dateien sind **historische Provenance** — abgeschlossen mit dem v2.0-Release. Für laufende Arbeit ist `docs/review/review_v2-1/consolidated_v2.1_task-list.md` der Anker, nicht die alten v1-Listen.
+
+`docs/migration-v1-to-v2.md` dokumentiert jeden v1 → v2 Break. `CHANGELOG.md` folgt Keep-a-Changelog und SemVer ist committed. v1 ist deprecated; dort keine neuen Codepfade einbauen.


### PR DESCRIPTION
## Context

Bislang gab es im Repo keine zentrale Onboarding-Datei für Claude-Code-Agents, kein Skill-Bundle und kein Pull-Request-Template — `.github/` enthielt ausschließlich `workflows/`. Dieser PR füllt alle drei Lücken in einem zusammenhängenden Setup-Schritt, damit Folge-Arbeit (insbesondere die v2.1.1-Hotfix-Items aus `docs/review/review_v2-1/consolidated_v2.1_task-list.md`) auf einer konsistenten Doku-Basis aufsetzt.

Drei atomare Commits, jeder unabhängig reviewbar:

1. `docs: add CLAUDE.md guide for Claude Code agents`
2. `docs(skills): add icap-flow-php agent skill suite`
3. `chore: add pull request template`

## API

none — reine Doku- und Tooling-Änderung. Keine Datei in `src/` oder `tests/` angefasst, kein BC-Impact.

## Behaviour

- Zukünftige PRs werden automatisch mit dem neuen Template vorgeblendet (Sektionen `Context / API / Behaviour / Refactoring / Tests / Verification / Status` plus Quality-Gate-Checkliste und optionalem Roadmap-Verweis).
- `CLAUDE.md` wird beim Start jeder Claude-Code-Session in dieser Repo geladen und definiert verbindlich Architektur-Invarianten (Fail-Secure-Auswertung in `IcapClient::interpretResponse()`, `executeRaw()` ist intern, Strict-§4.5 nur über `SessionAwareTransport`, Header-/URI-Validation am Boundary), Konventionen (PHP 8.4, PHPStan Level 9 + bleedingEdge, EUPL-Header, Pest-Suite-Layout) und Commit-/PR-Regeln (Conventional Commits 1.0 mit Pflicht-Body, keine Generator-Footer, kein `--no-verify`).
- Das Skill-Bundle unter `.claude/skills/icap-flow-php/` aktiviert sich kontextuell bei PHP/ICAP/amphp/Pest/Symfony-7.4-Anfragen und routet in sechs Reference-Files für PHP-8.4/8.5-Features, SOLID-/TDD-Architektur an dieser Codebase, amphp-v3-Async-Patterns, icap-flow-spezifische Invarianten, Pest-3-Testing und das geplante v2.3.0-Symfony-Bundle.

## Refactoring

none.

## Tests

none — keine Code-Änderungen, also keine neuen Tests. Das Skill-Bundle und CLAUDE.md verweisen ausführlich auf die existierenden Suites (`tests/Wire/`, `tests/Transport/`, `tests/Security/`, `tests/Integration/`) und die Coverage-Hotspots aus Jules' v2.1-Audit (Item #18 der konsolidierten Task-Liste).

## Verification

- [x] `composer cs-check` — sollte clean bleiben (keine PHP-Dateien geändert)
- [x] `composer stan` — sollte clean bleiben (keine PHP-Dateien geändert)
- [x] `composer test` — sollte unverändert grün sein (91 passed)
- [x] `composer test:integration` — nicht betroffen
- [x] CI-Matrix (PHP 8.4 + 8.5) — wird durch den Push ausgelöst

## Status

Nach Merge ist die Onboarding-Foundation gesetzt. Folge-PRs in absteigender Priorität laut konsolidierter v2.1-Task-Liste:

- **v2.1.1 P0**: `AmpConnectionPool::key()` um TLS-Context-Fingerprint erweitern (Item #2, 4/4 Reviewer — Cross-Tenant-TLS-Leakage).
- **v2.1.1 P0**: `DefaultPreviewStrategy` um 200/206-Branch erweitern (Item #3, 3/4 Reviewer — Virus-Treffer im Preview kommen heute als uncatchable Exception).
- **v2.1.1 P0**: `SECURITY.md:73-75` Stale-Claims entfernen (Item #1).
- **v2.1.1 P1/P2**: Cookbook- und Phpdoc-Korrekturen (Items #4–#6).

Beide P0-Bugs sind sicherheits- bzw. korrektheitsrelevant und rechtfertigen einen schnellen v2.1.1-Hotfix-Release nach Merge dieses Setup-PRs.