### PR TITLE
fix(docs): drop non-existent NullConnectionPool reference from phpdoc (#57)

### DIFF
--- a/src/Transport/ConnectionPoolInterface.php
+++ b/src/Transport/ConnectionPoolInterface.php
@@ -32,9 +32,7 @@ use Ndrstmr\Icap\Config;
  * decides whether to hand out an existing idle socket or open a new
  * one, and whether to keep a returned socket idle or close it.
  *
- * The default implementation is {@see AmpConnectionPool}. The
- * {@see NullConnectionPool} variant disables pooling — every
- * acquire opens a fresh connection, every release closes it.
+ * The default implementation is {@see AmpConnectionPool}.
  *
  * Implementations MUST be safe to use across concurrent
  * acquire/release cycles within a single fiber-driven event loop;


### PR DESCRIPTION
Closes #57.

## Summary
\`src/Transport/ConnectionPoolInterface.php:36\` documents a \`NullConnectionPool\` variant that doesn't exist in the codebase. The phpdoc reads as if pool-less mode is a concrete class consumers can pick, but \`AmpConnectionPool\` is the only implementation today — the reference was added speculatively for a v2.2.0 follow-up.

Drop the dangling \`{@see NullConnectionPool}\` sentence so the phpdoc no longer makes a false promise.

## Diff
```diff
- * The default implementation is {@see AmpConnectionPool}. The
- * {@see NullConnectionPool} variant disables pooling — every
- * acquire opens a fresh connection, every release closes it.
+ * The default implementation is {@see AmpConnectionPool}.
```

## Acceptance criteria (from issue)
- [x] Phpdoc in \`ConnectionPoolInterface.php:36\` no longer references \`NullConnectionPool\`.
- [x] No code changes — interface signatures and the AmpConnectionPool reference are unchanged.

## Notes
- The long-term work to actually ship a \`NullConnectionPool\` (Acceptance criteria for v2.2.0 in the issue body) is tracked separately and is out of scope for this v2.1.1 doc-only fix.