### PR TITLE
ci(v2.2): restore mutation testing as required CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,32 @@ jobs:
         if: always()
         run: docker compose down -v
 
-  # NOTE: The mutation-testing CI job was removed from this PR. Pest 3
-  # mutation CLI surface wouldn't stabilise in the scope of M4; it
-  # returns in a dedicated follow-up once the flag matrix +
-  # coverage-driver boot-up are fully worked out. The
-  # `composer mutation` script stays usable locally.
+  # Mutation testing via Pest --mutate. Runs after quality checks pass
+  # to avoid wasting CI minutes on code that doesn't compile or pass
+  # unit tests. Uses --min=65 as the MSI floor.
+  mutation-testing:
+    name: Mutation Testing (MSI ≥ 65%)
+    runs-on: ubuntu-latest
+    needs: quality-and-tests
+    # Only run on PRs — push-to-main already passed via the PR gate.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: sockets
+          coverage: pcov
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run mutation tests
+        run: composer mutation
 
   deploy-coverage:
     name: Deploy Coverage Report

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "stan": "phpstan analyse --memory-limit=1G",
     "cs-check": "php-cs-fixer fix --dry-run --diff",
     "cs-fix": "php-cs-fixer fix",
-    "mutation": "pest --mutate --testsuite=Unit --parallel --covered-only --min=65"
+    "mutation": "pest --mutate --testsuite=Unit --parallel --everything --covered-only --min=65"
   },
   "config": {
     "sort-packages": true,


### PR DESCRIPTION
## Context

v2.2-M from `consolidated_v2.1_task-list.md` — all 4 reviewers flagged the
missing mutation-testing CI job (P1). The job was removed during the v2.1
cycle because Pest 3's mutation CLI wasn't stable. It now works reliably
with `--everything --covered-only` in Pest 3.8.x.

## Summary

- New CI job `mutation-testing` runs `composer mutation` on every PR
- Uses pcov for fast coverage, runs after quality checks pass
- `composer mutation` script updated: `--everything --covered-only` instead
  of requiring `covers()`/`mutates()` per test file
- MSI floor: `--min=65` (same as before removal)

## Behaviour

- PRs now get a "Mutation Testing (MSI >= 65%)" check that must pass
- Push-to-main skips mutation (already gated via PR)
- No impact on existing test suite or local workflow

## Tests

- Mutation testing itself is the test — verified locally on single class
  (`ChunkedBodyEncoder`: 58 mutations generated, score above threshold)
- Full suite too slow with xdebug locally (~60+ min); CI uses pcov (~5-10 min)

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 107 tests passed
- [x] CI-Matrix (PHP 8.4 + 8.5) — will run on this PR
- [ ] Mutation job — will run on this PR (first real test)

## Closes

Closes #60

## Status

After merge: mark v2.2-M as done in task list.
Next: v2.2-E2 (NullConnectionPool), then v2.2-K/L (OPTIONS-driven tuning).