### PR TITLE
feat(transport): add NullConnectionPool for explicit no-reuse mode

### DIFF
--- a/src/Transport/NullConnectionPool.php
+++ b/src/Transport/NullConnectionPool.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Transport;
+
+use Amp\Cancellation;
+use Amp\Socket;
+use Amp\Socket\ConnectContext;
+use Amp\Socket\Socket as SocketInterface;
+use Closure;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Exception\IcapConnectionException;
+
+/**
+ * No-op connection pool: every {@see acquire()} opens a fresh TCP/TLS
+ * connection, every {@see release()} closes it immediately. No idle
+ * sockets are ever kept.
+ *
+ * Use this when connection reuse is explicitly unwanted (e.g. testing,
+ * debugging, or ICAP servers that close the connection after every
+ * request anyway).
+ *
+ * @see AmpConnectionPool for the keep-alive variant
+ */
+final class NullConnectionPool implements ConnectionPoolInterface
+{
+    /** @var Closure(Config, ?Cancellation): SocketInterface */
+    private Closure $connector;
+
+    /**
+     * @param (Closure(Config, ?Cancellation): SocketInterface)|null $connector optional override for testing
+     */
+    public function __construct(?Closure $connector = null)
+    {
+        $this->connector = $connector ?? self::defaultConnector();
+    }
+
+    #[\Override]
+    public function acquire(Config $config, ?Cancellation $cancellation = null): SocketInterface
+    {
+        return ($this->connector)($config, $cancellation);
+    }
+
+    #[\Override]
+    public function release(Config $config, SocketInterface $socket): void
+    {
+        $socket->close();
+    }
+
+    #[\Override]
+    public function close(): void
+    {
+        // Nothing to do — no idle sockets are ever stored.
+    }
+
+    /**
+     * @return Closure(Config, ?Cancellation): SocketInterface
+     */
+    private static function defaultConnector(): Closure
+    {
+        return static function (Config $config, ?Cancellation $cancellation): SocketInterface {
+            $tls = $config->getTlsContext();
+            $url = sprintf('tcp://%s:%d', $config->host, $config->port);
+            $context = (new ConnectContext())->withConnectTimeout($config->getSocketTimeout());
+            if ($tls !== null) {
+                $context = $context->withTlsContext($tls);
+            }
+
+            try {
+                if ($tls !== null) {
+                    return Socket\connectTls($url, $context, $cancellation);
+                }
+                return Socket\connect($url, $context, $cancellation);
+            } catch (Socket\ConnectException $e) {
+                throw new IcapConnectionException(
+                    sprintf('NullConnectionPool connect to %s:%d failed.', $config->host, $config->port),
+                    0,
+                    $e,
+                );
+            }
+        };
+    }
+}

--- a/tests/Transport/NullConnectionPoolTest.php
+++ b/tests/Transport/NullConnectionPoolTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Amp\Socket\Socket as SocketInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\ConnectionPoolInterface;
+use Ndrstmr\Icap\Transport\NullConnectionPool;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.2-E2 — NullConnectionPool: no keep-alive, every acquire() opens
+ * a fresh connection, every release() closes it. Useful for testing
+ * and explicit pool-off configurations.
+ */
+
+it('implements ConnectionPoolInterface', function () {
+    $pool = new NullConnectionPool(
+        connector: fn () => Socket\createSocketPair()[1],
+    );
+    expect($pool)->toBeInstanceOf(ConnectionPoolInterface::class);
+});
+
+it('never reuses a socket — every acquire returns a fresh connection', function () {
+    /** @var SocketInterface[] $queue */
+    $queue = [];
+    for ($i = 0; $i < 3; $i++) {
+        [, $end] = Socket\createSocketPair();
+        $queue[] = $end;
+    }
+    $created = $queue;
+
+    $config = new Config('icap.example');
+    $pool = new NullConnectionPool(
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $created) {
+        $a = $pool->acquire($config);
+        $pool->release($config, $a);
+        // Even though $a was released, the next acquire must NOT return it.
+        $b = $pool->acquire($config);
+        expect($b)->not->toBe($created[0])
+            ->and($b)->toBe($created[1]);
+    });
+});
+
+it('closes the socket on release', function () {
+    [, $socket] = Socket\createSocketPair();
+
+    $config = new Config('icap.example');
+    $pool = new NullConnectionPool(
+        connector: fn () => $socket,
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $s = $pool->acquire($config);
+        expect($s->isClosed())->toBeFalse();
+        $pool->release($config, $s);
+        expect($s->isClosed())->toBeTrue();
+    });
+});
+
+it('close() is a no-op — no pooled sockets to shut down', function () {
+    $config = new Config('icap.example');
+    [, $socket] = Socket\createSocketPair();
+
+    $pool = new NullConnectionPool(
+        connector: fn () => $socket,
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $s = $pool->acquire($config);
+        $pool->close();
+        // The in-flight socket is NOT affected by close().
+        expect($s->isClosed())->toBeFalse();
+        // But release after close still closes the socket.
+        $pool->release($config, $s);
+        expect($s->isClosed())->toBeTrue();
+    });
+});
+
+it('uses the default connector when none is injected', function () {
+    // Verify the no-arg constructor doesn't throw.
+    $pool = new NullConnectionPool();
+    expect($pool)->toBeInstanceOf(ConnectionPoolInterface::class);
+});


### PR DESCRIPTION
## Context

v2.2-E2 from `consolidated_v2.1_task-list.md` — Codex reviewer flagged the
missing no-op pool variant. Unblocks v2.3 Symfony Bundle DI configuration
where pool strategy is a service parameter.

## API

- **New**: `Ndrstmr\Icap\Transport\NullConnectionPool implements ConnectionPoolInterface`
  - `acquire()` — opens a fresh connection every time (via amphp connector)
  - `release()` — closes the socket immediately, no idle storage
  - `close()` — no-op (nothing to clean up)
  - Constructor accepts optional `Closure $connector` for testing

No BC breaks.

## Behaviour

Every ICAP request gets its own TCP/TLS connection, closed after the
response is framed. No keep-alive, no idle pool. Useful for:
- Testing (inject socket pairs without pool state leaking between tests)
- Debugging (each request visible as a separate TCP connection in Wireshark)
- ICAP servers that send `Connection: close` on every response anyway

## Tests

`tests/Transport/NullConnectionPoolTest.php` — 5 tests:
- Implements `ConnectionPoolInterface`
- Never reuses a released socket
- Closes socket on release
- `close()` is a no-op, doesn't affect in-flight sockets
- Default connector construction without injection

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 112 tests passed
- [x] CI-Matrix (PHP 8.4 + 8.5)
- [x] Mutation Testing (MSI ≥ 65%)

## Closes

n/a — no issue for this item (tracked in task list only)

## Status

After merge: mark v2.2-E2 in task list. Next: v2.2-K/L (OPTIONS-driven tuning).