### PR TITLE
fix(security): strict RFC 7230 §3.2.6 tchar validation for header names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closes it. Useful for testing and explicit no-pool configurations.
   (Issue #57)
 
+### Changed
+- **Strict header-name validation** (v2.2-S): `IcapClient::validateIcapHeaders()`
+  now rejects any character outside the RFC 7230 §3.2.6 `tchar` set.
+  The previous blacklist regex only blocked control characters and the
+  colon; separator tokens like parentheses, brackets, slash, at-sign,
+  etc. slipped through. The new whitelist regex accepts only
+  `ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" /
+  "-" / "." / "^" / "_" / "`" / "|" / "~"`. (Issue #62)
+
 ## [2.1.2] - 2026-04-28
 
 ### Fixed

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -67,7 +67,7 @@
 | P | Strict-§4.5-Path nutzt eine Session-Lifetime-Cancellation statt per-IO | Korrektheit P2 | `Transport/AsyncAmpTransport.php:111-114` | Claude |
 | Q | Pool ohne Idle-Eviction → langlebige Workers akkumulieren Stale-Connections | Robustheit P2 | `Transport/AmpConnectionPool.php:42-46` | 4/4 |
 | R | obs-fold (RFC 7230) im `Encapsulated`-Header wird im Framer nicht erkannt | RFC P2 | `Transport/ResponseFrameReader.php:144-153` | Claude, Codex |
-| S | Header-Name-Validation-Regex lässt RFC-7230-§3.2.6 Separator-Tokens durch | Security P2 | `IcapClient.php:601` | Claude |
+| S | ~~Header-Name-Validation-Regex lässt RFC-7230-§3.2.6 Separator-Tokens durch~~ ✅ PR #75 | Security P2 | `IcapClient.php:637` | Claude |
 | T | OPTIONS-Cache ohne ISTag-Invalidation — Signature-Update wird nicht erkannt | RFC P2 | `Cache/InMemoryOptionsCache.php` | Claude |
 | U | `InMemoryOptionsCache` nutzt `time()` direkt, kein PSR-20 `ClockInterface` | Testbarkeit P2 | `Cache/InMemoryOptionsCache.php:92-94` | Claude |
 | V | `IcapClient::executeRaw()` ist `public` aber nicht im Interface — leakt internen Pfad | API P1 | `IcapClient.php:144` | Claude, Codex |
@@ -260,9 +260,10 @@ Alle Items additiv; kein BC-Break.
   vor dem Zeilenweise-Split auf.
   *Datei: `src/Transport/ResponseFrameReader.php:144-153` — Quelle: Claude, Codex*
 
-- [ ] **v2.2-S** Header-Name-Validation auf RFC-7230-§3.2.6-Token-Set
+- [x] **v2.2-S** Header-Name-Validation auf RFC-7230-§3.2.6-Token-Set
   verschärfen: `[!#$%&'*+\-.^_` + "`" + `|~0-9a-zA-Z]+`.
-  *Datei: `src/IcapClient.php:601` — Quelle: Claude*
+  ✅ PR #75, Closes #62.
+  *Datei: `src/IcapClient.php:637` — Quelle: Claude*
 
 ### Doku & Tooling
 

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -634,9 +634,12 @@ final class IcapClient implements IcapClientInterface
     private function validateIcapHeaders(array $headers): void
     {
         foreach ($headers as $name => $value) {
-            if (preg_match('/[\x00-\x1F\x7F:]/', $name) === 1) {
+            // RFC 7230 §3.2.6 — header names must consist of tchar only:
+            // tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+"
+            //       / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+            if (preg_match('/^[!#$%&\'*+\-.^_`|~0-9a-zA-Z]+$/', $name) !== 1) {
                 throw new \InvalidArgumentException(
-                    'ICAP header name contains control characters or separator: ' . var_export($name, true),
+                    'ICAP header name contains invalid characters (RFC 7230 §3.2.6): ' . var_export($name, true),
                 );
             }
             foreach ((array) $value as $v) {

--- a/tests/CustomRequestHeadersTest.php
+++ b/tests/CustomRequestHeadersTest.php
@@ -146,3 +146,68 @@ it('rejects header values that contain CR/LF (injection)', function () {
     expect(fn () => $client->scanFile('/svc', __FILE__, ['X-Bad' => "value\r\nInjected: 1"]))
         ->toThrow(InvalidArgumentException::class);
 });
+
+/**
+ * v2.2-S — RFC 7230 §3.2.6 strict header-name validation.
+ *
+ * tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" /
+ *         "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+ *
+ * Anything outside this set must be rejected. The previous regex only
+ * blocked control characters and the colon; separator tokens like
+ * parentheses, brackets, slash, at-sign etc. slipped through.
+ */
+
+it('rejects header names containing RFC 7230 separator tokens', function () {
+    $client = IcapClient::forServer('icap.example');
+
+    // Each of these characters is a valid ASCII printable but NOT a
+    // valid tchar — they must all be rejected.
+    $separators = ['(', ')', '<', '>', '@', ',', ';', '\\', '"', '/', '[', ']', '?', '=', '{', '}', ' ', "\t"];
+
+    foreach ($separators as $sep) {
+        expect(fn () => $client->scanFile('/svc', __FILE__, ["X-Bad{$sep}Name" => 'value']))
+            ->toThrow(InvalidArgumentException::class, '', "Separator '{$sep}' was not rejected in header name");
+    }
+});
+
+it('accepts valid tchar-only header names per RFC 7230', function () {
+    $captured = null;
+
+    $config = new Config('icap.example');
+    /** @var RequestFormatterInterface&\Mockery\MockInterface $formatter */
+    $formatter = m::mock(RequestFormatterInterface::class);
+    /** @var TransportInterface&\Mockery\MockInterface $transport */
+    $transport = m::mock(TransportInterface::class);
+    /** @var ResponseParserInterface&\Mockery\MockInterface $parser */
+    $parser = m::mock(ResponseParserInterface::class);
+
+    /** @var \Mockery\Expectation $f */
+    $f = $formatter->shouldReceive('format');
+    $f->andReturn(['HEAD']);
+    /** @var \Mockery\Expectation $t */
+    $t = $transport->shouldReceive('request');
+    $t->andReturn(\Amp\Future::complete('RAW'));
+    /** @var \Mockery\Expectation $p */
+    $p = $parser->shouldReceive('parse');
+    $p->andReturn(new IcapResponse(204));
+
+    $client = new IcapClient($config, $transport, $formatter, $parser);
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, 'payload');
+
+    // All valid tchar characters in a header name.
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp) {
+        $client->scanFile('/svc', $tmp, [
+            "X-Valid!#\$%&'*+-.^_`|~09azAZ" => 'ok',
+        ])->await();
+    });
+
+    // If we got here without exception, the name was accepted.
+    expect(true)->toBeTrue();
+
+    unlink($tmp);
+    m::close();
+});


### PR DESCRIPTION
## Context

v2.2-S from `docs/review/review_v2-1/consolidated_v2.1_task-list.md`, item S — source: Claude deep-research audit.

`IcapClient::validateIcapHeaders()` used a blacklist regex that only
rejected control characters (0x00–0x1F, 0x7F) and colons. RFC 7230 §3.2.6
defines header field names as `token`, which must consist exclusively of
`tchar` characters. Separator tokens like `( ) < > @ , ; \ " / [ ] ? = { }`,
space, and tab were silently accepted.

## API

none — internal validation tightened, no public API change.

## Behaviour

Callers passing header names containing RFC 7230 separator tokens now
receive an `InvalidArgumentException` before any byte reaches the socket.
Previously accepted names like `X-Bad(Name` or `X-Bad/Name` are now
rejected. This is a security hardening, not a BC break — the previous
behaviour was a bug per the RFC.

## Refactoring

none

## Tests

- `tests/CustomRequestHeadersTest.php`: 2 new tests (total 6 in the file,
  44 assertions):
  - **rejects separator tokens**: exercises all 18 RFC 7230 separator
    characters — each must throw `InvalidArgumentException`.
  - **accepts valid tchar-only names**: a header name containing every
    valid tchar character (`!#$%&'*+-.^_\`|~09azAZ`) must be accepted.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 127 passed, 299 assertions
- [ ] CI-Matrix (PHP 8.4 + 8.5)

## Closes

Closes #62

## Status

v2.2-S marked complete in consolidated task list. No tag needed — ships
with v2.2.0.