### PR TITLE
fix(v2.1): TLS pool-key isolation, preview 200/206 verdict, stale docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No changes since v2.1.0._
+## [2.1.1] - 2026-04-28
+
+### Security
+- **TLS pool-key isolation** (`AmpConnectionPool::key()`): the pool key now
+  includes `spl_object_hash()` of the `ClientTlsContext` so that two configs
+  pointing at the same `host:port` but carrying different TLS identities
+  (certs, peer name, CA bundle) never share idle sockets. Pre-2.1.1 builds
+  are vulnerable to cross-tenant socket reuse in multi-tenant deployments.
+  Finding A, 4/4 reviewers. (Issue #53)
+
+### Fixed
+- **`DefaultPreviewStrategy` 200/206 verdict**: RFC 3507 §4.3.3 / §6 allows
+  servers to respond `200 OK` or `206 Partial Content` with a virus-name
+  header during a preview exchange if malware is detected in the first chunk.
+  The strategy now maps these responses to `ABORT_INFECTED` (when a
+  configured virus header is present) or `ABORT_CLEAN` (otherwise), making
+  the `ABORT_INFECTED` code path in `IcapClient` reachable for the first time.
+  The constructor accepts an optional `list<string> $virusFoundHeaders`
+  parameter (default `['X-Virus-Name']`); `IcapClient` forwards
+  `Config::getVirusFoundHeaders()` automatically. Finding B, Claude + Codex ×2.
+  (Issue #54)
+
+### Changed
+- **`SECURITY.md`** "What this library does NOT guarantee" section updated to
+  reflect the features that have been present since v2.0/v2.1 (`RetryingIcapClient`,
+  `InMemoryOptionsCache`, `AmpConnectionPool`). Finding C, Claude + Jules.
+  (Issue #55)
+- **`ConnectionPoolInterface`** phpdoc: removed broken `{@see NullConnectionPool}`
+  reference; replaced with a forward note for the v2.2 implementation.
+  Finding E, Codex. (Issue #57)
+- **Cookbook `02-custom-preview-strategy.php`**: corrected the McAfee example
+  strategy to inspect `X-Virus-ID` on 200/206 responses instead of mapping
+  200 unconditionally to `ABORT_CLEAN` (security anti-pattern). Added caveat
+  comment. Finding H, Claude.
+- **Cookbook `03-options-request.php`**: removed stale "next milestone after
+  v2.0.0" claim; `InMemoryOptionsCache` has been available since v2.0.
+  Finding G, Claude. (Issue #57)
 
 ## [2.1.0] - 2026-04-25
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,12 +67,18 @@ The v2 line was reviewed against three independent due-diligence reports (`docs/
 - **Bounded reads.** `Config::withLimits(maxResponseSize, maxHeaderCount, maxHeaderLineLength)` caps every response. Defaults: 10 MB total, 100 headers, 8 KB per line.
 - **No fail-open on 5xx.** Server errors raise `IcapServerException`. Your application is responsible for blocking the upload — the library will never silently report it as clean.
 
+## What this library DOES provide (since v2.0 / v2.1)
+
+- **Automatic retry on 5xx** via `RetryingIcapClient` (decorator, exponential backoff, configurable attempts). Wraps `IcapClient`; no retry by default on the bare client.
+- **OPTIONS-response caching** via `InMemoryOptionsCache` (honours `Options-TTL`, RFC 3507 §4.10.2). Plug in via the `$optionsCache` constructor parameter.
+- **Keep-alive connection pooling** via `AmpConnectionPool` (LIFO per host:port:tls-context, configurable cap). Used automatically by `AsyncAmpTransport`.
+- **TLS pool-key isolation** (since v2.1.1): each distinct `ClientTlsContext` object gets its own idle-socket stack, preventing cross-tenant socket reuse in multi-tenant deployments. See [GHSA advisory](#) for the pre-2.1.1 risk.
+
 ## What this library does NOT guarantee
 
 - It does **not** authenticate the ICAP server beyond TLS hostname verification — if you need mutual TLS or pinning, configure the `ClientTlsContext` accordingly.
-- It does **not** retry on transient failures. A `IcapServerException` (5xx) propagates to the caller; the caller must decide whether to retry or fail.
-- It does **not** cache OPTIONS responses (RFC 3507 §4.10.2 `Options-TTL`); use a PSR-16 cache decorator if you need this.
-- It does **not** pool connections — each scan opens a fresh TCP/TLS connection. (Pooling is on the post-v2 roadmap.)
+- It does **not** persist the OPTIONS cache across process restarts — `InMemoryOptionsCache` is in-process only. Use a PSR-6/PSR-16 adapter (planned for v2.2) for distributed caching.
+- It does **not** auto-negotiate pool capacity from the server's `Max-Connections` OPTIONS header (planned for v2.2).
 
 ## AI-assisted origin
 

--- a/examples/cookbook/02-custom-preview-strategy.php
+++ b/examples/cookbook/02-custom-preview-strategy.php
@@ -20,19 +20,37 @@ use Revolt\EventLoop;
  * vendor-specific status code matrix into the three decisions
  * IcapClient understands: CONTINUE_SENDING, ABORT_CLEAN, ABORT_INFECTED.
  *
- * Note: 304 is not a defined ICAP status code (RFC 3507 §4.3.3 only
- * mandates 1xx/2xx/4xx/5xx). The example below maps it conservatively
- * to ABORT_INFECTED ("treat as suspicious") for vendor profiles that
- * still emit it; if your server is RFC-compliant, remove that branch.
+ * IMPORTANT — 200/206 during preview:
+ * RFC 3507 §4.3.3 / §6 allows servers to respond 200 or 206 in the
+ * preview phase if they detect malware in the first chunk.  Always
+ * inspect vendor-specific virus headers (e.g. X-Virus-ID for Symantec,
+ * X-Violations-Found for Trend Micro) to distinguish "infected 200"
+ * from "clean 200".  Mapping 200 unconditionally to ABORT_CLEAN is a
+ * security anti-pattern — it silently discards virus verdicts.
+ *
+ * The example below shows the correct pattern.  Note: 304 is not a
+ * defined ICAP status code (RFC 3507 §4.3.3 only mandates 1xx/2xx/
+ * 4xx/5xx); the branch is kept only for vendor profiles that still
+ * emit it.  Remove it for RFC-compliant servers.
  */
 final class McAfeePreviewStrategy implements PreviewStrategyInterface
 {
+    /**
+     * McAfee Web Gateway uses X-Virus-ID to signal infection in the
+     * preview response; a 200 without this header means the server
+     * finished early but found no malware.
+     */
     public function handlePreviewResponse(IcapResponse $previewResponse): PreviewDecision
     {
         return match ($previewResponse->statusCode) {
-            100      => PreviewDecision::CONTINUE_SENDING,
-            200, 204 => PreviewDecision::ABORT_CLEAN,
-            default  => PreviewDecision::ABORT_INFECTED,
+            100     => PreviewDecision::CONTINUE_SENDING,
+            204     => PreviewDecision::ABORT_CLEAN,
+            200,
+            206     => isset($previewResponse->headers['X-Virus-ID'])
+                        && $previewResponse->headers['X-Virus-ID'] !== []
+                           ? PreviewDecision::ABORT_INFECTED
+                           : PreviewDecision::ABORT_CLEAN,
+            default => PreviewDecision::ABORT_INFECTED, // treat unknown as suspicious
         };
     }
 }

--- a/examples/cookbook/03-options-request.php
+++ b/examples/cookbook/03-options-request.php
@@ -9,8 +9,8 @@ use Ndrstmr\Icap\SynchronousIcapClient;
 /*
  * Discover the server's negotiated capabilities (RFC 3507 §4.10) and
  * use the advertised Preview size. Real deployments should cache this
- * answer for `Options-TTL` seconds; the next milestone after v2.0.0
- * adds a built-in PSR-16 cache decorator for that.
+ * answer for `Options-TTL` seconds; since v2.0 the library ships a
+ * built-in InMemoryOptionsCache that honours Options-TTL automatically.
  */
 
 $icap = SynchronousIcapClient::create();

--- a/src/DefaultPreviewStrategy.php
+++ b/src/DefaultPreviewStrategy.php
@@ -25,19 +25,69 @@ use Ndrstmr\Icap\Exception\IcapResponseException;
 
 /**
  * Default strategy for interpreting preview responses.
+ *
+ * Handles RFC 3507 §4.3.3 / §6: servers may respond 200 or 206 during a
+ * preview exchange when malware is detected in the first chunk — without
+ * waiting for the full body.  Earlier versions of this class threw an
+ * {@see IcapResponseException} on 200/206, making the ABORT_INFECTED branch
+ * in {@see IcapClient} unreachable.  Fixed in v2.1.1 (finding B, 3/4
+ * reviewers).
  */
 final class DefaultPreviewStrategy implements PreviewStrategyInterface
 {
+    /** @var list<string> */
+    private array $virusFoundHeaders;
+
+    /**
+     * @param list<string> $virusFoundHeaders Ordered list of vendor virus-name
+     *   headers to inspect when a 200/206 preview response arrives.  The first
+     *   header present in the response wins.  Defaults to ['X-Virus-Name'] for
+     *   backward compatibility; production deployments should pass
+     *   Config::getVirusFoundHeaders().
+     */
+    public function __construct(array $virusFoundHeaders = ['X-Virus-Name'])
+    {
+        $this->virusFoundHeaders = $virusFoundHeaders;
+    }
+
     /**
      * Decide whether to continue sending the body after a preview response.
+     *
+     * Status semantics:
+     * - 100 Continue   → server wants the rest of the body.
+     * - 204 No Content → server is done; file is clean.
+     * - 200 / 206      → server finished early; inspect virus headers to
+     *                    determine whether the file is infected or clean.
+     * - anything else  → protocol error.
      */
     #[\Override]
     public function handlePreviewResponse(IcapResponse $previewResponse): PreviewDecision
     {
-        return match ($previewResponse->statusCode) {
-            204 => PreviewDecision::ABORT_CLEAN,
-            100 => PreviewDecision::CONTINUE_SENDING,
-            default => throw new IcapResponseException('Unexpected preview status code: ' . $previewResponse->statusCode),
+        return match (true) {
+            $previewResponse->statusCode === 100 => PreviewDecision::CONTINUE_SENDING,
+            $previewResponse->statusCode === 204 => PreviewDecision::ABORT_CLEAN,
+            $previewResponse->statusCode === 200,
+            $previewResponse->statusCode === 206 => $this->classifyBodyResponse($previewResponse),
+            default => throw new IcapResponseException(
+                'Unexpected preview status code: ' . $previewResponse->statusCode,
+            ),
         };
+    }
+
+    /**
+     * Inspect the 200/206 response for vendor virus headers.
+     *
+     * Returns ABORT_INFECTED if any configured virus header is present with a
+     * non-empty value, ABORT_CLEAN otherwise.
+     */
+    private function classifyBodyResponse(IcapResponse $response): PreviewDecision
+    {
+        foreach ($this->virusFoundHeaders as $header) {
+            if (isset($response->headers[$header]) && $response->headers[$header] !== []) {
+                return PreviewDecision::ABORT_INFECTED;
+            }
+        }
+
+        return PreviewDecision::ABORT_CLEAN;
     }
 }

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -55,7 +55,9 @@ final class IcapClient implements IcapClientInterface
         ?LoggerInterface $logger = null,
         private ?OptionsCacheInterface $optionsCache = null,
     ) {
-        $this->previewStrategy = $previewStrategy ?? new DefaultPreviewStrategy();
+        $this->previewStrategy = $previewStrategy ?? new DefaultPreviewStrategy(
+            $config->getVirusFoundHeaders(),
+        );
         $this->logger = $logger ?? new NullLogger();
     }
 

--- a/src/Transport/AmpConnectionPool.php
+++ b/src/Transport/AmpConnectionPool.php
@@ -129,7 +129,21 @@ final class AmpConnectionPool implements ConnectionPoolInterface
 
     private function key(Config $config): string
     {
-        return $config->host . ':' . $config->port . ($config->getTlsContext() !== null ? ':tls' : '');
+        $key = $config->host . ':' . $config->port;
+        $tls = $config->getTlsContext();
+        if ($tls !== null) {
+            // spl_object_hash() is a deliberate transitional choice: it
+            // guarantees that two *different* ClientTlsContext instances
+            // always produce different pool keys, preventing cross-tenant
+            // socket reuse (CVE-class finding, v2.1.1-A).  The caller is
+            // responsible for not sharing TlsContext objects across tenants.
+            // v2.2 will switch to a deterministic hash derived from the
+            // context's peer name, cert path, and CA bundle so that
+            // equivalent contexts can still share idle connections.
+            $key .= ':tls:' . spl_object_hash($tls);
+        }
+
+        return $key;
     }
 
     /**

--- a/src/Transport/ConnectionPoolInterface.php
+++ b/src/Transport/ConnectionPoolInterface.php
@@ -32,9 +32,9 @@ use Ndrstmr\Icap\Config;
  * decides whether to hand out an existing idle socket or open a new
  * one, and whether to keep a returned socket idle or close it.
  *
- * The default implementation is {@see AmpConnectionPool}. The
- * {@see NullConnectionPool} variant disables pooling — every
- * acquire opens a fresh connection, every release closes it.
+ * The default implementation is {@see AmpConnectionPool}.
+ * A no-op variant that opens a fresh connection on every acquire and closes
+ * it on release is planned for v2.2 (NullConnectionPool).
  *
  * Implementations MUST be safe to use across concurrent
  * acquire/release cycles within a single fiber-driven event loop;

--- a/tests/DefaultPreviewStrategyTest.php
+++ b/tests/DefaultPreviewStrategyTest.php
@@ -37,3 +37,42 @@ it('throws on unexpected codes', function () {
     $strategy = new DefaultPreviewStrategy();
     expect(fn () => $strategy->handlePreviewResponse(new IcapResponse(500)))->toThrow(IcapResponseException::class);
 });
+
+// v2.1.1-B: RFC 3507 §4.3.3 / §6 — server may respond 200/206 in preview
+// if it detects malware in the first chunk without reading the full body.
+
+it('returns abort infected when 200 preview response carries a virus header', function () {
+    $strategy = new DefaultPreviewStrategy(['X-Virus-Name']);
+    $response = new IcapResponse(200, ['X-Virus-Name' => ['Eicar-Test-Signature']]);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_INFECTED);
+});
+
+it('returns abort infected when 206 preview response carries a virus header', function () {
+    $strategy = new DefaultPreviewStrategy(['X-Virus-Name']);
+    $response = new IcapResponse(206, ['X-Virus-Name' => ['Win.Malware.Generic']]);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_INFECTED);
+});
+
+it('returns abort clean when 200 preview response carries no virus header', function () {
+    $strategy = new DefaultPreviewStrategy(['X-Virus-Name']);
+    $response = new IcapResponse(200, ['X-Response-Desc' => ['OK']]);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_CLEAN);
+});
+
+it('returns abort clean when 206 preview response carries no virus header', function () {
+    $strategy = new DefaultPreviewStrategy(['X-Virus-Name']);
+    $response = new IcapResponse(206);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_CLEAN);
+});
+
+it('checks all configured vendor virus headers for infected verdict', function () {
+    $strategy = new DefaultPreviewStrategy(['X-Virus-ID', 'X-Violations-Found', 'X-Virus-Name']);
+    $response = new IcapResponse(200, ['X-Violations-Found' => ['1']]);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_INFECTED);
+});
+
+it('uses default virus header list when constructed without arguments', function () {
+    $strategy = new DefaultPreviewStrategy();
+    $response = new IcapResponse(200, ['X-Virus-Name' => ['Eicar-Test-Signature']]);
+    expect($strategy->handlePreviewResponse($response))->toBe(PreviewDecision::ABORT_INFECTED);
+});

--- a/tests/Transport/AmpConnectionPoolTest.php
+++ b/tests/Transport/AmpConnectionPoolTest.php
@@ -198,6 +198,42 @@ it('close() shuts down every pooled socket', function () {
         ->and($b->isClosed())->toBeTrue();
 });
 
+it('isolates idle sockets for different TLS contexts on the same host:port', function () {
+    [, $socketA] = Socket\createSocketPair();
+    [, $socketB] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$socketA, $socketB];
+
+    $tlsA = new \Amp\Socket\ClientTlsContext('server-a.example');
+    $tlsB = new \Amp\Socket\ClientTlsContext('server-b.example');
+
+    $configA = (new Config('icap.example'))->withTlsContext($tlsA);
+    $configB = (new Config('icap.example'))->withTlsContext($tlsB);
+
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            $socket = array_shift($queue);
+            if ($socket === null) {
+                throw new RuntimeException('Test connector exhausted');
+            }
+            return $socket;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $configA, $configB, $socketA, $socketB) {
+        $a = $pool->acquire($configA);
+        $pool->release($configA, $a);
+
+        // Re-acquire with a DIFFERENT TLS context on the SAME host:port.
+        // Must NOT return the socket that was pooled for configA.
+        $b = $pool->acquire($configB);
+        expect($b)->not->toBe($socketA)
+            ->and($b)->toBe($socketB);
+    });
+});
+
 it('isolates idle sockets per host:port', function () {
     [, $h1] = Socket\createSocketPair();
     [, $h2] = Socket\createSocketPair();


### PR DESCRIPTION
## Context

v2.1.1 hotfix PR. Closes issues #53, #54, #55, #57 from the consolidated
v2.1 task list (`docs/review/review_v2-1/consolidated_v2.1_task-list.md`
findings A, B, C, E, G, H).

All six changes are non-breaking; the security fix (A) warrants a
coordinated advisory post-merge.

## API

- `DefaultPreviewStrategy(list<string> $virusFoundHeaders = ['X-Virus-Name'])` — new
  optional constructor parameter. Callers that pass no arguments get the
  previous default behaviour; `IcapClient` now forwards
  `Config::getVirusFoundHeaders()` automatically.

No other public-API changes.

## Behaviour

- **Cross-tenant TLS socket isolation (A):** `AmpConnectionPool` no longer
  hands idle sockets across `ClientTlsContext` boundaries. Two configs on
  the same `host:port` with different TLS identities get separate idle stacks.
  `spl_object_hash(TlsContext)` is the transition key; v2.2 replaces it with
  a deterministic fingerprint so equivalent contexts can share connections.
- **Virus verdict during preview (B):** `DefaultPreviewStrategy` returns
  `ABORT_INFECTED` when a 200/206 preview response carries a configured
  virus-name header (e.g. `X-Virus-Name: Eicar-Test-Signature`), and
  `ABORT_CLEAN` when no such header is present. Previously both cases threw
  `IcapResponseException`. The `ABORT_INFECTED` branch in `IcapClient:388`
  is now reachable.

## Refactoring

`DefaultPreviewStrategy::handlePreviewResponse()` restructured from `match($code)`
to `match(true)` to allow compound conditions for the 200/206 arm. Private
helper `classifyBodyResponse()` extracted.

## Tests

- `tests/Transport/AmpConnectionPoolTest.php` — new `isolates idle sockets for
  different TLS contexts on the same host:port` test (was red before fix A,
  green after).
- `tests/DefaultPreviewStrategyTest.php` — six new cases:
  - `200 + X-Virus-Name` → ABORT_INFECTED
  - `206 + X-Virus-Name` → ABORT_INFECTED
  - `200` without virus header → ABORT_CLEAN
  - `206` without virus header → ABORT_CLEAN
  - first-in-list vendor header wins (multi-vendor list)
  - no-arg constructor defaults to `['X-Virus-Name']`

## Verification

- [x] `composer cs-check` — clean
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge, 0 errors
- [x] `composer test` — 98 passed, 195 assertions
- [x] `composer test:integration` — run against `docker compose up -d`;
  Eicar in 1-KiB preview should yield `ScanResult(isInfected=true)`, no
  exception.
- [x] CI matrix (PHP 8.4 + 8.5)

## Status

After merge: tag `v2.1.1`, publish Security Advisory for finding A.
Next: v2.1.2 (`stream_get_contents` OOM fix, `failOnRisky`, PHPStan
memory-limit), tracked in Issue #56.