### PR TITLE
docs(review): mark v2.2-M as completed

### DIFF
--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -214,10 +214,11 @@ Alle Items additiv; kein BC-Break.
 
 ### CI-Härtung & Test-Reife
 
-- [ ] **v2.2-M** Mutation-Testing wieder als Required-CI-Job:
+- [x] **v2.2-M** Mutation-Testing wieder als Required-CI-Job:
   `composer mutation` (`--min=65`, kein `continue-on-error`).
   Sollte früh im v2.2-Zyklus landen, damit Folge-PRs davon profitieren.
   *Datei: `.github/workflows/ci.yml:130-135` — Quelle: 4/4*
+  ✅ PR #69, Closes #60. MSI 68.47% im ersten CI-Lauf.
 
 - [ ] **v2.2-N** Integration-CI aus `continue-on-error: true` herausführen:
   entweder hartes Gate auf PRs oder Nightly-Workflow mit


### PR DESCRIPTION
## Summary

- Check off v2.2-M (mutation testing CI) with PR #69 reference and MSI score.

Docs-only, no code changes.