### PR TITLE
feat(pool): idle-eviction based on configurable maxIdleSeconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Pool idle-eviction** (v2.2-Q): `AmpConnectionPool` now records when each
+  socket became idle and evicts entries older than `maxIdleSeconds` (default
+  30 s) on the next `acquire()`. Prevents stale socket accumulation in
+  long-running PHP workers (Swoole, RoadRunner, ReactPHP). The constructor
+  accepts optional `maxIdleSeconds` and `clock` parameters for tuning and
+  deterministic testing. (Issue #64)
 - **OPTIONS-driven preview size auto-detection** (v2.2-K): `scanFileWithPreview()`
   now accepts `?int $previewSize = null`. When null, the client queries the
   OPTIONS cache for the server's advertised `Preview` header (RFC 3507 §4.10.2)

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -65,7 +65,7 @@
 | N | Integration-CI `continue-on-error: true` → Wire-Format-Regressionen bleiben unerkannt | CI P1 | `.github/workflows/ci.yml:63` | 3/4 |
 | O | Coverage-Hotspots: `AmpConnectionPool` 54 %, `SynchronousStreamTransport` 41 %, Socket-Error-Handling 63 % | Testing P1 | — | Jules |
 | P | Strict-§4.5-Path nutzt eine Session-Lifetime-Cancellation statt per-IO | Korrektheit P2 | `Transport/AsyncAmpTransport.php:111-114` | Claude |
-| Q | Pool ohne Idle-Eviction → langlebige Workers akkumulieren Stale-Connections | Robustheit P2 | `Transport/AmpConnectionPool.php:42-46` | 4/4 |
+| Q | ~~Pool ohne Idle-Eviction → langlebige Workers akkumulieren Stale-Connections~~ ✅ PR #77 | Robustheit P2 | `Transport/AmpConnectionPool.php` | 4/4 |
 | R | ~~obs-fold (RFC 7230) im `Encapsulated`-Header wird im Framer nicht erkannt~~ ✅ PR #76 | RFC P2 | `Transport/ResponseFrameReader.php:144-155` | Claude, Codex |
 | S | ~~Header-Name-Validation-Regex lässt RFC-7230-§3.2.6 Separator-Tokens durch~~ ✅ PR #75 | Security P2 | `IcapClient.php:637` | Claude |
 | T | OPTIONS-Cache ohne ISTag-Invalidation — Signature-Update wird nicht erkannt | RFC P2 | `Cache/InMemoryOptionsCache.php` | Claude |
@@ -252,9 +252,10 @@ Alle Items additiv; kein BC-Break.
   in Phpdoc + CHANGELOG.
   *Datei: `src/Transport/AsyncAmpTransport.php:111-114` — Quelle: Claude*
 
-- [ ] **v2.2-Q** Pool-Idle-Eviction mit konfigurierbarem `maxIdleAge`
+- [x] **v2.2-Q** Pool-Idle-Eviction mit konfigurierbarem `maxIdleSeconds`
   (Default 30 s): Beim `acquire()` abgelaufene Idle-Einträge verwerfen.
-  *Datei: `src/Transport/AmpConnectionPool.php:42-46` — Quelle: 4/4*
+  ✅ PR #77, Closes #64.
+  *Datei: `src/Transport/AmpConnectionPool.php` — Quelle: 4/4*
 
 - [x] **v2.2-R** obs-fold (RFC 7230) im `Encapsulated`-Header:
   `ResponseFrameReader::findEncapsulatedHeader()` faltet Continuation-Lines

--- a/src/Transport/AmpConnectionPool.php
+++ b/src/Transport/AmpConnectionPool.php
@@ -39,16 +39,15 @@ use Ndrstmr\Icap\Exception\IcapConnectionException;
  * if none are usable. On {@see release()} a socket is pushed back
  * unless the per-host cap is reached, in which case it's closed.
  *
- * The pool keeps no separate idle timer — c-icap and most ICAP
- * vendors send `Connection: close` once they're done with a session
- * (or simply close the socket); the next {@see acquire()} drops the
- * stale entry and reconnects. A future enhancement could add an
- * idle-time eviction sweep if real deployments show socket
- * accumulation.
+ * Each entry records when it became idle. On {@see acquire()} entries
+ * older than `$maxIdleSeconds` (default 30 s) are evicted and closed
+ * before testing `isClosed()`. This prevents stale socket
+ * accumulation in long-running PHP workers (Swoole, RoadRunner,
+ * ReactPHP) where the server may have closed its end silently.
  */
 final class AmpConnectionPool implements ConnectionPoolInterface
 {
-    /** @var array<string, list<SocketInterface>> */
+    /** @var array<string, list<array{socket: SocketInterface, idleSince: float}>> */
     private array $idle = [];
 
     private bool $closed = false;
@@ -56,15 +55,22 @@ final class AmpConnectionPool implements ConnectionPoolInterface
     /** @var Closure(Config, ?Cancellation): SocketInterface */
     private Closure $connector;
 
+    /** @var Closure(): float */
+    private Closure $clock;
+
     /**
      * @param int                                                                  $maxConnectionsPerHost  cap on idle sockets per host:port[:tls] key
      * @param (Closure(Config, ?Cancellation): SocketInterface)|null               $connector              optional override — production code uses the amphp connector; tests can inject pre-built socket pairs
      * @param int|null                                                             $serverMaxConnections   optional server-advertised Max-Connections (RFC 3507 §4.10.2); when set, the effective idle cap becomes min(localCap, serverMax)
+     * @param float                                                                $maxIdleSeconds         idle sockets older than this are evicted on acquire() (default 30 s)
+     * @param (Closure(): float)|null                                              $clock                  monotonic clock for idle-age checks; defaults to microtime(true); injectable for deterministic tests
      */
     public function __construct(
         private int $maxConnectionsPerHost = 8,
         ?Closure $connector = null,
         private ?int $serverMaxConnections = null,
+        private float $maxIdleSeconds = 30.0,
+        ?Closure $clock = null,
     ) {
         if ($maxConnectionsPerHost < 1) {
             throw new \InvalidArgumentException(
@@ -78,7 +84,14 @@ final class AmpConnectionPool implements ConnectionPoolInterface
             );
         }
 
+        if ($maxIdleSeconds <= 0.0) {
+            throw new \InvalidArgumentException(
+                'maxIdleSeconds must be > 0, got: ' . $maxIdleSeconds,
+            );
+        }
+
         $this->connector = $connector ?? self::defaultConnector();
+        $this->clock = $clock ?? static fn (): float => microtime(true);
     }
 
     #[\Override]
@@ -89,13 +102,22 @@ final class AmpConnectionPool implements ConnectionPoolInterface
         }
 
         $key = $this->key($config);
+        $now = ($this->clock)();
 
         while (!empty($this->idle[$key])) {
-            $socket = array_pop($this->idle[$key]);
-            if (!$socket->isClosed()) {
-                return $socket;
+            $entry = array_pop($this->idle[$key]);
+            $socket = $entry['socket'];
+
+            if ($socket->isClosed()) {
+                continue;
             }
-            // Drop the stale entry and try the next one.
+
+            if (($now - $entry['idleSince']) > $this->maxIdleSeconds) {
+                $socket->close();
+                continue;
+            }
+
+            return $socket;
         }
 
         return ($this->connector)($config, $cancellation);
@@ -118,16 +140,19 @@ final class AmpConnectionPool implements ConnectionPoolInterface
             return;
         }
 
-        $this->idle[$key][] = $socket;
+        $this->idle[$key][] = [
+            'socket' => $socket,
+            'idleSince' => ($this->clock)(),
+        ];
     }
 
     #[\Override]
     public function close(): void
     {
         $this->closed = true;
-        foreach ($this->idle as $sockets) {
-            foreach ($sockets as $socket) {
-                $socket->close();
+        foreach ($this->idle as $entries) {
+            foreach ($entries as $entry) {
+                $entry['socket']->close();
             }
         }
         $this->idle = [];

--- a/tests/Transport/AmpConnectionPoolIdleEvictionTest.php
+++ b/tests/Transport/AmpConnectionPoolIdleEvictionTest.php
@@ -1,0 +1,190 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Amp\Socket\Socket as SocketInterface;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.2-Q — idle-eviction on acquire().
+ *
+ * Long-running PHP workers (Swoole, RoadRunner, ReactPHP) keep the
+ * event loop alive for hours. Without eviction, idle sockets
+ * accumulate and go stale silently — the server closes its end but
+ * isClosed() may not reflect that until the next write attempt.
+ * The pool now records when each socket became idle and drops entries
+ * older than maxIdleSeconds on the next acquire().
+ */
+
+it('evicts idle sockets that exceed maxIdleSeconds on acquire', function () {
+    $now = 1000.0;
+    [, $stale] = Socket\createSocketPair();
+    [, $fresh] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$stale, $fresh];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        maxIdleSeconds: 30.0,
+        clock: function () use (&$now): float {
+            return $now;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $fresh, &$now) {
+        $s = $pool->acquire($config);
+        $pool->release($config, $s);
+
+        // Advance clock past maxIdleSeconds.
+        $now = 1031.0;
+
+        // Next acquire must skip the stale entry and connect fresh.
+        $next = $pool->acquire($config);
+        expect($next)->toBe($fresh);
+    });
+
+    // The stale socket must have been closed by the eviction.
+    expect($stale->isClosed())->toBeTrue();
+});
+
+it('keeps idle sockets that are within maxIdleSeconds', function () {
+    $now = 1000.0;
+    [, $socket] = Socket\createSocketPair();
+    [, $spare] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$socket, $spare];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        maxIdleSeconds: 30.0,
+        clock: function () use (&$now): float {
+            return $now;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $socket, &$now) {
+        $s = $pool->acquire($config);
+        $pool->release($config, $s);
+
+        // Advance clock but stay within maxIdleSeconds.
+        $now = 1029.0;
+
+        $next = $pool->acquire($config);
+        // Same socket reused — not evicted.
+        expect($next)->toBe($socket);
+    });
+
+    // Spare was never needed.
+    expect($spare->isClosed())->toBeFalse();
+});
+
+it('defaults maxIdleSeconds to 30 when not specified', function () {
+    $now = 1000.0;
+    [, $stale] = Socket\createSocketPair();
+    [, $fresh] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$stale, $fresh];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        // maxIdleSeconds not set — default 30.
+        clock: function () use (&$now): float {
+            return $now;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $fresh, &$now) {
+        $s = $pool->acquire($config);
+        $pool->release($config, $s);
+
+        // 31 seconds later — exceeds the default 30s.
+        $now = 1031.0;
+
+        $next = $pool->acquire($config);
+        expect($next)->toBe($fresh);
+    });
+
+    expect($stale->isClosed())->toBeTrue();
+});
+
+it('rejects maxIdleSeconds of zero or negative', function () {
+    expect(fn () => new AmpConnectionPool(maxIdleSeconds: 0.0))
+        ->toThrow(InvalidArgumentException::class);
+
+    expect(fn () => new AmpConnectionPool(maxIdleSeconds: -5.0))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('evicts multiple stale sockets and connects fresh on acquire', function () {
+    $now = 1000.0;
+    [, $stale1] = Socket\createSocketPair();
+    [, $stale2] = Socket\createSocketPair();
+    [, $fresh] = Socket\createSocketPair();
+    /** @var SocketInterface[] $queue */
+    $queue = [$stale1, $stale2, $fresh];
+
+    $config = new Config('icap.example');
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use (&$queue): SocketInterface {
+            return array_shift($queue) ?? throw new RuntimeException('exhausted');
+        },
+        maxIdleSeconds: 10.0,
+        clock: function () use (&$now): float {
+            return $now;
+        },
+    );
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($pool, $config, $fresh, &$now) {
+        $a = $pool->acquire($config);
+        $b = $pool->acquire($config);
+        $pool->release($config, $a);
+        $pool->release($config, $b);
+
+        // Both are now stale.
+        $now = 1011.0;
+
+        $next = $pool->acquire($config);
+        expect($next)->toBe($fresh);
+    });
+
+    expect($stale1->isClosed())->toBeTrue()
+        ->and($stale2->isClosed())->toBeTrue();
+});


### PR DESCRIPTION
## Context

v2.2-Q from `docs/review/review_v2-1/consolidated_v2.1_task-list.md`, item Q — source: **4/4 reviewers** (strongest consensus in the v2.1 audit).

Long-running PHP workers (Swoole, RoadRunner, ReactPHP) keep the event
loop alive for hours. Without eviction, idle sockets accumulate — the
server closes its end but `isClosed()` doesn't reflect that until the
next write attempt, causing silent failures on the first request after
a pause.

## API

`AmpConnectionPool` constructor gains two optional parameters:

- `float $maxIdleSeconds = 30.0` — idle entries older than this are
  evicted and closed on the next `acquire()`.
- `(Closure(): float)|null $clock = null` — injectable monotonic clock;
  defaults to `microtime(true)`. Allows deterministic testing without
  `sleep()`.

Both are additive — existing callers are unaffected.

## Behaviour

On `acquire()`, the pool now checks `(now - idleSince) > maxIdleSeconds`
for each candidate before testing `isClosed()`. Expired entries are closed
and discarded. This prevents stale socket accumulation without requiring
a background eviction sweep.

The internal data structure changes from `list<SocketInterface>` to
`list<array{socket: SocketInterface, idleSince: float}>`. The LIFO stack
semantics are preserved.

## Refactoring

none — the data structure change is internal to `AmpConnectionPool`.

## Tests

- `tests/Transport/AmpConnectionPoolIdleEvictionTest.php`: 5 new tests
  (11 assertions):
  - **evicts stale sockets**: clock advanced past maxIdleSeconds → stale
    entry closed, fresh connection returned.
  - **keeps fresh sockets**: clock within threshold → same socket reused.
  - **default 30s**: no explicit maxIdleSeconds → default applies.
  - **rejects invalid maxIdleSeconds**: zero and negative values throw.
  - **evicts multiple stale entries**: two stale sockets evicted in one
    acquire cycle.
- All 14 existing pool tests (AmpConnectionPoolTest +
  AmpConnectionPoolMaxConnectionsTest) remain green.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 135 passed, 313 assertions
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Closes

v2.2-Q from the consolidated task list (no GitHub issue).

## Status

v2.2-Q marked complete in consolidated task list. No tag needed — ships
with v2.2.0.