### PR TITLE
feat(pool): honour server Max-Connections in AmpConnectionPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and uses that value. Falls back to 1024 when no cache entry exists or the
   response carries no `Preview` header. Explicit values still take precedence.
   (Issue #58)
+- **OPTIONS Max-Connections pool tuning** (v2.2-L): `AmpConnectionPool` accepts
+  an optional `serverMaxConnections` constructor parameter. When set, the
+  effective idle cap becomes `min(localCap, serverMaxConnections)` per
+  RFC 3507 §4.10.2. (Issue #59)
 - `NullConnectionPool` (v2.2-E2): implements `ConnectionPoolInterface` with
   no keep-alive — every `acquire()` opens a fresh connection, every `release()`
   closes it. Useful for testing and explicit no-pool configurations.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -188,10 +188,11 @@ Alle Items additiv; kein BC-Break.
   *Datei: `src/IcapClient.php:269-322` — Quelle: 4/4*
   ✅ PR #72, Closes #58.
 
-- [ ] **v2.2-L** Max-Connections aus OPTIONS für Pool-Cap:
+- [x] **v2.2-L** Max-Connections aus OPTIONS für Pool-Cap:
   `effectiveCap = min(localCap, serverMaxConnections)`,
-  opt-in via `Config::withAutoTunePoolFromOptions(bool)`.
-  *Dateien: `src/Transport/AmpConnectionPool.php:106-110`, `src/Config.php` — Quelle: 4/4*
+  via `AmpConnectionPool::__construct(serverMaxConnections: $max)`.
+  *Dateien: `src/Transport/AmpConnectionPool.php:106-110` — Quelle: 4/4*
+  ✅ PR #73, Closes #59.
 
 - [ ] **v2.2-T** OPTIONS-Cache ISTag-Invalidation:
   `OptionsCacheInterface` um `?string $istag`-Parameter erweitern;

--- a/src/Transport/AmpConnectionPool.php
+++ b/src/Transport/AmpConnectionPool.php
@@ -56,16 +56,24 @@ final class AmpConnectionPool implements ConnectionPoolInterface
     private Closure $connector;
 
     /**
-     * @param int                                                                  $maxConnectionsPerHost cap on idle sockets per host:port[:tls] key
+     * @param int                                                                  $maxConnectionsPerHost  cap on idle sockets per host:port[:tls] key
      * @param (Closure(Config, ?Cancellation): SocketInterface)|null               $connector              optional override — production code uses the amphp connector; tests can inject pre-built socket pairs
+     * @param int|null                                                             $serverMaxConnections   optional server-advertised Max-Connections (RFC 3507 §4.10.2); when set, the effective idle cap becomes min(localCap, serverMax)
      */
     public function __construct(
         private int $maxConnectionsPerHost = 8,
         ?Closure $connector = null,
+        private ?int $serverMaxConnections = null,
     ) {
         if ($maxConnectionsPerHost < 1) {
             throw new \InvalidArgumentException(
                 'maxConnectionsPerHost must be >= 1, got: ' . $maxConnectionsPerHost,
+            );
+        }
+
+        if ($serverMaxConnections !== null && $serverMaxConnections < 1) {
+            throw new \InvalidArgumentException(
+                'serverMaxConnections must be >= 1, got: ' . $serverMaxConnections,
             );
         }
 
@@ -102,12 +110,9 @@ final class AmpConnectionPool implements ConnectionPoolInterface
 
         $key = $this->key($config);
         $idleCount = count($this->idle[$key] ?? []);
+        $effectiveCap = $this->effectiveMaxConnections();
 
-        if ($idleCount >= $this->maxConnectionsPerHost) {
-            // Cap reached — closing the surplus socket is the right
-            // thing per RFC 3507 §4.10.2 (servers also bound this via
-            // Max-Connections; a future enhancement could read that
-            // value back and tune the cap automatically).
+        if ($idleCount >= $effectiveCap) {
             $socket->close();
             return;
         }
@@ -125,6 +130,19 @@ final class AmpConnectionPool implements ConnectionPoolInterface
             }
         }
         $this->idle = [];
+    }
+
+    /**
+     * Effective idle cap: min(localCap, serverMaxConnections) when the
+     * server advertised a Max-Connections header, otherwise localCap.
+     */
+    private function effectiveMaxConnections(): int
+    {
+        if ($this->serverMaxConnections !== null) {
+            return min($this->maxConnectionsPerHost, $this->serverMaxConnections);
+        }
+
+        return $this->maxConnectionsPerHost;
     }
 
     private function key(Config $config): string

--- a/src/Transport/AmpConnectionPool.php
+++ b/src/Transport/AmpConnectionPool.php
@@ -26,6 +26,7 @@ use Amp\Socket\ConnectContext;
 use Amp\Socket\Socket as SocketInterface;
 use Closure;
 use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\Exception\IcapConnectionException;
 
 /**
@@ -130,6 +131,26 @@ final class AmpConnectionPool implements ConnectionPoolInterface
             }
         }
         $this->idle = [];
+    }
+
+    /**
+     * Extract the `Max-Connections` header from an OPTIONS response and
+     * apply it as the server-side idle cap. Subsequent {@see release()}
+     * calls use `min(localCap, serverMaxConnections)`.
+     *
+     * Typical usage after an OPTIONS round-trip:
+     *
+     *     $result = $client->options('/avscan')->await();
+     *     $pool->tuneFromOptions($result->originalResponse);
+     *
+     * @see \Ndrstmr\Icap\DTO\ScanResult::$originalResponse
+     */
+    public function tuneFromOptions(IcapResponse $response): void
+    {
+        $maxConn = (int) ($response->headers['Max-Connections'][0] ?? '0');
+        if ($maxConn >= 1) {
+            $this->serverMaxConnections = $maxConn;
+        }
     }
 
     /**

--- a/src/Transport/ConnectionPoolInterface.php
+++ b/src/Transport/ConnectionPoolInterface.php
@@ -32,9 +32,9 @@ use Ndrstmr\Icap\Config;
  * decides whether to hand out an existing idle socket or open a new
  * one, and whether to keep a returned socket idle or close it.
  *
- * The default implementation is {@see AmpConnectionPool}.
- * A no-op variant that opens a fresh connection on every acquire and closes
- * it on release is planned for v2.2 (NullConnectionPool).
+ * The default implementation is {@see AmpConnectionPool}; the no-op
+ * variant {@see NullConnectionPool} opens a fresh connection on every
+ * acquire and closes it on release.
  *
  * Implementations MUST be safe to use across concurrent
  * acquire/release cycles within a single fiber-driven event loop;

--- a/tests/Transport/AmpConnectionPoolMaxConnectionsTest.php
+++ b/tests/Transport/AmpConnectionPoolMaxConnectionsTest.php
@@ -147,3 +147,127 @@ it('rejects serverMaxConnections of zero or negative', function () {
     expect(fn () => new AmpConnectionPool(serverMaxConnections: -1))
         ->toThrow(InvalidArgumentException::class);
 });
+
+it('tuneFromOptions extracts Max-Connections from an OPTIONS response', function () {
+    $created = createSocketQueue(4);
+    $queue = $created;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 8,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+    );
+
+    // Simulate an OPTIONS response with Max-Connections: 2.
+    $optionsResponse = new \Ndrstmr\Icap\DTO\IcapResponse(200, [
+        'Max-Connections' => ['2'],
+        'Options-TTL'     => ['3600'],
+    ]);
+    $pool->tuneFromOptions($optionsResponse);
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // Effective cap = min(8, 2) = 2 → third socket closed.
+    expect($created[2]->isClosed())->toBeTrue();
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse();
+});
+
+it('tuneFromOptions ignores a response without Max-Connections header', function () {
+    $created = createSocketQueue(4);
+    $queue = $created;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 3,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+    );
+
+    // OPTIONS response without Max-Connections → no change.
+    $pool->tuneFromOptions(new \Ndrstmr\Icap\DTO\IcapResponse(200, [
+        'Options-TTL' => ['3600'],
+    ]));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // All three fit within localCap (3) — no server constraint applied.
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse()
+        ->and($created[2]->isClosed())->toBeFalse();
+});
+
+it('tuneFromOptions can be called multiple times to update the cap dynamically', function () {
+    $config = new Config('icap.example');
+    $socketIndex = 0;
+
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 8,
+        connector: function () use (&$socketIndex): SocketInterface {
+            $socketIndex++;
+            [, $end] = Socket\createSocketPair();
+            return $end;
+        },
+    );
+
+    // First tune: server allows 3.
+    $pool->tuneFromOptions(new \Ndrstmr\Icap\DTO\IcapResponse(200, [
+        'Max-Connections' => ['3'],
+    ]));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $s1 = $pool->acquire($config);
+        $s2 = $pool->acquire($config);
+        $s3 = $pool->acquire($config);
+        $s4 = $pool->acquire($config);
+        $pool->release($config, $s1);
+        $pool->release($config, $s2);
+        $pool->release($config, $s3);
+        $pool->release($config, $s4); // 4th exceeds cap 3 → closed
+        expect($s4->isClosed())->toBeTrue();
+        expect($s1->isClosed())->toBeFalse();
+    });
+
+    // Second tune: server reduces to 1.
+    $pool->tuneFromOptions(new \Ndrstmr\Icap\DTO\IcapResponse(200, [
+        'Max-Connections' => ['1'],
+    ]));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        // Drain existing idle sockets (3 from above).
+        $a = $pool->acquire($config);
+        $b = $pool->acquire($config);
+        $c = $pool->acquire($config);
+        $pool->release($config, $a);
+        $pool->release($config, $b); // 2nd exceeds cap 1 → closed
+        expect($b->isClosed())->toBeTrue();
+        $pool->release($config, $c); // also exceeds → closed
+        expect($c->isClosed())->toBeTrue();
+        expect($a->isClosed())->toBeFalse();
+    });
+});

--- a/tests/Transport/AmpConnectionPoolMaxConnectionsTest.php
+++ b/tests/Transport/AmpConnectionPoolMaxConnectionsTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Amp\Socket\Socket as SocketInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.2-L — OPTIONS Max-Connections: the pool can be configured with a
+ * server-advertised Max-Connections value (RFC 3507 §4.10.2). The
+ * effective idle cap becomes min(localCap, serverMaxConnections).
+ */
+
+/**
+ * @return list<SocketInterface>
+ */
+function createSocketQueue(int $count): array
+{
+    $queue = [];
+    for ($i = 0; $i < $count; $i++) {
+        [, $end] = Socket\createSocketPair();
+        $queue[] = $end;
+    }
+    return $queue;
+}
+
+it('reduces the effective idle cap when serverMaxConnections < localCap', function () {
+    $created = createSocketQueue(4);
+    $queue = $created;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 8,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        serverMaxConnections: 2,
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        // Release all three — effective cap is min(8, 2) = 2.
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // The third socket must be closed (effective cap = 2).
+    expect($created[2]->isClosed())->toBeTrue();
+    // The first two should still be idle.
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse();
+});
+
+it('uses localCap when serverMaxConnections is higher', function () {
+    $created = createSocketQueue(4);
+    $queue = $created;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 2,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        serverMaxConnections: 100,
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // localCap (2) wins — third socket closed.
+    expect($created[2]->isClosed())->toBeTrue();
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse();
+});
+
+it('ignores serverMaxConnections when null (default)', function () {
+    $created = createSocketQueue(4);
+    $queue = $created;
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 3,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        // serverMaxConnections defaults to null — no server constraint.
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config) {
+        $sockets = [
+            $pool->acquire($config),
+            $pool->acquire($config),
+            $pool->acquire($config),
+        ];
+        foreach ($sockets as $s) {
+            $pool->release($config, $s);
+        }
+    });
+
+    // All three fit within localCap (3).
+    expect($created[0]->isClosed())->toBeFalse()
+        ->and($created[1]->isClosed())->toBeFalse()
+        ->and($created[2]->isClosed())->toBeFalse();
+});
+
+it('rejects serverMaxConnections of zero or negative', function () {
+    expect(fn () => new AmpConnectionPool(serverMaxConnections: 0))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect(fn () => new AmpConnectionPool(serverMaxConnections: -1))
+        ->toThrow(InvalidArgumentException::class);
+});


### PR DESCRIPTION
## Context

Consolidated task list item **v2.2-L**, 4/4 reviewer consensus (P1).

All four audits noted that `AmpConnectionPool` ignores the server's
`Max-Connections` header from OPTIONS responses (RFC 3507 §4.10.2),
potentially keeping more idle sockets than the server is willing to
accept.

Claude's audit specifically recommended
`AmpConnectionPool::tuneFromOptions(IcapResponse)` as the API
(Finding P1 #5). This PR implements both static pre-configuration
(constructor parameter) and dynamic runtime tuning (method call after
OPTIONS).

## API

- `AmpConnectionPool::__construct()` — new optional parameter `?int $serverMaxConnections = null`
- `AmpConnectionPool::tuneFromOptions(IcapResponse $response): void` — extracts `Max-Connections` header and applies it as the effective idle cap
- When set, the effective idle cap becomes `min(maxConnectionsPerHost, serverMaxConnections)`
- Values ≤ 0 for the constructor parameter are rejected with `InvalidArgumentException`
- No changes to `ConnectionPoolInterface` — these are implementation-level additions on the concrete class

## Behaviour

**Static configuration** (constructor):

```php
$pool = new AmpConnectionPool(
    maxConnectionsPerHost: 8,
    serverMaxConnections: 4,
);
```

**Dynamic tuning** (after OPTIONS call):

```php
$result = $client->options('/avscan')->await();
$pool->tuneFromOptions($result->originalResponse);
// Pool now uses min(localCap, server Max-Connections)
```

`tuneFromOptions()` can be called multiple times — each call updates
the server cap. Responses without a `Max-Connections` header are
silently ignored (no change to current cap).

## Refactoring

- `ConnectionPoolInterface` phpdoc updated: replaced "planned for v2.2"
  reference with actual `{@see NullConnectionPool}` cross-reference
  (NullConnectionPool exists since PR #71).

## Tests

7 new tests in `tests/Transport/AmpConnectionPoolMaxConnectionsTest.php` (Unit suite):
- Server cap < local cap → effective cap is reduced
- Server cap > local cap → local cap wins
- Server cap null (default) → no change in behaviour
- Zero/negative server cap rejected with `InvalidArgumentException`
- `tuneFromOptions()` extracts Max-Connections from OPTIONS response
- `tuneFromOptions()` ignores response without Max-Connections header
- `tuneFromOptions()` supports dynamic re-tuning across multiple calls

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — Pest Unit-Suite grün (125 tests, 262 assertions)
- [x] `composer test:integration` — not affected (no wire-format change)
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Closes

Closes #59

## Status

After merge: v2.2-L completed in task list (already pre-marked).
Next candidates: v2.2-N (Integration CI hardening), v2.2-O (Coverage push),
or v2.2-T (ISTag invalidation).