### PR TITLE
docs: enforce GitHub Auto-Close keywords in commit/PR conventions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,6 +48,15 @@ welche Edge-Cases sie absichern, ob Mutation-Score betroffen ist.
 - [ ] `composer test:integration` — gegen `docker compose up -d` (falls relevant)
 - [ ] CI-Matrix (PHP 8.4 + 8.5)
 
+## Closes
+
+<!--
+GitHub Auto-Close: jedes Issue auf eigener Zeile mit Keyword.
+Nur Closes/Fixes/Resolves löst Auto-Close aus — "Refs" verlinkt nur.
+Zeilen entfernen, wenn kein Issue geschlossen wird.
+-->
+Closes #
+
 ## Status
 
 <!--

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a PHP 8.4 Composer library for an async-ready ICAP client. Production code lives in `src/` under the `Ndrstmr\Icap\` PSR-4 namespace. Key areas are `src/DTO/`, `src/Exception/`, `src/Transport/`, and `src/Cache/`. Tests live in `tests/`; integration tests are isolated in `tests/Integration/`. Examples are in `examples/` and `examples/cookbook/`. Design notes, audits, and roadmap material are in `docs/`; treat review task lists as historical unless confirmed by `CHANGELOG.md` and Git tags. Current local tags include `v2.1.2`.
+
+## Build, Test, and Development Commands
+
+- `composer install`: install runtime and development dependencies.
+- `composer test`: run the Pest unit suite.
+- `composer test:integration`: run integration tests; see `tests/Integration/README.md` and `docker-compose.yml` for local ICAP service setup.
+- `composer test:all`: run all Pest suites.
+- `composer stan`: run PHPStan with a 1 GB memory limit.
+- `composer cs-check`: check formatting and EUPL headers without changes.
+- `composer cs-fix`: apply php-cs-fixer formatting.
+- `composer mutation`: run covered unit mutation tests with minimum score 65.
+
+## Coding Style & Naming Conventions
+
+Follow PSR-12 with `declare(strict_types=1);`, 4-space indentation, typed properties and parameters, and explicit return types where practical. Class names use `PascalCase`; methods and variables use `camelCase`; test files end in `Test.php`. Keep namespaces aligned with paths, for example `src/Transport/AmpConnectionPool.php` maps to `Ndrstmr\Icap\Transport\AmpConnectionPool`. New PHP files in `src/` and `tests/` must keep the EUPL-1.2 header enforced by php-cs-fixer.
+
+## Testing Guidelines
+
+The project uses Pest on PHPUnit 11. PHPUnit fails on risky tests, warnings, and unexpected output, so avoid debug output and add explicit assertions. Add focused tests for parser, transport, retry, cancellation, and security-sensitive behavior when touching those areas. Keep external-service checks in `tests/Integration/`.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses Conventional Commit-style subjects such as `fix(v2.1): ...` and `docs(review): ...`. Keep subjects imperative, scoped when useful, and concise. Before opening a PR, run `composer test`, `composer stan`, and `composer cs-check`. PRs should describe behavior changes, link issues, mention integration-test needs, and update examples or docs for public API changes.
+
+## Security & Configuration Tips
+
+Do not commit credentials, private ICAP endpoints, or generated coverage/build artifacts. Security-sensitive changes should review `SECURITY.md`, include negative-path tests, and preserve fail-secure handling for malformed responses, timeouts, parser limits, and streaming large files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Diese Repo folgt **strikt** [Conventional Commits 1.0](https://www.conventionalc
 - **Body:** Pflicht. Erklärt **warum**, nicht **was** — der Diff zeigt das Was. Bei Items aus `docs/review/review_v2-1/consolidated_v2.1_task-list.md` die Tabellenzeile + Reviewer-Quelle nennen.
 - **Footer:**
   - `BREAKING CHANGE: <Beschreibung>` für jeden BC-Break (gehören in den v3.0.0-Bucket, nicht in Patch/Minor).
-  - `Refs #<issue>` / `Closes #<issue>` für Verlinkung zur GitHub-Issue.
+  - `Closes #<issue>` wenn der Commit/PR das Issue schließen soll. `Refs #<issue>` nur für Verweise ohne Schließen. **Wichtig:** GitHub Auto-Close braucht exakt `Closes #XX` / `Fixes #XX` / `Resolves #XX` — `Refs` verlinkt nur, schließt nicht. Bei mehreren Issues jedes einzeln auflisten (`Closes #53`, `Closes #54`), nicht komma-separiert.
 
 ### Was nicht in Commits / PRs gehört
 


### PR DESCRIPTION
## Context

PRs #65 and #66 used `Refs #XX` and `(Issue #XX)` in commit footers and
PR bodies — neither triggered GitHub Auto-Close, requiring manual
`gh issue close` after merge. This PR codifies the correct convention.

## Summary

- **CLAUDE.md**: clarify that `Closes #XX` (not `Refs #XX`) must be used
  to auto-close issues. Each issue needs its own keyword line.
- **PR template**: add a dedicated `## Closes` section as a visual reminder.
- **AGENTS.md**: generic agent context for non-Claude-Code tooling
  (Codex, Copilot with Claude model, etc.).

## Test plan

- Review the diff — docs-only, no code changes.

## Verification

- [x] No code changes — quality gates not affected.

## Closes

n/a — no issue for this.

## Status

Convention applies to all future PRs.