### PR TITLE
chore(exception): add PHP 8.4 #[\Deprecated] to IcapResponseException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   closes it. Useful for testing and explicit no-pool configurations.
   (Issue #57)
 
+### Deprecated
+- **`IcapResponseException`** (v2.2-F): constructor now carries a PHP 8.4
+  `#[\Deprecated]` attribute with `since: '2.0'`. Instantiation triggers
+  `E_USER_DEPRECATED`. Use `IcapProtocolException`, `IcapClientException`
+  (4xx), or `IcapServerException` (5xx) instead. Will be removed in v3.0.0.
+
 ### Changed
 - **Strict header-name validation** (v2.2-S): `IcapClient::validateIcapHeaders()`
   now rejects any character outside the RFC 7230 §3.2.6 `tchar` set.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -54,7 +54,7 @@
 | C | `SECURITY.md` Z. 73-75 behauptet: kein Retry, kein Cache, kein Pooling — alles seit v2.0/2.1 implementiert | Doku P0 | `SECURITY.md:73-75` | Claude, Jules |
 | D | `scanFileWithPreviewStrict()` lädt Body-Remainder via `stream_get_contents()` in RAM → OOM bei GB-Uploads | OOM P1 | `IcapClient.php:399` | Claude, Codex ×2 |
 | E | `ConnectionPoolInterface` Phpdoc referenziert nicht-existente `NullConnectionPool`-Klasse | Doku/Code P1 | `Transport/ConnectionPoolInterface.php:36` | Codex |
-| F | `IcapResponseException` ist `@deprecated since 2.0, removal in M2` — M2 ist released, Klasse im Hot-Path | Inkonsistenz P1 | `Exception/IcapResponseException.php:28-32` | Claude, Codex |
+| F | ~~`IcapResponseException` ist `@deprecated since 2.0, removal in M2` — M2 ist released, Klasse im Hot-Path~~ ✅ PR #79 | Inkonsistenz P1 | `Exception/IcapResponseException.php` | Claude, Codex |
 | G | Cookbook `03-options-request.php` Z. 11-13: „next milestone after v2.0.0" — v2.0 ist released | Doku P1 | `examples/cookbook/03-options-request.php:11-13` | Claude |
 | H | Cookbook `02-custom-preview-strategy.php`: McAfee-Strategy mappt 200 → `ABORT_CLEAN` (Anti-Pattern, lehrt unsicheres Muster) | Doku P2 | `examples/cookbook/02-custom-preview-strategy.php` | Claude |
 | I | `phpunit.xml.dist`: `failOnRisky=false` + `failOnWarning=false`; 3 risky Tests im Unit-Run | CI P2 | `phpunit.xml.dist` | Codex-PR |
@@ -300,9 +300,10 @@ Alle Items additiv; kein BC-Break.
 - [ ] **v2.2-sbom** SBOM (CycloneDX/SPDX) in CI generieren.
   *Datei: `.github/workflows/ci.yml` — Quelle: Claude*
 
-- [ ] **v2.2-F** `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit
-  konkretem `v3.0.0`-Removal-Tag setzen.
-  *Datei: `src/Exception/IcapResponseException.php:28-32` — Quelle: Claude, Codex*
+- [x] **v2.2-F** `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit
+  konkretem `v3.0.0`-Removal-Tag auf dem Konstruktor gesetzt.
+  ✅ PR #79.
+  *Datei: `src/Exception/IcapResponseException.php` — Quelle: Claude, Codex*
 
 ### P3 — Nice-to-Have
 

--- a/src/Exception/IcapResponseException.php
+++ b/src/Exception/IcapResponseException.php
@@ -27,10 +27,13 @@ use RuntimeException;
  *
  * @deprecated since 2.0 — use the more specific IcapProtocolException,
  *   IcapMalformedResponseException, IcapClientException (4xx) or
- *   IcapServerException (5xx) introduced by M0.1. This class will be
- *   removed in a future minor release once all internal throw sites are
- *   migrated (M2).
+ *   IcapServerException (5xx). This class will be removed in v3.0.0.
  */
 class IcapResponseException extends RuntimeException implements IcapExceptionInterface
 {
+    #[\Deprecated(message: 'use IcapProtocolException, IcapClientException (4xx) or IcapServerException (5xx)', since: '2.0')]
+    public function __construct(string $message = '', int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
 }


### PR DESCRIPTION
## Context

v2.2-F from `docs/review/review_v2-1/consolidated_v2.1_task-list.md`,
item F — source: Claude, Codex.

`IcapResponseException` has carried a `@deprecated` PHPDoc tag since
v2.0 but lacked the native PHP 8.4 `#[\Deprecated]` attribute. Without
it, runtime callers get no deprecation notice — only static analysers
flag the usage.

## API

`IcapResponseException::__construct()` now carries
`#[\Deprecated(message: '...', since: '2.0')]`. Instantiation triggers
`E_USER_DEPRECATED` at runtime.

Note: PHP 8.4 does not support `#[\Deprecated]` on class declarations —
only on functions, methods, and class constants — so the attribute is
placed on the constructor.

## Behaviour

Code paths that throw `new IcapResponseException(...)` (currently
`IcapClient::interpretResponse()` and `DefaultPreviewStrategy`) now emit
a deprecation notice. This signals to callers that they should catch the
specific subtypes instead.

## Refactoring

none

## Tests

No new tests. The existing test suite reports 2 deprecation notices
from the two internal throw sites — expected and harmless. 138 passed,
323 assertions.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 138 passed, 323 assertions (2 deprecation notices)
- [ ] CI-Matrix (PHP 8.4 + 8.5)

## Closes

n/a — no GitHub issue for this task-list item.

## Status

v2.2-F marked complete in consolidated task list. The class will be
removed in v3.0.0 when all throw sites migrate to specific subtypes.