### PR TITLE
docs(review): consolidated v2.1 task list from four independent audits

### DIFF
--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -1,149 +1,308 @@
-# Plan: Nächste Todos aus den v2.1-Reviews ableiten
+# Konsolidierte Task-Liste — v2.1.x / v2.2.0 Findings & Roadmap
 
-## Context
-
-`docs/review/review_v2-1/` (Commit `84e5a99` auf `main`) enthält vier
-unabhängige Deep-Research-Audits zu icap-flow v2.1.0:
-
-- `claude_deep-research-audit-icap-flow-v2.1.0.md`
-- `codex_deep-research-v2.1.0-audit.md`
-- `codex_v2.1.0-production-readiness-audit-2026-04-25.md`
-- `jules_deep_research_report_2-1.md`
-
-Die vier Reviewer landen mit Scores zwischen 74 und 77/100 bei TRL-7-Konsens.
-v2.1.0 ist „mit Einschränkungen produktionstauglich" für Single-Tenant — aber
-Multi-Tenant ist durch die Pool-Key-TLS-Kollision **blockiert**, und die
-Default-Preview-Strategie verschluckt Virus-Treffer als uncatchable Exception.
-Beide Punkte rechtfertigen einen schnellen v2.1.1-Hotfix vor allem anderen.
-
-Diese Plan-Datei sortiert die in der Konsolidierung identifizierten Findings
-nach Release-Milestone, ordnet jeden Punkt seinen Reviewer-Quellen zu und
-nennt die kritischen Dateien.
-
-## Entscheidungen (aus Klärungsdialog)
-
-1. **Release-Kadenz**: v2.1.1 zuerst (Critical-Hotfix), v2.1.2 für CI-Quality,
-   v2.2.0 als additives Minor, v2.3.0 in separatem Bundle-Repo,
-   v3.0.0 sammelt BC-Breaks.
-2. **`options()`-Korrektur**: BC-Break direkt — `options()` wechselt zu
-   `Future<IcapResponse>` in v3.0.0. Kein additives `optionsRaw()` als
-   Brücke. Das verschiebt **Items, die auf `optionsRaw()` aufbauten**
-   (Preview-Size-Negotiation, Max-Connections-Auto-Tune) auf einen internen
-   Pfad in v2.2 (lib-intern via OPTIONS-Cache, nicht über `optionsRaw()`).
-3. **Symfony-Bundle**: separates Repo `ndrstmr/icap-flow-bundle`,
-   eigener Release-Zyklus, keine Monorepo-Aufnahme.
-4. **Deliverable nach Plan-Approval**: (c) GitHub-Issues für jeden
-   P0/P1-Punkt erstellen **und** (a) `consolidated_v2.1_task-list.md`
-   im Repo anlegen.
-
-## Korrekturen gegenüber Roh-Synthese
-
-- **Strict-§4.5-Streaming-Bug ist 3/4, nicht 4/4** (Jules hat ihn nicht
-  erfasst).
-- **Jules' Header-Array-Validation-Befund ist faktisch falsch** —
-  `IcapClient::validateIcapHeaders()` Z. 606-612 iteriert per
-  `foreach ((array) $value as $v)` über jeden Array-Eintrag. **Nicht
-  in den Plan aufnehmen.**
-- **Konkrete Coverage-Hotspots aus Jules** (Gesamt 82.4 %):
-  - `AmpConnectionPool` 54 %
-  - `SynchronousStreamTransport` 41 %
-  - Async-Socket-Error-Handling 63 %
-  → liefern messbares Coverage-Gate für v2.2.
+> **Basis:** Synthese der vier unabhängigen Deep-Research-Audits zu v2.1.0
+> in `docs/review/review_v2-1/` (Claude, Codex ×2, Jules), verifiziert am
+> `src/`-Stand bei Commit `84e5a99`.
+>
+> **Scores (auf 100 normiert):** Claude 74, Codex-DR 77, Codex-PR 77, Jules 74
+> — Mittel **76/100, TRL-7-Konsens.**
+> v2.1.0 ist produktionstauglich für Single-Tenant; Multi-Tenant ist durch die
+> Pool-Key-TLS-Kollision **blockiert** (Finding #2 unten).
+>
+> **Archiv:** Die ursprüngliche Plan-Export-Version steht in
+> `consolidated_v2.1_task-list_plan-export.md`.
 
 ---
 
-## v2.1.1 — Critical Hotfix (2-3 Tage, kein BC-Break)
+## Reviewer-Konsens-Matrix
 
-Zweck: Sicherheits- und Korrektheits-Regressionen schließen, die im Feld
-heute schon Schaden anrichten können. Alle Items konsens-relevant oder
-eindeutige Bugs.
+| Finding | Claude | Codex-DR | Codex-PR | Jules | Konsens |
+|---|---|---|---|---|---|
+| Pool-Key TLS-Context-Collision | P0 | P0 | P1 | P0 | **4/4 P0** |
+| DefaultPreviewStrategy wirft auf 200/206 | P0 | P1 | P1 | — | 3/4 P0/P1 |
+| Strict-Preview `stream_get_contents` OOM | P1 | P1 | P1 | — | **3/4 P1** |
+| OPTIONS-driven Preview-Size-Negotiation | P1 | P1 | P1 | P1 | **4/4 P1** |
+| OPTIONS-driven Max-Connections für Pool | P1 | P1 | P1 | P1 | **4/4 P1** |
+| Mutation-Testing wieder in CI | P1 | P1 | P1 | P1 | **4/4 P1** |
+| Integration-CI `continue-on-error: true` | P1 | P1 | P1 | — | 3/4 P1 |
+| OpenTelemetry-Decorator | P2 | P2 | P2 | P2 | **4/4 P2** |
+| Pool-Idle-Eviction (max-idle-age) | P2 | P2 | P2 | P2 | **4/4 P2** |
+| PSR-6/16 Cache-Adapter | P2 | — | P2 | P2 | 3/4 P2 |
+| PHPBench-Suite | P3 | P2 | P2 | — | 3/4 P2 |
+| Symfony-Bundle (separates Repo) | P1 | P1 | P1 | P1 | **4/4 P1** |
+| SECURITY.md v2.0-stale | P0 | — | — | P0 | 2/4 P0 |
+| `ConnectionPoolInterface` Phpdoc → `NullConnectionPool` | P1 | P1 | — | — | 2/4 P1 |
+| `IcapResponseException` Deprecation unklar | P1 | P1 | — | — | 2/4 P1 |
+| `executeRaw()` public / nicht im Interface | P1 | P1 | — | — | 2/4 P1 |
+| `options()` liefert `ScanResult` statt `IcapResponse` | P1 | P1 | — | — | 2/4 P1 |
+| `failOnRisky=false` / 3 risky Unit-Tests | — | — | P2 | — | Codex-PR |
+| PHPStan CI Memory-Limit | — | P2 | — | — | Codex-DR |
 
-| # | Sev | Titel | Datei(en) | Quelle |
-|---|---|---|---|---|
-| 1 | P0 | SECURITY.md Z. 73-75 aktualisieren — Cache/Pool/Retry sind seit v2.0/2.1 implementiert | `SECURITY.md:73-75` | Claude, Jules |
-| 2 | P0 | `AmpConnectionPool::key()` um TLS-Context-Fingerprint erweitern (Übergang: `spl_object_hash($tls)`; deterministischer Hash später in v2.2) + Cross-TLS-Isolation-Test | `src/Transport/AmpConnectionPool.php:130-133`, `tests/Transport/AmpConnectionPoolTest.php` | 4/4 |
-| 3 | P0 | `DefaultPreviewStrategy` für 200/206 erweitern: Virus-Header → `ABORT_INFECTED`, sonst `ABORT_CLEAN`. Macht den toten Branch in `IcapClient.php:388` erreichbar | `src/DefaultPreviewStrategy.php:35-42`, `tests/DefaultPreviewStrategyTest.php` | Claude, Codex, Jules |
-| 4 | P1 | Phpdoc-Verweis auf `NullConnectionPool` korrigieren (Klasse erst in v2.2 anlegen, hier nur Phpdoc-Drop) | `src/Transport/ConnectionPoolInterface.php:36` | Codex |
-| 5 | P1 | Cookbook `03-options-request.php` Z. 11-13: „next milestone after v2.0.0"-Stale-Claim entfernen | `examples/cookbook/03-options-request.php` | Claude |
-| 6 | P2 | Cookbook `02-custom-preview-strategy.php`: McAfee-Strategy korrigieren (200-Verhalten + Virus-Header-Inspektion zeigen, Caveat zum Anti-Pattern ergänzen) | `examples/cookbook/02-custom-preview-strategy.php` | Claude |
-
-**Abhängigkeiten:** Item 2 und Cross-TLS-Test im selben PR. Item 3 inkl. Test
-für `200 + X-Virus-Name` Antwort.
-
-**Release-Notes:** Security-Advisory für Item 2 (Cross-Tenant-Leakage,
-CVE-würdig für Multi-Tenant-Deployments), Bug-Fix-Note für Item 3.
-
----
-
-## v2.1.2 — CI-Quality-Patch (1 Woche, kein BC-Break)
-
-Zweck: Streaming-Bug + CI-Hygiene; bewusst getrennt von v2.1.1, damit der
-Hotfix klein und reviewbar bleibt.
-
-| # | Sev | Titel | Datei(en) | Quelle |
-|---|---|---|---|---|
-| 7 | P1 | Strict-§4.5-Streaming-Fix: `stream_get_contents()` durch `ChunkedBodyEncoder::encodeRemainderFromStream($stream)` ersetzen + Memory-Watermark-Test | `src/IcapClient.php:399`, `src/ChunkedBodyEncoder.php`, `tests/PreviewContinueStrictTest.php` | Claude, Codex×2 (3/4) |
-| 8 | P2 | 3 risky Tests im Unit-Run entkernen, dann `failOnRisky=true` + `failOnWarning=true` | `phpunit.xml.dist` | Codex-PR |
-| 9 | P2 | PHPStan CI Memory-Limit-Stabilisierung (`composer stan` mit `--memory-limit=1G`) | `composer.json`, `.github/workflows/ci.yml:43` | Codex-DR |
+> **Korrektur:** Jules' Befund „Header-Array-Werte werden nicht tief validiert"
+> ist **faktisch falsch** — `IcapClient::validateIcapHeaders()` Z. 606-612
+> iteriert via `foreach ((array) $value as $v)` über jeden Eintrag.
+> Dieser Punkt ist **nicht** in die Task-Liste aufgenommen.
 
 ---
 
-## v2.2.0 — Minor (4-6 Wochen, additiv)
+## Verifizierte Findings
 
-Zweck: Funktionale Lücken schließen, Observability + Test-Reife heben.
-Alle Items additiv (kein BC-Break).
-
-### OPTIONS-getriebene Pool-/Preview-Tuning (intern, ohne API-Bruch)
-
-| # | Sev | Titel | Datei(en) | Quelle |
+| ID | Finding | Schweregrad | Code-Nachweis | Quelle |
 |---|---|---|---|---|
-| 10 | P1 | OPTIONS-driven Preview-Size: `scanFileWithPreview()` ohne `$previewSize` befragt OPTIONS-Cache und nutzt Server-`Preview`-Header | `src/IcapClient.php:269-322`, `src/Cache/InMemoryOptionsCache.php` | 4/4 |
-| 11 | P1 | Max-Connections aus OPTIONS für Pool-Cap: `effectiveCap = min(localCap, serverMaxConnections)` (intern, opt-in via `Config::autoTunePoolFromOptions`) | `src/Transport/AmpConnectionPool.php:106-110`, `src/Config.php` | 4/4 |
-| 12 | P2 | OPTIONS-Cache ISTag-Invalidation (`OptionsCacheInterface` um `?string $istag` erweitern) | `src/Cache/InMemoryOptionsCache.php`, `src/Cache/OptionsCacheInterface.php` | Claude |
-| 13 | P2 | PSR-20 `ClockInterface` in `InMemoryOptionsCache` (deterministische TTL-Tests) | `src/Cache/InMemoryOptionsCache.php` | Claude |
-| 14 | P2 | `NullConnectionPool` jetzt anlegen (für explizite Pool-Off-Konfigs + Tests) | `src/Transport/NullConnectionPool.php` (neu) | Codex |
-| 15 | P2 | PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps | `src/Cache/Psr16OptionsCache.php`, `src/Cache/Psr6OptionsCache.php` | 3/4 |
+| A | Pool-Key ignoriert TLS-Context-Unterschiede → Cross-Tenant-Socket-Reuse | Security P0 | `Transport/AmpConnectionPool.php:130-133` | 4/4 |
+| B | `DefaultPreviewStrategy` wirft `IcapResponseException` auf 200/206 → ABORT_INFECTED-Branch unerreichbar | Bug P0/P1 | `DefaultPreviewStrategy.php:37-41`, `IcapClient.php:388` | Claude, Codex ×2 |
+| C | `SECURITY.md` Z. 73-75 behauptet: kein Retry, kein Cache, kein Pooling — alles seit v2.0/2.1 implementiert | Doku P0 | `SECURITY.md:73-75` | Claude, Jules |
+| D | `scanFileWithPreviewStrict()` lädt Body-Remainder via `stream_get_contents()` in RAM → OOM bei GB-Uploads | OOM P1 | `IcapClient.php:399` | Claude, Codex ×2 |
+| E | `ConnectionPoolInterface` Phpdoc referenziert nicht-existente `NullConnectionPool`-Klasse | Doku/Code P1 | `Transport/ConnectionPoolInterface.php:36` | Codex |
+| F | `IcapResponseException` ist `@deprecated since 2.0, removal in M2` — M2 ist released, Klasse im Hot-Path | Inkonsistenz P1 | `Exception/IcapResponseException.php:28-32` | Claude, Codex |
+| G | Cookbook `03-options-request.php` Z. 11-13: „next milestone after v2.0.0" — v2.0 ist released | Doku P1 | `examples/cookbook/03-options-request.php:11-13` | Claude |
+| H | Cookbook `02-custom-preview-strategy.php`: McAfee-Strategy mappt 200 → `ABORT_CLEAN` (Anti-Pattern, lehrt unsicheres Muster) | Doku P2 | `examples/cookbook/02-custom-preview-strategy.php` | Claude |
+| I | `phpunit.xml.dist`: `failOnRisky=false` + `failOnWarning=false`; 3 risky Tests im Unit-Run | CI P2 | `phpunit.xml.dist` | Codex-PR |
+| J | PHPStan-CI setzt kein `--memory-limit` → lokale OOM möglich | Tooling P2 | `.github/workflows/ci.yml:43` | Codex-DR |
+| K | OPTIONS-Cache `Preview`-Header wird nicht genutzt → Caller muss `$previewSize` manuell setzen | RFC P1 | `IcapClient.php:269-322` | 4/4 |
+| L | OPTIONS-Cache `Max-Connections` wird nicht für Pool-Cap genutzt | RFC P1 | `Transport/AmpConnectionPool.php:106-110` | 4/4 |
+| M | Mutation-Testing-Job aus CI entfernt — kein MSI-Gate auf PRs | Testing P1 | `.github/workflows/ci.yml:130-135` | 4/4 |
+| N | Integration-CI `continue-on-error: true` → Wire-Format-Regressionen bleiben unerkannt | CI P1 | `.github/workflows/ci.yml:63` | 3/4 |
+| O | Coverage-Hotspots: `AmpConnectionPool` 54 %, `SynchronousStreamTransport` 41 %, Socket-Error-Handling 63 % | Testing P1 | — | Jules |
+| P | Strict-§4.5-Path nutzt eine Session-Lifetime-Cancellation statt per-IO | Korrektheit P2 | `Transport/AsyncAmpTransport.php:111-114` | Claude |
+| Q | Pool ohne Idle-Eviction → langlebige Workers akkumulieren Stale-Connections | Robustheit P2 | `Transport/AmpConnectionPool.php:42-46` | 4/4 |
+| R | obs-fold (RFC 7230) im `Encapsulated`-Header wird im Framer nicht erkannt | RFC P2 | `Transport/ResponseFrameReader.php:144-153` | Claude, Codex |
+| S | Header-Name-Validation-Regex lässt RFC-7230-§3.2.6 Separator-Tokens durch | Security P2 | `IcapClient.php:601` | Claude |
+| T | OPTIONS-Cache ohne ISTag-Invalidation — Signature-Update wird nicht erkannt | RFC P2 | `Cache/InMemoryOptionsCache.php` | Claude |
+| U | `InMemoryOptionsCache` nutzt `time()` direkt, kein PSR-20 `ClockInterface` | Testbarkeit P2 | `Cache/InMemoryOptionsCache.php:92-94` | Claude |
+| V | `IcapClient::executeRaw()` ist `public` aber nicht im Interface — leakt internen Pfad | API P1 | `IcapClient.php:144` | Claude, Codex |
+| W | `options()` gibt `Future<ScanResult>` zurück — semantisch falsch (keine infected/clean Semantik) | API P1 | `IcapClient.php:157` | Claude, Codex |
+| X | Kein PSR-6/16 Cache-Adapter für OPTIONS-Cache | Erweiterbarkeit P2 | — | 3/4 |
+| Y | Kein OpenTelemetry-Decorator | Observability P2 | — | 4/4 |
+| Z | Kein PHPBench-Suite | Performance P2 | — | 3/4 |
+| Z1 | Symfony-Bundle fehlt vollständig | Ökosystem P1 | — | 4/4 |
+
+---
+
+## Release-Plan
+
+```
+v2.1.1  Critical Hotfix     kein BC    2–3 Tage   Findings A, B, C, E, G, H
+v2.1.2  CI-Quality-Patch    kein BC    1 Woche    Findings D, I, J
+v2.2.0  Minor (additiv)     kein BC    4–6 Wochen Findings K–Z
+v2.3.0  Symfony-Bundle      neues Repo 8–12 Wochen Findings Z1
+v3.0.0  Major (BC-Breaks)   BC         ~6 Monate  Findings F, V, W
+```
+
+---
+
+## Milestone v2.1.1 — Critical Hotfix
+
+**Scope:** Sicherheits- und Korrektheits-Regressionen, die im Feld sofort
+schaden können. Kein BC-Break.
+
+**PR-Vorschlag:** `fix(v2.1): TLS pool-key isolation, preview 200/206 verdict, stale SECURITY.md`
+
+- [ ] **v2.1.1-A** `AmpConnectionPool::key()` um TLS-Context-Fingerprint erweitern.
+  Übergang: `spl_object_hash($tls)` als Suffix; deterministischer Hash (z.B.
+  SHA-256 über Peer-Name + Cert-Path + CA-File) in v2.2 folgen.
+  **+ Cross-TLS-Isolation-Test in `tests/Transport/AmpConnectionPoolTest.php`**
+  (muss vor dem Fix rot sein).
+  *Datei: `src/Transport/AmpConnectionPool.php:130-133` — Quelle: 4/4*
+
+- [ ] **v2.1.1-B** `DefaultPreviewStrategy::handlePreviewResponse()` für
+  200/206 erweitern: Virus-Header vorhanden → `ABORT_INFECTED`,
+  sonst → `ABORT_CLEAN`. Macht den toten Branch in `IcapClient.php:388`
+  erreichbar. **+ Test `200 + X-Virus-Name: Eicar-Test`** in
+  `tests/DefaultPreviewStrategyTest.php`.
+  *Dateien: `src/DefaultPreviewStrategy.php:35-42` — Quelle: Claude, Codex ×2*
+
+- [ ] **v2.1.1-C** `SECURITY.md` Z. 73-75 aktualisieren: „does not retry /
+  cache / pool" durch aktuelle Aussagen zu `RetryingIcapClient`,
+  `InMemoryOptionsCache` und `AmpConnectionPool` ersetzen. Hinweis auf
+  TLS-Pool-Key-Fix ergänzen.
+  *Datei: `SECURITY.md:73-75` — Quelle: Claude, Jules*
+
+- [ ] **v2.1.1-E** Phpdoc-Verweis auf `NullConnectionPool` aus
+  `ConnectionPoolInterface.php:36` entfernen (Klasse folgt in v2.2).
+  *Datei: `src/Transport/ConnectionPoolInterface.php:36` — Quelle: Codex*
+
+- [ ] **v2.1.1-G** Cookbook `03-options-request.php` Z. 11-13:
+  „next milestone after v2.0.0"-Stale-Claim entfernen.
+  *Datei: `examples/cookbook/03-options-request.php` — Quelle: Claude*
+
+- [ ] **v2.1.1-H** Cookbook `02-custom-preview-strategy.php`:
+  McAfee-Strategy korrigieren — 200-Antwort mit Virus-Header richtig
+  behandeln, Caveat zum Anti-Pattern ergänzen.
+  *Datei: `examples/cookbook/02-custom-preview-strategy.php` — Quelle: Claude*
+
+**Abhängigkeiten:** v2.1.1-A + Cross-TLS-Test im selben Commit.
+v2.1.1-B inkl. Test für `200 + Virus-Header`.
+**Security-Advisory** für Finding A erforderlich (Cross-Tenant-Leakage,
+CVE-würdig in Multi-Tenant-Deployments).
+
+---
+
+## Milestone v2.1.2 — CI-Quality-Patch
+
+**Scope:** Streaming-OOM-Fix + CI-Hygiene. Bewusst getrennt von v2.1.1,
+damit der Hotfix klein und eigenständig reviewbar bleibt. Kein BC-Break.
+
+**PR-Vorschlag:** `fix(v2.1): streaming remainder, failOnRisky, PHPStan memory-limit`
+
+- [ ] **v2.1.2-D** `IcapClient::scanFileWithPreviewStrict()` Z. 399:
+  `stream_get_contents($stream)` durch neue Methode
+  `ChunkedBodyEncoder::encodeRemainderFromStream(resource $stream): iterable<string>`
+  ersetzen (liest in bounded Chunks, puffert keinen vollständigen Body).
+  Referenzimplementierung: `scanFileWithPreviewLegacy()` ab Z. 426.
+  **+ Memory-Watermark-Test** in `tests/PreviewContinueStrictTest.php`
+  (2-GB-Stream, `memory_limit=128M`).
+  *Dateien: `src/IcapClient.php:399`, `src/ChunkedBodyEncoder.php` — Quelle: Claude, Codex ×2*
+
+- [ ] **v2.1.2-I** 3 risky Unit-Tests entkernen (fehlende Assertions ergänzen
+  oder explizit als `markTestIncomplete`), dann `failOnRisky="true"` +
+  `failOnWarning="true"` in `phpunit.xml.dist` setzen.
+  *Datei: `phpunit.xml.dist` — Quelle: Codex-PR*
+
+- [ ] **v2.1.2-J** `composer stan`-Skript um `--memory-limit=1G` ergänzen;
+  CI-Job in `.github/workflows/ci.yml:43` entsprechend anpassen.
+  *Dateien: `composer.json`, `.github/workflows/ci.yml:43` — Quelle: Codex-DR*
+
+---
+
+## Milestone v2.2.0 — Minor (additiv)
+
+**Scope:** Funktionale Lücken schließen, Observability + Test-Reife heben.
+Alle Items additiv; kein BC-Break.
+
+### OPTIONS-getriebenes Pool-/Preview-Tuning
+
+- [ ] **v2.2-K** OPTIONS-driven Preview-Size: `scanFileWithPreview()` ohne
+  expliziten `$previewSize`-Parameter befragt den OPTIONS-Cache und nutzt
+  den Server-`Preview`-Header-Wert. Intern über bestehendes
+  `OptionsCacheInterface` — kein neues Public-API nötig.
+  *Datei: `src/IcapClient.php:269-322` — Quelle: 4/4*
+
+- [ ] **v2.2-L** Max-Connections aus OPTIONS für Pool-Cap:
+  `effectiveCap = min(localCap, serverMaxConnections)`,
+  opt-in via `Config::withAutoTunePoolFromOptions(bool)`.
+  *Dateien: `src/Transport/AmpConnectionPool.php:106-110`, `src/Config.php` — Quelle: 4/4*
+
+- [ ] **v2.2-T** OPTIONS-Cache ISTag-Invalidation:
+  `OptionsCacheInterface` um `?string $istag`-Parameter erweitern;
+  `InMemoryOptionsCache` eviktet den Eintrag bei ISTag-Wechsel.
+  *Dateien: `src/Cache/OptionsCacheInterface.php`, `src/Cache/InMemoryOptionsCache.php` — Quelle: Claude*
+
+- [ ] **v2.2-U** PSR-20 `ClockInterface` als optionalen Konstruktor-Parameter
+  in `InMemoryOptionsCache` einführen; ermöglicht deterministische
+  TTL-Tests ohne `advanceClockForTesting()`.
+  *Datei: `src/Cache/InMemoryOptionsCache.php:92-94` — Quelle: Claude*
+
+- [ ] **v2.2-E2** `NullConnectionPool` anlegen:
+  implementiert `ConnectionPoolInterface`, jede `acquire()`-Anfrage
+  öffnet eine frische Verbindung, `release()` schließt sie.
+  Nützlich für explizite Pool-Off-Konfigs und Tests.
+  *Datei: `src/Transport/NullConnectionPool.php` (neu) — Quelle: Codex*
+
+- [ ] **v2.2-X** PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps:
+  `Cache/Psr16OptionsCache.php`, `Cache/Psr6OptionsCache.php`.
+  *Quelle: 3/4*
 
 ### CI-Härtung & Test-Reife
 
-| # | Sev | Titel | Datei(en) | Quelle |
-|---|---|---|---|---|
-| 16 | P1 | Mutation-Testing wieder als CI-Job (`composer mutation`, `--min=65`, kein `continue-on-error`) | `.github/workflows/ci.yml:130-135` | 4/4 |
-| 17 | P1 | Integration-CI aus `continue-on-error: true` herausführen (hartes Gate **oder** Nightly-Cron mit Required-Status) | `.github/workflows/ci.yml:63` | 3/4 |
-| 18 | P1 | Coverage-Push: `AmpConnectionPool` 54 → ≥90 %, `SynchronousStreamTransport` 41 → ≥85 %, Async-Socket-Error 63 → ≥85 %. Konkrete Fälle: Cross-TLS-Pool-Isolation (bereits in v2.1.1), Concurrent-Acquire-Race (Fiber), `0; ieof`-Recv-Pfad, Multi-Section-Encapsulated, Cancellation mid-write/mid-read/Composite, `Options-TTL=0`, `SynchronousIcapClient::scanFileWithPreview`, Logger-Sensitive-Header-Regression | `tests/Transport/`, `tests/Wire/`, `tests/CancellationTest.php`, `tests/SynchronousIcapClientTest.php`, `tests/LoggerIntegrationTest.php`, `tests/OptionsCacheTest.php` | Jules + Claude + Codex |
+- [ ] **v2.2-M** Mutation-Testing wieder als Required-CI-Job:
+  `composer mutation` (`--min=65`, kein `continue-on-error`).
+  Sollte früh im v2.2-Zyklus landen, damit Folge-PRs davon profitieren.
+  *Datei: `.github/workflows/ci.yml:130-135` — Quelle: 4/4*
+
+- [ ] **v2.2-N** Integration-CI aus `continue-on-error: true` herausführen:
+  entweder hartes Gate auf PRs oder Nightly-Workflow mit
+  Required-Status-Check. Nightly empfohlen wegen flaky ClamAV-Image.
+  *Datei: `.github/workflows/ci.yml:63` — Quelle: 3/4*
+
+- [ ] **v2.2-O** Coverage-Push auf Hotspot-Klassen. Ziele:
+  `AmpConnectionPool` 54 → ≥ 90 %, `SynchronousStreamTransport` 41 → ≥ 85 %,
+  Async-Socket-Error-Handling 63 → ≥ 85 %.
+  Konkrete fehlende Test-Cases:
+  - Cross-TLS-Pool-Isolation (bereits in v2.1.1, hier counted)
+  - Concurrent-Acquire-Race (Fiber)
+  - `0; ieof`-Recv-Pfad in `ResponseFrameReaderTest`
+  - Multi-Section Encapsulated (`req-hdr + res-hdr + req-body`)
+  - Cancellation mid-write / mid-read / Composite (Timeout + explizit)
+  - `Options-TTL=0` (kein-Caching-Pfad)
+  - `SynchronousIcapClient::scanFileWithPreview()`
+  - Logger Sensitive-Header-Regression
+  *Dateien: `tests/Transport/`, `tests/Wire/`, `tests/CancellationTest.php`,
+  `tests/SynchronousIcapClientTest.php`, `tests/LoggerIntegrationTest.php`,
+  `tests/OptionsCacheTest.php` — Quelle: Jules + Claude + Codex*
 
 ### Korrektheit & Robustheit
 
-| # | Sev | Titel | Datei(en) | Quelle |
-|---|---|---|---|---|
-| 19 | P2 | Strict-§4.5-Path: per-IO-Timeout-Reset statt Session-Lifetime-Timeout (oder Caveat dokumentieren) | `src/Transport/AsyncAmpTransport.php:111-114` | Claude |
-| 20 | P2 | Pool-Idle-Eviction mit `maxIdleAge` (Default 30 s) | `src/Transport/AmpConnectionPool.php:42-46` | 4/4 |
-| 21 | P2 | obs-fold (RFC 7230) im Encapsulated-Header beachten | `src/Transport/ResponseFrameReader.php:144-153` | Claude, Codex |
-| 22 | P2 | Header-Name-Validation strenger auf RFC-7230-§3.2.6-Token-Set | `src/IcapClient.php:601` | Claude |
+- [ ] **v2.2-P** Strict-§4.5-Path: per-IO-Timeout-Reset statt
+  Session-Lifetime-`TimeoutCancellation`. Alternativ: explizites Caveat
+  in Phpdoc + CHANGELOG.
+  *Datei: `src/Transport/AsyncAmpTransport.php:111-114` — Quelle: Claude*
+
+- [ ] **v2.2-Q** Pool-Idle-Eviction mit konfigurierbarem `maxIdleAge`
+  (Default 30 s): Beim `acquire()` abgelaufene Idle-Einträge verwerfen.
+  *Datei: `src/Transport/AmpConnectionPool.php:42-46` — Quelle: 4/4*
+
+- [ ] **v2.2-R** obs-fold (RFC 7230) im `Encapsulated`-Header:
+  `ResponseFrameReader::findEncapsulatedHeader()` faltet Continuation-Lines
+  vor dem Zeilenweise-Split auf.
+  *Datei: `src/Transport/ResponseFrameReader.php:144-153` — Quelle: Claude, Codex*
+
+- [ ] **v2.2-S** Header-Name-Validation auf RFC-7230-§3.2.6-Token-Set
+  verschärfen: `[!#$%&'*+\-.^_` + "`" + `|~0-9a-zA-Z]+`.
+  *Datei: `src/IcapClient.php:601` — Quelle: Claude*
 
 ### Doku & Tooling
 
-| # | Sev | Titel | Datei(en) | Quelle |
-|---|---|---|---|---|
-| 23 | P1 | 4 neue Cookbook-Files: TLS/mTLS, RetryingIcapClient, Pool-Tuning, External-Cancellation | `examples/cookbook/04-tls-mtls.php`, `…/05-retry-decorator.php`, `…/06-pool-tuning.php`, `…/07-cancellation-from-upload.php` | Claude, Codex |
-| 24 | P2 | Connection-Pool im Config-Block des README dokumentieren | `README.md:89-129` | Claude |
-| 25 | P2 | `docs/compliance.md` mit BSI OPS.1.1.4 / APP.4.4 / DSGVO-Mapping + AI-Disclaimer | `docs/compliance.md` (neu) | Claude |
-| 26 | P2 | DSGVO/Logging-Caveat in `SECURITY.md` und Logger-Phpdoc | `SECURITY.md`, `src/IcapClient.php` (Logger-Doku) | Jules |
-| 27 | P2 | CONTRIBUTING.md um Conventional-Commits-Konvention ergänzen | `CONTRIBUTING.md` | Claude |
-| 28 | P2 | OpenTelemetry-Decorator als Optional-Dep auf `open-telemetry/api` | `src/Tracing/OtelTracingIcapClient.php` (neu) | 4/4 |
-| 29 | P2 | PHPBench-Suite: Pool-Throughput, Strict-§4.5-Latency, Chunked-Encoder | `benchmarks/` (neu) | 3/4 |
-| 30 | P2 | SBOM (CycloneDX/SPDX) in CI | `.github/workflows/ci.yml` | Claude |
-| 31 | P3 | Property-based Tests für `ResponseParser` / `ResponseFrameReader` | `tests/Property/` (neu) | 3/4 |
-| 32 | P3 | Fuzz-Korpus für Parser | `tests/Fuzz/` (neu) | Claude |
-| 33 | P2 | `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit konkretem v3.0.0-Removal-Tag | `src/Exception/IcapResponseException.php:28-32` | Claude, Codex |
+- [ ] **v2.2-cookbook** 4 neue Cookbook-Files:
+  `04-tls-mtls.php`, `05-retry-decorator.php`,
+  `06-pool-tuning.php`, `07-cancellation-from-upload.php`.
+  *Dateien: `examples/cookbook/` — Quelle: Claude, Codex*
+
+- [ ] **v2.2-readme** Connection-Pool-Konfiguration im README-Config-Block
+  dokumentieren.
+  *Datei: `README.md:89-129` — Quelle: Claude*
+
+- [ ] **v2.2-compliance** `docs/compliance.md` mit BSI OPS.1.1.4 / APP.4.4 /
+  DSGVO Art. 32-Mapping + AI-Disclaimer-Verlinkung.
+  *Datei: `docs/compliance.md` (neu) — Quelle: Claude*
+
+- [ ] **v2.2-contrib** CONTRIBUTING.md um Conventional-Commits-Konvention
+  ergänzen (Typen, Scopes, Body-Pflicht).
+  *Datei: `CONTRIBUTING.md` — Quelle: Claude*
+
+- [ ] **v2.2-Y** OpenTelemetry-Decorator `OtelTracingIcapClient` als
+  Optional-Dep auf `open-telemetry/api`.
+  *Datei: `src/Tracing/OtelTracingIcapClient.php` (neu) — Quelle: 4/4*
+
+- [ ] **v2.2-Z** PHPBench-Suite: Pool-Throughput, Strict-§4.5-Latency,
+  Chunked-Encoder-Durchsatz.
+  *Verzeichnis: `benchmarks/` (neu) — Quelle: 3/4*
+
+- [ ] **v2.2-sbom** SBOM (CycloneDX/SPDX) in CI generieren.
+  *Datei: `.github/workflows/ci.yml` — Quelle: Claude*
+
+- [ ] **v2.2-F** `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit
+  konkretem `v3.0.0`-Removal-Tag setzen.
+  *Datei: `src/Exception/IcapResponseException.php:28-32` — Quelle: Claude, Codex*
+
+### P3 — Nice-to-Have
+
+- [ ] Property-based Tests für `ResponseParser` / `ResponseFrameReader`
+  (z.B. mit `eris-php`).
+  *Verzeichnis: `tests/Property/` (neu) — Quelle: 3/4*
+
+- [ ] Fuzz-Korpus für `ResponseParser` (PHPUnit-Data-Provider-basiert oder
+  nativer Fuzzer).
+  *Verzeichnis: `tests/Fuzz/` (neu) — Quelle: Claude*
 
 ---
 
-## v2.3.0 — Symfony-Bundle (8-12 Wochen, separates Repo)
+## Milestone v2.3.0 — Symfony-Bundle (separates Repo)
 
-Eigenes Repo `ndrstmr/icap-flow-bundle`, abhängig auf `^2.2`. Nicht Teil
-dieses Plans im Detail; Initial-Scope:
+**Scope:** Eigenes Repo `ndrstmr/icap-flow-bundle`, abhängig auf `^2.2`.
+Nicht Teil dieses Repos.
 
+Initial-Scope des neuen Repos:
 - `IcapFlowBundle` mit Configuration-Tree + `IcapFlowExtension`
 - Auto-DI: `IcapClientInterface` → `RetryingIcapClient` → inner `IcapClient`
 - Tagged-Services für Multi-Client (`icap_flow.client.<name>`)
@@ -154,112 +313,81 @@ dieses Plans im Detail; Initial-Scope:
 - Flex-Recipe für `symfony/recipes-contrib`
 - Adapter für VichUploaderBundle / OneupUploaderBundle
 
-Quelle: 4/4 Reviewer.
+*Quelle: 4/4. Blockiert auf v2.2.0-Release.*
 
 ---
 
-## v3.0.0 — Major (BC-Breaks gesammelt, nur falls erforderlich)
+## Milestone v3.0.0 — BC-Breaks (gesammelt)
 
-| # | Titel | Datei(en) | Quelle |
-|---|---|---|---|
-| 34 | `IcapClient::executeRaw()` → `protected` ODER ins Interface heben | `src/IcapClient.php:144`, `src/IcapClientInterface.php` | Claude, Codex |
-| 35 | `options()` direkt zu `Future<IcapResponse>` umstellen (entsprechend Entscheidung 2) | `src/IcapClient.php:157`, `src/IcapClientInterface.php`, `src/SynchronousIcapClient.php` | Claude, Codex |
-| 36 | `IcapResponseException` entfernen (Deprecation einlösen) | `src/Exception/IcapResponseException.php` + Call-Sites | Claude, Codex |
+Nur relevasen, wenn mindestens zwei der folgenden Punkte durch User-Feedback
+erzwungen werden.
 
-Trigger: erst wenn mind. zwei davon durch User-Feedback erzwungen werden.
+- [ ] **v3-V** `IcapClient::executeRaw()` → `protected` **oder** in
+  `IcapClientInterface` heben.
+  *Datei: `src/IcapClient.php:144`, `src/IcapClientInterface.php` — Quelle: Claude, Codex*
+
+- [ ] **v3-W** `options()` zu `Future<IcapResponse>` umstellen
+  (BC-Break direkt, kein additives `optionsRaw()`).
+  *Dateien: `src/IcapClient.php:157`, `src/IcapClientInterface.php`,
+  `src/SynchronousIcapClient.php` — Quelle: Claude, Codex*
+
+- [ ] **v3-F** `IcapResponseException` entfernen (Deprecation einlösen).
+  *Datei: `src/Exception/IcapResponseException.php` + alle Call-Sites — Quelle: Claude, Codex*
 
 ---
 
 ## Abhängigkeitskarte
 
-- **v2.1.1 #2 ↔ Cross-TLS-Test**: gleicher PR.
-- **v2.1.2 #7 ↔ Memory-Watermark-Test**: gleicher PR; läuft im CI unter
-  niedrigem `memory_limit`.
-- **v2.2 #10 + #11**: bauen auf bestehendem `OptionsCacheInterface` auf
-  (kein `optionsRaw()` nötig dank Entscheidung 2).
-- **v2.2 #12 ↔ #13**: zusammen mergen, sonst keine deterministische
-  ISTag-Test-Fixture.
-- **v2.2 #14**: blockiert keine anderen Items, entkoppelt das Phpdoc-Versprechen
-  aus v2.1.1.
-- **v2.2 #16** (Mutation-CI) sollte früh im v2.2-Zyklus landen, damit
-  Folge-PRs davon profitieren.
-- **v2.3 (Bundle)**: vollständig blockiert auf v2.2-Release (insbesondere
-  #14 NullConnectionPool und #28 Otel).
+| Item | Blockiert durch | Blockiert |
+|---|---|---|
+| v2.1.1-A | — | Cross-TLS-Test (gleicher PR) |
+| v2.1.2-D | v2.1.1 (Hotfix erst raus) | Memory-Watermark-Test (gleicher PR) |
+| v2.2-K + v2.2-L | v2.1.2 | v2.3 Bundle-DI-Config |
+| v2.2-T + v2.2-U | — | zusammen mergen für testbare Fixtures |
+| v2.2-E2 | — | v2.3 Bundle-DI-Default-Pool |
+| v2.2-M | v2.2-O (Coverage-Lücken zuerst schließen) | alle v2.2-Folge-PRs |
+| v2.2-Y | v2.2-E2 | v2.3 Bundle-Tracing |
+| v2.3 Bundle | v2.2.0-Release | — |
 
 ---
 
-## Kritische Dateien (Implementierungs-Hotspots)
+## Kritische Dateien
 
-- `src/Transport/AmpConnectionPool.php` — Pool-Key, Idle-Eviction, Max-Connections
-- `src/IcapClient.php` — Strict-§4.5-Path, OPTIONS-driven Preview-Size, Header-Validation
-- `src/DefaultPreviewStrategy.php` — 200/206-Branch
-- `src/Cache/InMemoryOptionsCache.php` — ISTag, PSR-20 Clock
-- `src/Transport/ConnectionPoolInterface.php` — Phpdoc, später `NullConnectionPool`
-- `src/Transport/AsyncAmpTransport.php` — Per-IO-Timeout
-- `src/Transport/ResponseFrameReader.php` — obs-fold
-- `src/Exception/IcapResponseException.php` — Deprecation-Status
-- `SECURITY.md` — Stale-Claims (v2.1.1 P0)
-- `examples/cookbook/02-…`, `…03-…` — Anti-Pattern-Korrektur
-- `.github/workflows/ci.yml` — Mutation-Job, Integration-Gate, SBOM
-
----
-
-## Wiederverwendung bestehender Bausteine
-
-- `OptionsCacheInterface` (`src/Cache/OptionsCacheInterface.php`) ist bereits
-  vorhanden und reicht für #10 + #11; `InMemoryOptionsCache` muss nur um Clock
-  und ISTag-Param erweitert werden.
-- `ChunkedBodyEncoder` (`src/ChunkedBodyEncoder.php`) hat bereits einen
-  `encode(string)` — die Streaming-Variante `encodeRemainderFromStream($resource)`
-  passt direkt daneben (Referenzpfad ist der existierende
-  `scanFileWithPreviewLegacy` in `IcapClient.php:426ff`, der schon korrekt
-  per `rewind() + resource` arbeitet).
-- Logger-Sensitive-Header-Logik existiert bereits — der fehlende Test
-  (#18) ist reine Regressions-Absicherung, kein neues Verhalten.
+| Datei | Betroffene Findings |
+|---|---|
+| `src/Transport/AmpConnectionPool.php` | A, L, Q |
+| `src/IcapClient.php` | B, D, K, S, V, W |
+| `src/DefaultPreviewStrategy.php` | B |
+| `src/Cache/InMemoryOptionsCache.php` | T, U |
+| `src/Cache/OptionsCacheInterface.php` | T |
+| `src/Transport/ConnectionPoolInterface.php` | E |
+| `src/Transport/AsyncAmpTransport.php` | P |
+| `src/Transport/ResponseFrameReader.php` | R |
+| `src/Exception/IcapResponseException.php` | F |
+| `src/IcapClientInterface.php` | V, W |
+| `SECURITY.md` | C |
+| `examples/cookbook/02-…` | H |
+| `examples/cookbook/03-…` | G |
+| `phpunit.xml.dist` | I |
+| `.github/workflows/ci.yml` | J, M, N |
 
 ---
 
-## Deliverables nach Plan-Approval
+## Verifizierung je Milestone
 
-1. **(c) GitHub-Issues** für jeden P0/P1-Punkt (insgesamt 11 Items: v2.1.1
-   #1-3, v2.1.2 #7, v2.2 #10-11, #16-18, #23, plus #4 als "good first issue").
-   Pro Issue: Reviewer-Quellen-Tabelle, Datei-Verweise, Akzeptanzkriterien,
-   Milestone-Label (`v2.1.1`, `v2.1.2`, `v2.2.0`).
-2. **(a) `docs/review/review_v2-1/consolidated_v2.1_task-list.md`** im Stil der
-   bestehenden `consolidated_task-list.md` aus v2.0. Inhalt: diese Plan-Datei
-   in Repo-tauglicher Form, ohne den Plan-Mode-Vorspann.
+**Nach v2.1.1:**
+- `composer test` grün; `AmpConnectionPoolTest::testCrossTlsIsolation` schlägt vor dem Fix fehl, danach grün.
+- `DefaultPreviewStrategyTest`: `200 + X-Virus-Name: Eicar-Test` → `ABORT_INFECTED`.
+- `SECURITY.md` Z. 73-75 beschreibt `RetryingIcapClient`, `InMemoryOptionsCache`, `AmpConnectionPool`.
+- Manuell gegen `docker compose up icap-clamav`: Eicar im 1-KiB-Preview → `ScanResult(isInfected=true)`, keine Exception.
 
-Beide Deliverables erfolgen auf dem Branch `claude/review-v2-1-feedback-k5kRX`
-(GitHub-Issues sind Repo-weit, der Branch hostet die Doku).
-
----
-
-## Verification
-
-Nach v2.1.1-Release:
-
-- `composer test` grün, neuer `AmpConnectionPoolTest::testCrossTlsIsolation`
-  schlägt **vor** dem Pool-Key-Fix fehl, **nach** dem Fix grün.
-- `DefaultPreviewStrategyTest::testInfectedDuringPreview` (mit fixiertem
-  `200 + X-Virus-Name: Eicar-Test`) liefert `ABORT_INFECTED`.
-- `SECURITY.md` Z. 73-75 referenziert `RetryingIcapClient`, `InMemoryOptionsCache`
-  und `AmpConnectionPool` als vorhandene Komponenten.
-- `examples/cookbook/03-options-request.php` enthält keinen "next milestone"-Text.
-- Manuell: ein Lauf gegen `docker compose up icap-clamav` mit dem
-  bekannten Eicar-Sample im 1-KiB-Preview liefert `ScanResult(isInfected=true)`
-  statt `IcapResponseException`.
-
-Nach v2.1.2-Release:
-
-- Memory-Watermark-Test mit 2-GB-Stream und `memory_limit=128M` (per
-  `php -d memory_limit=128M`) muss durchlaufen.
+**Nach v2.1.2:**
+- Memory-Watermark-Test: `php -d memory_limit=128M` mit 2-GB-Stream durch `scanFileWithPreviewStrict()` — kein OOM.
 - `composer test` mit `failOnRisky=true` + `failOnWarning=true` grün.
-- CI-PHPStan-Job läuft ohne OOM.
+- CI-PHPStan-Job ohne OOM.
 
-Nach v2.2-Release:
-
-- `composer mutation --min=65` als Required-Status auf PR-Branches.
-- Coverage-Report bestätigt `AmpConnectionPool` ≥ 90 %, `SynchronousStreamTransport`
-  ≥ 85 %, Async-Socket-Error ≥ 85 %.
-- Integration-CI ist Required-Status (oder Nightly mit Issue-on-Failure).
-- `phpbench run benchmarks/ --report=default` liefert Baseline-Zahlen.
+**Nach v2.2.0:**
+- `composer mutation --min=65` als Required-Status-Check auf PRs.
+- Coverage: `AmpConnectionPool` ≥ 90 %, `SynchronousStreamTransport` ≥ 85 %, Socket-Error ≥ 85 %.
+- Integration-CI als Required-Status (oder Nightly mit Issue-on-Failure).
+- `phpbench run benchmarks/ --report=default` liefert Baseline.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list_plan-export.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list_plan-export.md
@@ -1,0 +1,265 @@
+# Plan: Nächste Todos aus den v2.1-Reviews ableiten
+
+## Context
+
+`docs/review/review_v2-1/` (Commit `84e5a99` auf `main`) enthält vier
+unabhängige Deep-Research-Audits zu icap-flow v2.1.0:
+
+- `claude_deep-research-audit-icap-flow-v2.1.0.md`
+- `codex_deep-research-v2.1.0-audit.md`
+- `codex_v2.1.0-production-readiness-audit-2026-04-25.md`
+- `jules_deep_research_report_2-1.md`
+
+Die vier Reviewer landen mit Scores zwischen 74 und 77/100 bei TRL-7-Konsens.
+v2.1.0 ist „mit Einschränkungen produktionstauglich" für Single-Tenant — aber
+Multi-Tenant ist durch die Pool-Key-TLS-Kollision **blockiert**, und die
+Default-Preview-Strategie verschluckt Virus-Treffer als uncatchable Exception.
+Beide Punkte rechtfertigen einen schnellen v2.1.1-Hotfix vor allem anderen.
+
+Diese Plan-Datei sortiert die in der Konsolidierung identifizierten Findings
+nach Release-Milestone, ordnet jeden Punkt seinen Reviewer-Quellen zu und
+nennt die kritischen Dateien.
+
+## Entscheidungen (aus Klärungsdialog)
+
+1. **Release-Kadenz**: v2.1.1 zuerst (Critical-Hotfix), v2.1.2 für CI-Quality,
+   v2.2.0 als additives Minor, v2.3.0 in separatem Bundle-Repo,
+   v3.0.0 sammelt BC-Breaks.
+2. **`options()`-Korrektur**: BC-Break direkt — `options()` wechselt zu
+   `Future<IcapResponse>` in v3.0.0. Kein additives `optionsRaw()` als
+   Brücke. Das verschiebt **Items, die auf `optionsRaw()` aufbauten**
+   (Preview-Size-Negotiation, Max-Connections-Auto-Tune) auf einen internen
+   Pfad in v2.2 (lib-intern via OPTIONS-Cache, nicht über `optionsRaw()`).
+3. **Symfony-Bundle**: separates Repo `ndrstmr/icap-flow-bundle`,
+   eigener Release-Zyklus, keine Monorepo-Aufnahme.
+4. **Deliverable nach Plan-Approval**: (c) GitHub-Issues für jeden
+   P0/P1-Punkt erstellen **und** (a) `consolidated_v2.1_task-list.md`
+   im Repo anlegen.
+
+## Korrekturen gegenüber Roh-Synthese
+
+- **Strict-§4.5-Streaming-Bug ist 3/4, nicht 4/4** (Jules hat ihn nicht
+  erfasst).
+- **Jules' Header-Array-Validation-Befund ist faktisch falsch** —
+  `IcapClient::validateIcapHeaders()` Z. 606-612 iteriert per
+  `foreach ((array) $value as $v)` über jeden Array-Eintrag. **Nicht
+  in den Plan aufnehmen.**
+- **Konkrete Coverage-Hotspots aus Jules** (Gesamt 82.4 %):
+  - `AmpConnectionPool` 54 %
+  - `SynchronousStreamTransport` 41 %
+  - Async-Socket-Error-Handling 63 %
+  → liefern messbares Coverage-Gate für v2.2.
+
+---
+
+## v2.1.1 — Critical Hotfix (2-3 Tage, kein BC-Break)
+
+Zweck: Sicherheits- und Korrektheits-Regressionen schließen, die im Feld
+heute schon Schaden anrichten können. Alle Items konsens-relevant oder
+eindeutige Bugs.
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 1 | P0 | SECURITY.md Z. 73-75 aktualisieren — Cache/Pool/Retry sind seit v2.0/2.1 implementiert | `SECURITY.md:73-75` | Claude, Jules |
+| 2 | P0 | `AmpConnectionPool::key()` um TLS-Context-Fingerprint erweitern (Übergang: `spl_object_hash($tls)`; deterministischer Hash später in v2.2) + Cross-TLS-Isolation-Test | `src/Transport/AmpConnectionPool.php:130-133`, `tests/Transport/AmpConnectionPoolTest.php` | 4/4 |
+| 3 | P0 | `DefaultPreviewStrategy` für 200/206 erweitern: Virus-Header → `ABORT_INFECTED`, sonst `ABORT_CLEAN`. Macht den toten Branch in `IcapClient.php:388` erreichbar | `src/DefaultPreviewStrategy.php:35-42`, `tests/DefaultPreviewStrategyTest.php` | Claude, Codex, Jules |
+| 4 | P1 | Phpdoc-Verweis auf `NullConnectionPool` korrigieren (Klasse erst in v2.2 anlegen, hier nur Phpdoc-Drop) | `src/Transport/ConnectionPoolInterface.php:36` | Codex |
+| 5 | P1 | Cookbook `03-options-request.php` Z. 11-13: „next milestone after v2.0.0"-Stale-Claim entfernen | `examples/cookbook/03-options-request.php` | Claude |
+| 6 | P2 | Cookbook `02-custom-preview-strategy.php`: McAfee-Strategy korrigieren (200-Verhalten + Virus-Header-Inspektion zeigen, Caveat zum Anti-Pattern ergänzen) | `examples/cookbook/02-custom-preview-strategy.php` | Claude |
+
+**Abhängigkeiten:** Item 2 und Cross-TLS-Test im selben PR. Item 3 inkl. Test
+für `200 + X-Virus-Name` Antwort.
+
+**Release-Notes:** Security-Advisory für Item 2 (Cross-Tenant-Leakage,
+CVE-würdig für Multi-Tenant-Deployments), Bug-Fix-Note für Item 3.
+
+---
+
+## v2.1.2 — CI-Quality-Patch (1 Woche, kein BC-Break)
+
+Zweck: Streaming-Bug + CI-Hygiene; bewusst getrennt von v2.1.1, damit der
+Hotfix klein und reviewbar bleibt.
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 7 | P1 | Strict-§4.5-Streaming-Fix: `stream_get_contents()` durch `ChunkedBodyEncoder::encodeRemainderFromStream($stream)` ersetzen + Memory-Watermark-Test | `src/IcapClient.php:399`, `src/ChunkedBodyEncoder.php`, `tests/PreviewContinueStrictTest.php` | Claude, Codex×2 (3/4) |
+| 8 | P2 | 3 risky Tests im Unit-Run entkernen, dann `failOnRisky=true` + `failOnWarning=true` | `phpunit.xml.dist` | Codex-PR |
+| 9 | P2 | PHPStan CI Memory-Limit-Stabilisierung (`composer stan` mit `--memory-limit=1G`) | `composer.json`, `.github/workflows/ci.yml:43` | Codex-DR |
+
+---
+
+## v2.2.0 — Minor (4-6 Wochen, additiv)
+
+Zweck: Funktionale Lücken schließen, Observability + Test-Reife heben.
+Alle Items additiv (kein BC-Break).
+
+### OPTIONS-getriebene Pool-/Preview-Tuning (intern, ohne API-Bruch)
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 10 | P1 | OPTIONS-driven Preview-Size: `scanFileWithPreview()` ohne `$previewSize` befragt OPTIONS-Cache und nutzt Server-`Preview`-Header | `src/IcapClient.php:269-322`, `src/Cache/InMemoryOptionsCache.php` | 4/4 |
+| 11 | P1 | Max-Connections aus OPTIONS für Pool-Cap: `effectiveCap = min(localCap, serverMaxConnections)` (intern, opt-in via `Config::autoTunePoolFromOptions`) | `src/Transport/AmpConnectionPool.php:106-110`, `src/Config.php` | 4/4 |
+| 12 | P2 | OPTIONS-Cache ISTag-Invalidation (`OptionsCacheInterface` um `?string $istag` erweitern) | `src/Cache/InMemoryOptionsCache.php`, `src/Cache/OptionsCacheInterface.php` | Claude |
+| 13 | P2 | PSR-20 `ClockInterface` in `InMemoryOptionsCache` (deterministische TTL-Tests) | `src/Cache/InMemoryOptionsCache.php` | Claude |
+| 14 | P2 | `NullConnectionPool` jetzt anlegen (für explizite Pool-Off-Konfigs + Tests) | `src/Transport/NullConnectionPool.php` (neu) | Codex |
+| 15 | P2 | PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps | `src/Cache/Psr16OptionsCache.php`, `src/Cache/Psr6OptionsCache.php` | 3/4 |
+
+### CI-Härtung & Test-Reife
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 16 | P1 | Mutation-Testing wieder als CI-Job (`composer mutation`, `--min=65`, kein `continue-on-error`) | `.github/workflows/ci.yml:130-135` | 4/4 |
+| 17 | P1 | Integration-CI aus `continue-on-error: true` herausführen (hartes Gate **oder** Nightly-Cron mit Required-Status) | `.github/workflows/ci.yml:63` | 3/4 |
+| 18 | P1 | Coverage-Push: `AmpConnectionPool` 54 → ≥90 %, `SynchronousStreamTransport` 41 → ≥85 %, Async-Socket-Error 63 → ≥85 %. Konkrete Fälle: Cross-TLS-Pool-Isolation (bereits in v2.1.1), Concurrent-Acquire-Race (Fiber), `0; ieof`-Recv-Pfad, Multi-Section-Encapsulated, Cancellation mid-write/mid-read/Composite, `Options-TTL=0`, `SynchronousIcapClient::scanFileWithPreview`, Logger-Sensitive-Header-Regression | `tests/Transport/`, `tests/Wire/`, `tests/CancellationTest.php`, `tests/SynchronousIcapClientTest.php`, `tests/LoggerIntegrationTest.php`, `tests/OptionsCacheTest.php` | Jules + Claude + Codex |
+
+### Korrektheit & Robustheit
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 19 | P2 | Strict-§4.5-Path: per-IO-Timeout-Reset statt Session-Lifetime-Timeout (oder Caveat dokumentieren) | `src/Transport/AsyncAmpTransport.php:111-114` | Claude |
+| 20 | P2 | Pool-Idle-Eviction mit `maxIdleAge` (Default 30 s) | `src/Transport/AmpConnectionPool.php:42-46` | 4/4 |
+| 21 | P2 | obs-fold (RFC 7230) im Encapsulated-Header beachten | `src/Transport/ResponseFrameReader.php:144-153` | Claude, Codex |
+| 22 | P2 | Header-Name-Validation strenger auf RFC-7230-§3.2.6-Token-Set | `src/IcapClient.php:601` | Claude |
+
+### Doku & Tooling
+
+| # | Sev | Titel | Datei(en) | Quelle |
+|---|---|---|---|---|
+| 23 | P1 | 4 neue Cookbook-Files: TLS/mTLS, RetryingIcapClient, Pool-Tuning, External-Cancellation | `examples/cookbook/04-tls-mtls.php`, `…/05-retry-decorator.php`, `…/06-pool-tuning.php`, `…/07-cancellation-from-upload.php` | Claude, Codex |
+| 24 | P2 | Connection-Pool im Config-Block des README dokumentieren | `README.md:89-129` | Claude |
+| 25 | P2 | `docs/compliance.md` mit BSI OPS.1.1.4 / APP.4.4 / DSGVO-Mapping + AI-Disclaimer | `docs/compliance.md` (neu) | Claude |
+| 26 | P2 | DSGVO/Logging-Caveat in `SECURITY.md` und Logger-Phpdoc | `SECURITY.md`, `src/IcapClient.php` (Logger-Doku) | Jules |
+| 27 | P2 | CONTRIBUTING.md um Conventional-Commits-Konvention ergänzen | `CONTRIBUTING.md` | Claude |
+| 28 | P2 | OpenTelemetry-Decorator als Optional-Dep auf `open-telemetry/api` | `src/Tracing/OtelTracingIcapClient.php` (neu) | 4/4 |
+| 29 | P2 | PHPBench-Suite: Pool-Throughput, Strict-§4.5-Latency, Chunked-Encoder | `benchmarks/` (neu) | 3/4 |
+| 30 | P2 | SBOM (CycloneDX/SPDX) in CI | `.github/workflows/ci.yml` | Claude |
+| 31 | P3 | Property-based Tests für `ResponseParser` / `ResponseFrameReader` | `tests/Property/` (neu) | 3/4 |
+| 32 | P3 | Fuzz-Korpus für Parser | `tests/Fuzz/` (neu) | Claude |
+| 33 | P2 | `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit konkretem v3.0.0-Removal-Tag | `src/Exception/IcapResponseException.php:28-32` | Claude, Codex |
+
+---
+
+## v2.3.0 — Symfony-Bundle (8-12 Wochen, separates Repo)
+
+Eigenes Repo `ndrstmr/icap-flow-bundle`, abhängig auf `^2.2`. Nicht Teil
+dieses Plans im Detail; Initial-Scope:
+
+- `IcapFlowBundle` mit Configuration-Tree + `IcapFlowExtension`
+- Auto-DI: `IcapClientInterface` → `RetryingIcapClient` → inner `IcapClient`
+- Tagged-Services für Multi-Client (`icap_flow.client.<name>`)
+- Symfony Profiler DataCollector
+- Monolog-Channel `icap`
+- Console-Commands `icap:scan`, `icap:options`, `icap:health`
+- Validator-Constraint `#[IcapClean]`
+- Flex-Recipe für `symfony/recipes-contrib`
+- Adapter für VichUploaderBundle / OneupUploaderBundle
+
+Quelle: 4/4 Reviewer.
+
+---
+
+## v3.0.0 — Major (BC-Breaks gesammelt, nur falls erforderlich)
+
+| # | Titel | Datei(en) | Quelle |
+|---|---|---|---|
+| 34 | `IcapClient::executeRaw()` → `protected` ODER ins Interface heben | `src/IcapClient.php:144`, `src/IcapClientInterface.php` | Claude, Codex |
+| 35 | `options()` direkt zu `Future<IcapResponse>` umstellen (entsprechend Entscheidung 2) | `src/IcapClient.php:157`, `src/IcapClientInterface.php`, `src/SynchronousIcapClient.php` | Claude, Codex |
+| 36 | `IcapResponseException` entfernen (Deprecation einlösen) | `src/Exception/IcapResponseException.php` + Call-Sites | Claude, Codex |
+
+Trigger: erst wenn mind. zwei davon durch User-Feedback erzwungen werden.
+
+---
+
+## Abhängigkeitskarte
+
+- **v2.1.1 #2 ↔ Cross-TLS-Test**: gleicher PR.
+- **v2.1.2 #7 ↔ Memory-Watermark-Test**: gleicher PR; läuft im CI unter
+  niedrigem `memory_limit`.
+- **v2.2 #10 + #11**: bauen auf bestehendem `OptionsCacheInterface` auf
+  (kein `optionsRaw()` nötig dank Entscheidung 2).
+- **v2.2 #12 ↔ #13**: zusammen mergen, sonst keine deterministische
+  ISTag-Test-Fixture.
+- **v2.2 #14**: blockiert keine anderen Items, entkoppelt das Phpdoc-Versprechen
+  aus v2.1.1.
+- **v2.2 #16** (Mutation-CI) sollte früh im v2.2-Zyklus landen, damit
+  Folge-PRs davon profitieren.
+- **v2.3 (Bundle)**: vollständig blockiert auf v2.2-Release (insbesondere
+  #14 NullConnectionPool und #28 Otel).
+
+---
+
+## Kritische Dateien (Implementierungs-Hotspots)
+
+- `src/Transport/AmpConnectionPool.php` — Pool-Key, Idle-Eviction, Max-Connections
+- `src/IcapClient.php` — Strict-§4.5-Path, OPTIONS-driven Preview-Size, Header-Validation
+- `src/DefaultPreviewStrategy.php` — 200/206-Branch
+- `src/Cache/InMemoryOptionsCache.php` — ISTag, PSR-20 Clock
+- `src/Transport/ConnectionPoolInterface.php` — Phpdoc, später `NullConnectionPool`
+- `src/Transport/AsyncAmpTransport.php` — Per-IO-Timeout
+- `src/Transport/ResponseFrameReader.php` — obs-fold
+- `src/Exception/IcapResponseException.php` — Deprecation-Status
+- `SECURITY.md` — Stale-Claims (v2.1.1 P0)
+- `examples/cookbook/02-…`, `…03-…` — Anti-Pattern-Korrektur
+- `.github/workflows/ci.yml` — Mutation-Job, Integration-Gate, SBOM
+
+---
+
+## Wiederverwendung bestehender Bausteine
+
+- `OptionsCacheInterface` (`src/Cache/OptionsCacheInterface.php`) ist bereits
+  vorhanden und reicht für #10 + #11; `InMemoryOptionsCache` muss nur um Clock
+  und ISTag-Param erweitert werden.
+- `ChunkedBodyEncoder` (`src/ChunkedBodyEncoder.php`) hat bereits einen
+  `encode(string)` — die Streaming-Variante `encodeRemainderFromStream($resource)`
+  passt direkt daneben (Referenzpfad ist der existierende
+  `scanFileWithPreviewLegacy` in `IcapClient.php:426ff`, der schon korrekt
+  per `rewind() + resource` arbeitet).
+- Logger-Sensitive-Header-Logik existiert bereits — der fehlende Test
+  (#18) ist reine Regressions-Absicherung, kein neues Verhalten.
+
+---
+
+## Deliverables nach Plan-Approval
+
+1. **(c) GitHub-Issues** für jeden P0/P1-Punkt (insgesamt 11 Items: v2.1.1
+   #1-3, v2.1.2 #7, v2.2 #10-11, #16-18, #23, plus #4 als "good first issue").
+   Pro Issue: Reviewer-Quellen-Tabelle, Datei-Verweise, Akzeptanzkriterien,
+   Milestone-Label (`v2.1.1`, `v2.1.2`, `v2.2.0`).
+2. **(a) `docs/review/review_v2-1/consolidated_v2.1_task-list.md`** im Stil der
+   bestehenden `consolidated_task-list.md` aus v2.0. Inhalt: diese Plan-Datei
+   in Repo-tauglicher Form, ohne den Plan-Mode-Vorspann.
+
+Beide Deliverables erfolgen auf dem Branch `claude/review-v2-1-feedback-k5kRX`
+(GitHub-Issues sind Repo-weit, der Branch hostet die Doku).
+
+---
+
+## Verification
+
+Nach v2.1.1-Release:
+
+- `composer test` grün, neuer `AmpConnectionPoolTest::testCrossTlsIsolation`
+  schlägt **vor** dem Pool-Key-Fix fehl, **nach** dem Fix grün.
+- `DefaultPreviewStrategyTest::testInfectedDuringPreview` (mit fixiertem
+  `200 + X-Virus-Name: Eicar-Test`) liefert `ABORT_INFECTED`.
+- `SECURITY.md` Z. 73-75 referenziert `RetryingIcapClient`, `InMemoryOptionsCache`
+  und `AmpConnectionPool` als vorhandene Komponenten.
+- `examples/cookbook/03-options-request.php` enthält keinen "next milestone"-Text.
+- Manuell: ein Lauf gegen `docker compose up icap-clamav` mit dem
+  bekannten Eicar-Sample im 1-KiB-Preview liefert `ScanResult(isInfected=true)`
+  statt `IcapResponseException`.
+
+Nach v2.1.2-Release:
+
+- Memory-Watermark-Test mit 2-GB-Stream und `memory_limit=128M` (per
+  `php -d memory_limit=128M`) muss durchlaufen.
+- `composer test` mit `failOnRisky=true` + `failOnWarning=true` grün.
+- CI-PHPStan-Job läuft ohne OOM.
+
+Nach v2.2-Release:
+
+- `composer mutation --min=65` als Required-Status auf PR-Branches.
+- Coverage-Report bestätigt `AmpConnectionPool` ≥ 90 %, `SynchronousStreamTransport`
+  ≥ 85 %, Async-Socket-Error ≥ 85 %.
+- Integration-CI ist Required-Status (oder Nightly mit Issue-on-Failure).
+- `phpbench run benchmarks/ --report=default` liefert Baseline-Zahlen.


### PR DESCRIPTION
## Context

Replaces the raw plan-export (`consolidated_v2.1_task-list_plan-export.md`,
archived in place) with a proper repo-style task list for icap-flow v2.1.x and
v2.2.0 development.

Basis: synthesis of four independent deep-research audits in
`docs/review/review_v2-1/` — Claude, Codex-DR, Codex-PR, Jules.
Scores: 74–77/100, TRL-7 consensus.

Key items driving the structure:
- v2.1.1-A, **4/4 reviewers** — cross-tenant TLS leakage in `AmpConnectionPool::key()` (CVE-worthy)
- v2.1.1-B, Claude + Codex ×2 — `DefaultPreviewStrategy` throws on 200/206 → `ABORT_INFECTED` branch unreachable
- v2.1.1-C, Claude + Jules — `SECURITY.md` stale claims (v2.0-era negations still present)
- v2.1.2-D, 3/4 reviewers — `stream_get_contents()` in strict §4.5 path → OOM on GB uploads

Correction included: Jules' claim about header array-value validation depth is
factually wrong (`validateIcapHeaders()` already iterates via
`foreach ((array) $value as $v)`) — not included as a finding.

## API

none — documentation only.

## Behaviour

none.

## Refactoring

none.

## Tests

none (documentation PR).

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — Pest Unit-Suite grün
- [x] `composer test:integration` — nicht relevant
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Status

After merge: serves as the authoritative planning anchor for v2.1.1, v2.1.2,
v2.2.0, v2.3.0 (separate bundle repo), and v3.0.0. Next step: create GitHub
Issues for all P0/P1 findings with milestone labels and acceptance criteria.