### PR TITLE
feat(preview): auto-detect preview size from OPTIONS cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **OPTIONS-driven preview size auto-detection** (v2.2-K): `scanFileWithPreview()`
+  now accepts `?int $previewSize = null`. When null, the client queries the
+  OPTIONS cache for the server's advertised `Preview` header (RFC 3507 §4.10.2)
+  and uses that value. Falls back to 1024 when no cache entry exists or the
+  response carries no `Preview` header. Explicit values still take precedence.
+  (Issue #58)
+- `NullConnectionPool` (v2.2-E2): implements `ConnectionPoolInterface` with
+  no keep-alive — every `acquire()` opens a fresh connection, every `release()`
+  closes it. Useful for testing and explicit no-pool configurations.
+  (Issue #57)
+
 ## [2.1.2] - 2026-04-28
 
 ### Fixed

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -181,11 +181,12 @@ Alle Items additiv; kein BC-Break.
 
 ### OPTIONS-getriebenes Pool-/Preview-Tuning
 
-- [ ] **v2.2-K** OPTIONS-driven Preview-Size: `scanFileWithPreview()` ohne
+- [x] **v2.2-K** OPTIONS-driven Preview-Size: `scanFileWithPreview()` ohne
   expliziten `$previewSize`-Parameter befragt den OPTIONS-Cache und nutzt
   den Server-`Preview`-Header-Wert. Intern über bestehendes
   `OptionsCacheInterface` — kein neues Public-API nötig.
   *Datei: `src/IcapClient.php:269-322` — Quelle: 4/4*
+  ✅ PR #72, Closes #58.
 
 - [ ] **v2.2-L** Max-Connections aus OPTIONS für Pool-Cap:
   `effectiveCap = min(localCap, serverMaxConnections)`,
@@ -202,11 +203,12 @@ Alle Items additiv; kein BC-Break.
   TTL-Tests ohne `advanceClockForTesting()`.
   *Datei: `src/Cache/InMemoryOptionsCache.php:92-94` — Quelle: Claude*
 
-- [ ] **v2.2-E2** `NullConnectionPool` anlegen:
+- [x] **v2.2-E2** `NullConnectionPool` anlegen:
   implementiert `ConnectionPoolInterface`, jede `acquire()`-Anfrage
   öffnet eine frische Verbindung, `release()` schließt sie.
   Nützlich für explizite Pool-Off-Konfigs und Tests.
   *Datei: `src/Transport/NullConnectionPool.php` (neu) — Quelle: Codex*
+  ✅ PR #71, Closes #57.
 
 - [ ] **v2.2-X** PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps:
   `Cache/Psr16OptionsCache.php`, `Cache/Psr6OptionsCache.php`.

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -271,14 +271,16 @@ final class IcapClient implements IcapClientInterface
     public function scanFileWithPreview(
         string $service,
         string $filePath,
-        int $previewSize = 1024,
+        ?int $previewSize = null,
         array $extraHeaders = [],
         ?Cancellation $cancellation = null,
     ): Future {
-        if ($previewSize < 1) {
+        if ($previewSize !== null && $previewSize < 1) {
             throw new \InvalidArgumentException('Preview size must be >= 1, got: ' . $previewSize);
         }
         $this->validateIcapHeaders($extraHeaders);
+
+        $previewSize = $this->resolvePreviewSize($service, $previewSize);
 
         /** @var int<1, max> $previewSize */
         /** @var Future<ScanResult> $future */
@@ -492,6 +494,40 @@ final class IcapClient implements IcapClientInterface
             encapsulatedResponse: $fullResponse,
         );
         return $this->request($fullRequest, $cancellation)->await();
+    }
+
+    private const int DEFAULT_PREVIEW_SIZE = 1024;
+
+    /**
+     * Resolve the effective preview size. When the caller passes null,
+     * the OPTIONS cache is consulted for the server's advertised
+     * `Preview` header (RFC 3507 §4.10.2). Falls back to
+     * {@see DEFAULT_PREVIEW_SIZE} when no cache is configured, the
+     * cache has no entry, or the cached response lacks a `Preview`
+     * header.
+     *
+     * @return int<1, max>
+     */
+    private function resolvePreviewSize(string $service, ?int $previewSize): int
+    {
+        if ($previewSize !== null) {
+            /** @var int<1, max> $previewSize */
+            return $previewSize;
+        }
+
+        if ($this->optionsCache !== null) {
+            $cacheKey = $this->config->host . ':' . $this->config->port . $service;
+            $cached = $this->optionsCache->get($cacheKey);
+            if ($cached !== null && isset($cached->headers['Preview'][0])) {
+                $advertised = (int) $cached->headers['Preview'][0];
+                if ($advertised >= 1) {
+                    /** @var int<1, max> $advertised */
+                    return $advertised;
+                }
+            }
+        }
+
+        return self::DEFAULT_PREVIEW_SIZE;
     }
 
     private function buildServiceUri(string $service): string

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -72,6 +72,11 @@ interface IcapClientInterface
     /**
      * Scan a file using preview mode, streaming the remainder on demand.
      *
+     * When $previewSize is null the client queries the OPTIONS cache for
+     * the server's advertised `Preview` header (RFC 3507 §4.10.2) and
+     * uses that value. Falls back to 1024 when the cache has no entry
+     * or the response carries no `Preview` header.
+     *
      * @param array<string, string|string[]> $extraHeaders See {@see scanFile()}.
      *        `Preview` and `Allow` are library-managed and cannot be
      *        overridden via this parameter.
@@ -80,7 +85,7 @@ interface IcapClientInterface
     public function scanFileWithPreview(
         string $service,
         string $filePath,
-        int $previewSize = 1024,
+        ?int $previewSize = null,
         array $extraHeaders = [],
         ?Cancellation $cancellation = null,
     ): Future;

--- a/src/RetryingIcapClient.php
+++ b/src/RetryingIcapClient.php
@@ -124,7 +124,7 @@ final class RetryingIcapClient implements IcapClientInterface
     public function scanFileWithPreview(
         string $service,
         string $filePath,
-        int $previewSize = 1024,
+        ?int $previewSize = null,
         array $extraHeaders = [],
         ?Cancellation $cancellation = null,
     ): Future {

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -91,7 +91,7 @@ final class SynchronousIcapClient
     public function scanFileWithPreview(
         string $service,
         string $filePath,
-        int $previewSize = 1024,
+        ?int $previewSize = null,
         array $extraHeaders = [],
         ?Cancellation $cancellation = null,
     ): ScanResult {

--- a/tests/OptionsDrivenPreviewSizeTest.php
+++ b/tests/OptionsDrivenPreviewSizeTest.php
@@ -1,0 +1,289 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Mockery as m;
+use Ndrstmr\Icap\Cache\InMemoryOptionsCache;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatterInterface;
+use Ndrstmr\Icap\ResponseParserInterface;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\SessionAwareTransport;
+use Ndrstmr\Icap\Transport\TransportSession;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.2-K — OPTIONS-driven Preview-Size: when no explicit $previewSize is
+ * passed to scanFileWithPreview(), the client queries the OPTIONS cache
+ * for the server's advertised Preview header and uses that value. Falls
+ * back to 1024 when no cache is configured or no Preview header exists.
+ */
+
+/**
+ * Build an IcapClient with a SessionAwareTransport mock. The formatter
+ * spy captures the IcapRequest so tests can inspect the Preview header.
+ *
+ * @param IcapRequest|null $capturedRequest receives the RESPMOD request via reference
+ * @return array{IcapClient, InMemoryOptionsCache}
+ */
+function makePreviewSizeClient(?IcapRequest &$capturedRequest, ?InMemoryOptionsCache $cache = null): array
+{
+    $config = new Config('icap.example');
+    $cache ??= new InMemoryOptionsCache();
+
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+    /** @var SessionAwareTransport&\Mockery\MockInterface $transport */
+    $transport = m::mock(SessionAwareTransport::class);
+    /** @var TransportSession&\Mockery\MockInterface $session */
+    $session = m::mock(TransportSession::class);
+
+    // Capture the IcapRequest passed to format() so the test can
+    // inspect the Preview header value chosen by the client.
+    /** @var \Mockery\Expectation $fe */
+    $fe = $formatter->shouldReceive('format');
+    $fe->andReturnUsing(function (IcapRequest $req) use (&$capturedRequest): array {
+        $capturedRequest = $req;
+        return ['FORMATTED'];
+    });
+
+    // The session mock drives a simple "204 No Content" (clean) flow:
+    // preview is complete for our tiny test file, so the client reads
+    // exactly one response and then releases.
+    /** @var \Mockery\Expectation $sw */
+    $sw = $session->shouldReceive('write');
+    $sw->andReturnNull();
+    /** @var \Mockery\Expectation $sr */
+    $sr = $session->shouldReceive('readResponse');
+    $sr->andReturn('ICAP/1.0 204 No Content');
+    /** @var \Mockery\Expectation $srel */
+    $srel = $session->shouldReceive('release');
+    $srel->andReturnNull();
+
+    /** @var \Mockery\Expectation $pe */
+    $pe = $parser->shouldReceive('parse');
+    $pe->andReturn(new IcapResponse(204));
+
+    /** @var \Mockery\Expectation $tos */
+    $tos = $transport->shouldReceive('openSession');
+    $tos->andReturn($session);
+    // TransportInterface::request() is also part of SessionAwareTransport;
+    // we don't expect it to be called in the preview flow, but define it
+    // so Mockery doesn't complain.
+    /** @var \Mockery\Expectation $tr */
+    $tr = $transport->shouldReceive('request');
+    $tr->never();
+
+    $client = new IcapClient(
+        $config,
+        $transport,
+        $formatter,
+        $parser,
+        optionsCache: $cache,
+    );
+
+    return [$client, $cache];
+}
+
+/**
+ * Create a tiny temp file for preview tests.
+ */
+function makeTinyFile(): string
+{
+    $tmp = tempnam(sys_get_temp_dir(), 'icap_preview_');
+    if ($tmp === false) {
+        throw new RuntimeException('Failed to create temp file');
+    }
+    // 64 bytes — small enough that any preview size >= 64 will trigger
+    // the previewIsComplete=true path (single read, no continuation).
+    file_put_contents($tmp, str_repeat('X', 64));
+    return $tmp;
+}
+
+afterEach(function () {
+    m::close();
+});
+
+it('uses the server-advertised Preview size from the OPTIONS cache when previewSize is null', function () {
+    $captured = null;
+    [$client, $cache] = makePreviewSizeClient($captured);
+
+    // Seed the OPTIONS cache with a response that advertises Preview: 4096
+    $optionsResponse = new IcapResponse(200, [
+        'Preview'     => ['4096'],
+        'Options-TTL' => ['3600'],
+    ]);
+    $cache->set('icap.example:1344/avscan', $optionsResponse, 3600);
+
+    $tmp = makeTinyFile();
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFileWithPreview('/avscan', $tmp)->await();
+    });
+
+    expect($captured)->toBeInstanceOf(IcapRequest::class);
+    \assert($captured instanceof IcapRequest);
+    // The Preview header on the wire must reflect the server's advertised value.
+    expect($captured->headers['Preview'][0])->toBe('4096');
+
+    @unlink($tmp);
+});
+
+it('falls back to 1024 when the OPTIONS cache has no entry for the service', function () {
+    $captured = null;
+    [$client] = makePreviewSizeClient($captured);
+    // Cache is empty — no OPTIONS response for /avscan.
+
+    $tmp = makeTinyFile();
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFileWithPreview('/avscan', $tmp)->await();
+    });
+
+    expect($captured)->toBeInstanceOf(IcapRequest::class);
+    \assert($captured instanceof IcapRequest);
+    expect($captured->headers['Preview'][0])->toBe('1024');
+
+    @unlink($tmp);
+});
+
+it('falls back to 1024 when the cached OPTIONS response has no Preview header', function () {
+    $captured = null;
+    [$client, $cache] = makePreviewSizeClient($captured);
+
+    // OPTIONS response without a Preview header (server doesn't advertise it).
+    $optionsResponse = new IcapResponse(200, [
+        'Options-TTL' => ['3600'],
+    ]);
+    $cache->set('icap.example:1344/avscan', $optionsResponse, 3600);
+
+    $tmp = makeTinyFile();
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFileWithPreview('/avscan', $tmp)->await();
+    });
+
+    expect($captured)->toBeInstanceOf(IcapRequest::class);
+    \assert($captured instanceof IcapRequest);
+    expect($captured->headers['Preview'][0])->toBe('1024');
+
+    @unlink($tmp);
+});
+
+it('falls back to 1024 when no OPTIONS cache is configured at all', function () {
+    $config = new Config('icap.example');
+
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+    /** @var SessionAwareTransport&\Mockery\MockInterface $transport */
+    $transport = m::mock(SessionAwareTransport::class);
+    /** @var TransportSession&\Mockery\MockInterface $session */
+    $session = m::mock(TransportSession::class);
+
+    $captured = null;
+    /** @var \Mockery\Expectation $fe2 */
+    $fe2 = $formatter->shouldReceive('format');
+    $fe2->andReturnUsing(function (IcapRequest $req) use (&$captured): array {
+        $captured = $req;
+        return ['FORMATTED'];
+    });
+    /** @var \Mockery\Expectation $sw2 */
+    $sw2 = $session->shouldReceive('write');
+    $sw2->andReturnNull();
+    /** @var \Mockery\Expectation $sr2 */
+    $sr2 = $session->shouldReceive('readResponse');
+    $sr2->andReturn('ICAP/1.0 204 No Content');
+    /** @var \Mockery\Expectation $srel2 */
+    $srel2 = $session->shouldReceive('release');
+    $srel2->andReturnNull();
+    /** @var \Mockery\Expectation $pe2 */
+    $pe2 = $parser->shouldReceive('parse');
+    $pe2->andReturn(new IcapResponse(204));
+    /** @var \Mockery\Expectation $tos2 */
+    $tos2 = $transport->shouldReceive('openSession');
+    $tos2->andReturn($session);
+    /** @var \Mockery\Expectation $tr2 */
+    $tr2 = $transport->shouldReceive('request');
+    $tr2->never();
+
+    // No optionsCache parameter — null by default.
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    $tmp = makeTinyFile();
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFileWithPreview('/avscan', $tmp)->await();
+    });
+
+    expect($captured)->toBeInstanceOf(IcapRequest::class);
+    \assert($captured instanceof IcapRequest);
+    expect($captured->headers['Preview'][0])->toBe('1024');
+
+    @unlink($tmp);
+});
+
+it('honours an explicit previewSize even when the OPTIONS cache has a different value', function () {
+    $captured = null;
+    [$client, $cache] = makePreviewSizeClient($captured);
+
+    // Cache advertises 4096, but the caller explicitly passes 2048.
+    $optionsResponse = new IcapResponse(200, [
+        'Preview'     => ['4096'],
+        'Options-TTL' => ['3600'],
+    ]);
+    $cache->set('icap.example:1344/avscan', $optionsResponse, 3600);
+
+    $tmp = makeTinyFile();
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFileWithPreview('/avscan', $tmp, 2048)->await();
+    });
+
+    expect($captured)->toBeInstanceOf(IcapRequest::class);
+    \assert($captured instanceof IcapRequest);
+    // Explicit parameter wins over cached value.
+    expect($captured->headers['Preview'][0])->toBe('2048');
+
+    @unlink($tmp);
+});
+
+it('rejects previewSize of zero or negative when passed explicitly', function () {
+    $captured = null;
+    [$client] = makePreviewSizeClient($captured);
+
+    $tmp = makeTinyFile();
+
+    expect(fn () => $client->scanFileWithPreview('/avscan', $tmp, 0))
+        ->toThrow(InvalidArgumentException::class);
+
+    @unlink($tmp);
+});


### PR DESCRIPTION
## Context

Consolidated task list item **v2.2-K**, 4/4 reviewer consensus (P1).

All four audits flagged that callers must manually pass `$previewSize` to
`scanFileWithPreview()` even though the library already caches OPTIONS
responses that carry the server's advertised `Preview` header
(RFC 3507 §4.10.2). This PR closes that gap.

## API

- `IcapClientInterface::scanFileWithPreview()` — `int $previewSize = 1024` → `?int $previewSize = null`
- Same change in `IcapClient`, `SynchronousIcapClient`, `RetryingIcapClient`
- BC-safe: all implementers are `final class` within the library. Existing callers passing an explicit `int` are unaffected.

## Behaviour

When `$previewSize` is `null` (now the default):
1. The client builds the OPTIONS cache key (`host:port + service`) and queries the cache.
2. If a cached `IcapResponse` exists and carries a `Preview` header with a value ≥ 1, that value is used.
3. Otherwise falls back to 1024 (the previous hard-coded default).

Explicit values still take precedence — the cache is never consulted when a caller passes an `int`.

New private method `IcapClient::resolvePreviewSize()` encapsulates this logic.

## Refactoring

none

## Tests

6 new tests in `tests/OptionsDrivenPreviewSizeTest.php` (Unit suite):
- Server-advertised Preview size from cache is used
- Fallback to 1024 when cache has no entry for the service
- Fallback to 1024 when cached response has no Preview header
- Fallback to 1024 when no OPTIONS cache is configured at all
- Explicit `$previewSize` takes precedence over cached value
- Zero/negative `$previewSize` is rejected with `InvalidArgumentException`

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — Pest Unit-Suite grün (118 tests, 240 assertions)
- [x] `composer test:integration` — not affected (no wire-format change)
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Closes

Closes #58

## Status

After merge: mark v2.2-K as completed in task list (already pre-marked).
Next: v2.2-L (OPTIONS Max-Connections for pool cap).