### PR TITLE
fix(wire): support RFC 7230 §3.2.4 obs-fold in Encapsulated header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   etc. slipped through. The new whitelist regex accepts only
   `ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" /
   "-" / "." / "^" / "_" / "`" / "|" / "~"`. (Issue #62)
+- **obs-fold support in ResponseFrameReader** (v2.2-R):
+  `findEncapsulatedHeader()` now unfolds RFC 7230 §3.2.4 obsolete line
+  folding (continuation lines starting with SP or HTAB) before parsing
+  the `Encapsulated` header value. Servers that fold long header values
+  across multiple lines (e.g. c-icap) previously caused the framer to
+  miss the body offset, truncating the response at the head separator.
+  (Issue #63)
 - **Integration CI hardened** (v2.2-N): removed `continue-on-error: true` from
   the integration job. Integration tests now run on push-to-main and a nightly
   schedule (03:15 UTC) instead of on every PR, avoiding flaky ClamAV image

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -66,7 +66,7 @@
 | O | Coverage-Hotspots: `AmpConnectionPool` 54 %, `SynchronousStreamTransport` 41 %, Socket-Error-Handling 63 % | Testing P1 | — | Jules |
 | P | Strict-§4.5-Path nutzt eine Session-Lifetime-Cancellation statt per-IO | Korrektheit P2 | `Transport/AsyncAmpTransport.php:111-114` | Claude |
 | Q | Pool ohne Idle-Eviction → langlebige Workers akkumulieren Stale-Connections | Robustheit P2 | `Transport/AmpConnectionPool.php:42-46` | 4/4 |
-| R | obs-fold (RFC 7230) im `Encapsulated`-Header wird im Framer nicht erkannt | RFC P2 | `Transport/ResponseFrameReader.php:144-153` | Claude, Codex |
+| R | ~~obs-fold (RFC 7230) im `Encapsulated`-Header wird im Framer nicht erkannt~~ ✅ PR #76 | RFC P2 | `Transport/ResponseFrameReader.php:144-155` | Claude, Codex |
 | S | ~~Header-Name-Validation-Regex lässt RFC-7230-§3.2.6 Separator-Tokens durch~~ ✅ PR #75 | Security P2 | `IcapClient.php:637` | Claude |
 | T | OPTIONS-Cache ohne ISTag-Invalidation — Signature-Update wird nicht erkannt | RFC P2 | `Cache/InMemoryOptionsCache.php` | Claude |
 | U | `InMemoryOptionsCache` nutzt `time()` direkt, kein PSR-20 `ClockInterface` | Testbarkeit P2 | `Cache/InMemoryOptionsCache.php:92-94` | Claude |
@@ -256,10 +256,11 @@ Alle Items additiv; kein BC-Break.
   (Default 30 s): Beim `acquire()` abgelaufene Idle-Einträge verwerfen.
   *Datei: `src/Transport/AmpConnectionPool.php:42-46` — Quelle: 4/4*
 
-- [ ] **v2.2-R** obs-fold (RFC 7230) im `Encapsulated`-Header:
+- [x] **v2.2-R** obs-fold (RFC 7230) im `Encapsulated`-Header:
   `ResponseFrameReader::findEncapsulatedHeader()` faltet Continuation-Lines
   vor dem Zeilenweise-Split auf.
-  *Datei: `src/Transport/ResponseFrameReader.php:144-153` — Quelle: Claude, Codex*
+  ✅ PR #76, Closes #63.
+  *Datei: `src/Transport/ResponseFrameReader.php:144-155` — Quelle: Claude, Codex*
 
 - [x] **v2.2-S** Header-Name-Validation auf RFC-7230-§3.2.6-Token-Set
   verschärfen: `[!#$%&'*+\-.^_` + "`" + `|~0-9a-zA-Z]+`.

--- a/src/Transport/ResponseFrameReader.php
+++ b/src/Transport/ResponseFrameReader.php
@@ -143,7 +143,13 @@ final class ResponseFrameReader
 
     private function findEncapsulatedHeader(string $headBlock): ?string
     {
-        $lines = preg_split('/\r?\n/', $headBlock) ?: [];
+        // RFC 7230 §3.2.4: obs-fold — a continuation line starts with
+        // at least one SP or HTAB and belongs to the previous header.
+        // Unfold before splitting so multi-line Encapsulated values
+        // (seen with c-icap) are parsed correctly.
+        $unfolded = (string) preg_replace('/\r?\n[ \t]+/', ' ', $headBlock);
+
+        $lines = preg_split('/\r?\n/', $unfolded) ?: [];
         foreach ($lines as $line) {
             if (preg_match('/^Encapsulated\s*:\s*(.+)$/i', $line, $m) === 1) {
                 return trim($m[1]);

--- a/tests/Transport/ResponseFrameReaderTest.php
+++ b/tests/Transport/ResponseFrameReaderTest.php
@@ -107,6 +107,61 @@ it('raises a malformed-response exception on EOF before any separator', function
 });
 
 /**
+ * v2.2-R — RFC 7230 §3.2.4 obs-fold support in the Encapsulated header.
+ *
+ * Some ICAP servers (notably c-icap under certain configurations) fold
+ * long headers across multiple lines using obs-fold: a continuation
+ * line starts with at least one SP or HTAB. The reader must unfold
+ * these before parsing the Encapsulated header value.
+ */
+
+it('handles obs-fold (continuation line) in the Encapsulated header — SP prefix', function () {
+    $http = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n";
+    // Encapsulated value is folded across two lines with a leading SP.
+    $bytes = "ICAP/1.0 200 OK\r\n"
+        . "ISTag: \"fold\"\r\n"
+        . "Encapsulated: res-hdr=0,\r\n"
+        . " res-body=" . strlen($http) . "\r\n"
+        . "\r\n"
+        . $http
+        . "3\r\nabc\r\n0\r\n\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([$bytes]));
+
+    expect($response)->toBe($bytes);
+});
+
+it('handles obs-fold (continuation line) in the Encapsulated header — HTAB prefix', function () {
+    $http = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\n";
+    // Folded with HTAB instead of SP.
+    $bytes = "ICAP/1.0 200 OK\r\n"
+        . "Encapsulated: res-hdr=0,\r\n"
+        . "\tres-body=" . strlen($http) . "\r\n"
+        . "\r\n"
+        . $http
+        . "3\r\nxyz\r\n0\r\n\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([$bytes]));
+
+    expect($response)->toBe($bytes);
+});
+
+it('handles obs-fold in the Encapsulated header with null-body', function () {
+    // null-body on a continuation line.
+    $bytes = "ICAP/1.0 204 No Content\r\n"
+        . "Encapsulated:\r\n"
+        . " null-body=0\r\n"
+        . "\r\n";
+
+    $reader = new ResponseFrameReader(maxResponseSize: 1 << 20, maxHeaderLineLength: 8192);
+    $response = $reader->readFrom(makeChunkProducer([$bytes]));
+
+    expect($response)->toBe($bytes);
+});
+
+/**
  * @param list<string> $chunks
  * @return Closure(): ?string
  */


### PR DESCRIPTION
## Context

v2.2-R from `docs/review/review_v2-1/consolidated_v2.1_task-list.md`, item R — source: Claude, Codex.

`ResponseFrameReader::findEncapsulatedHeader()` split the ICAP head
block into individual lines and matched each one against the
`Encapsulated` pattern. RFC 7230 §3.2.4 allows obsolete line folding
(obs-fold): a continuation line starting with SP or HTAB belongs to
the previous header. Servers that fold the Encapsulated header across
multiple lines (e.g. c-icap under certain configurations) caused the
framer to miss the body offset entirely, truncating the response at
the head separator.

Note: `ResponseParser::parseHeaderBlock()` already handled obs-fold
correctly — only `ResponseFrameReader` was affected.

## API

none — internal framing fix, no public API change.

## Behaviour

ICAP responses where the `Encapsulated` header is folded across
multiple lines (e.g. `Encapsulated: res-hdr=0,\r\n res-body=38\r\n`)
are now correctly framed. Previously the body was silently dropped.

## Refactoring

none

## Tests

- `tests/Transport/ResponseFrameReaderTest.php`: 3 new tests (total 9,
  10 assertions):
  - **obs-fold with SP prefix** — `Encapsulated: res-hdr=0,\r\n res-body=N`
    with chunked body, verifies full response is returned.
  - **obs-fold with HTAB prefix** — same scenario with `\t` instead of SP.
  - **obs-fold with null-body** — `Encapsulated:\r\n null-body=0`,
    verifies message ends at head separator.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 130 passed, 302 assertions
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Closes

Closes #63

## Status

v2.2-R marked complete in consolidated task list. No tag needed — ships
with v2.2.0.