### PR TITLE
ci(integration): remove continue-on-error, add nightly schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Nightly at 03:15 UTC — runs integration tests against the latest
+    # ClamAV signatures so wire-format regressions don't hide until the
+    # next push-to-main.
+    - cron: '15 3 * * *'
 
 jobs:
   # Unit tests + static analysis + coverage, run against every
@@ -54,13 +59,17 @@ jobs:
   # Integration tests against a real c-icap + ClamAV stack spun up via
   # docker-compose. Runs only on PHP 8.4 (the integration contract is
   # version-agnostic) to keep CI cost bounded.
+  #
+  # Runs on push-to-main and nightly schedule only — NOT on PRs. The
+  # ClamAV image needs 30–120 s for signature download on cold start,
+  # which is flaky on shared runners. Wire-format regressions surface
+  # on the next push-to-main or the nightly run; PRs are gated by
+  # unit tests + mutation testing instead.
   integration:
     name: Integration tests (c-icap + ClamAV)
     runs-on: ubuntu-latest
     needs: quality-and-tests
-    # Don't fail the whole workflow if the public image for c-icap or
-    # ClamAV is flaky — we'll know from the step status.
-    continue-on-error: true
+    if: github.event_name == 'push' || github.event_name == 'schedule'
 
     steps:
       - name: Checkout code
@@ -108,8 +117,6 @@ jobs:
         # --display-all-issues + --display-skipped print the full
         # assertion diffs that Pest normally hides behind a summary
         # line; --debug replaces the progress bar with event output.
-        # The integration job stays continue-on-error while we
-        # reverse-engineer the ICAP server contract.
         run: composer test:integration -- --display-all-issues --display-skipped --debug
 
       - name: Dump service logs on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closes it. Useful for testing and explicit no-pool configurations.
   (Issue #57)
 
+### Changed
+- **Integration CI hardened** (v2.2-N): removed `continue-on-error: true` from
+  the integration job. Integration tests now run on push-to-main and a nightly
+  schedule (03:15 UTC) instead of on every PR, avoiding flaky ClamAV image
+  bootstrapping on shared runners. Failures are now hard failures. (Issue #61)
+
 ## [2.1.2] - 2026-04-28
 
 ### Fixed

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -223,10 +223,11 @@ Alle Items additiv; kein BC-Break.
   *Datei: `.github/workflows/ci.yml:130-135` — Quelle: 4/4*
   ✅ PR #69, Closes #60. MSI 68.47% im ersten CI-Lauf.
 
-- [ ] **v2.2-N** Integration-CI aus `continue-on-error: true` herausführen:
+- [x] **v2.2-N** Integration-CI aus `continue-on-error: true` herausführen:
   entweder hartes Gate auf PRs oder Nightly-Workflow mit
   Required-Status-Check. Nightly empfohlen wegen flaky ClamAV-Image.
   *Datei: `.github/workflows/ci.yml:63` — Quelle: 3/4*
+  ✅ PR #74, Closes #61. Nightly + push-to-main, kein continue-on-error.
 
 - [ ] **v2.2-O** Coverage-Push auf Hotspot-Klassen. Ziele:
   `AmpConnectionPool` 54 → ≥ 90 %, `SynchronousStreamTransport` 41 → ≥ 85 %,


### PR DESCRIPTION
## Context

Consolidated task list item **v2.2-N**, 3/4 reviewer consensus (P1).

The integration job used `continue-on-error: true` since the initial CI
setup, masking wire-format regressions against the real c-icap + ClamAV
stack. Three of four audits flagged this as a P1 issue.

## API

none

## Behaviour

- Integration tests no longer run on `pull_request` events — PRs are
  gated by unit tests + mutation testing instead
- Integration tests run on `push` to main (after PR merge) and on a
  nightly `schedule` (03:15 UTC cron)
- `continue-on-error: true` is removed — integration failures are now
  hard failures
- The nightly schedule catches regressions from ClamAV signature updates
  or image changes within 24 hours

## Refactoring

none

## Tests

No new tests — this is a CI-only change. Existing integration tests are
unmodified; they now simply run in a context where failures are not
silenced.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — no source changes
- [x] `composer test` — no test changes
- [x] CI-Matrix (PHP 8.4 + 8.5) — integration job will be skipped on
  this PR (by design: `if: github.event_name == 'push' || 'schedule'`)

## Closes

Closes #61

## Status

After merge: integration tests run on the next push-to-main and
every night at 03:15 UTC. First nightly run will validate the schedule.