### PR TITLE
fix(transport): use per-IO timeout instead of session-lifetime timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `E_USER_DEPRECATED`. Use `IcapProtocolException`, `IcapClientException`
   (4xx), or `IcapServerException` (5xx) instead. Will be removed in v3.0.0.
 
+### Fixed
+- **Per-IO timeout for session-aware transports** (v2.2-P):
+  `AmpTransportSession` now creates a fresh `TimeoutCancellation` for each
+  `readResponse()` call instead of sharing a single session-lifetime timer.
+  For multi-round-trip flows (strict RFC 3507 §4.5 preview-continue), the
+  old timer accumulated across all IO phases — a server that legitimately
+  takes close to `streamTimeout` for a scan after `100 Continue` would
+  trigger a spurious `CancelledException`. Each IO phase now gets the full
+  `streamTimeout` window independently.
+
 ### Changed
 - **Strict header-name validation** (v2.2-S): `IcapClient::validateIcapHeaders()`
   now rejects any character outside the RFC 7230 §3.2.6 `tchar` set.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -249,9 +249,10 @@ Alle Items additiv; kein BC-Break.
 
 ### Korrektheit & Robustheit
 
-- [ ] **v2.2-P** Strict-§4.5-Path: per-IO-Timeout-Reset statt
+- [x] **v2.2-P** Strict-§4.5-Path: per-IO-Timeout-Reset statt
   Session-Lifetime-`TimeoutCancellation`. Alternativ: explizites Caveat
   in Phpdoc + CHANGELOG.
+  ✅ PR #80.
   *Datei: `src/Transport/AsyncAmpTransport.php:111-114` — Quelle: Claude*
 
 - [x] **v2.2-Q** Pool-Idle-Eviction mit konfigurierbarem `maxIdleSeconds`

--- a/src/Transport/AmpTransportSession.php
+++ b/src/Transport/AmpTransportSession.php
@@ -21,7 +21,9 @@ declare(strict_types=1);
 namespace Ndrstmr\Icap\Transport;
 
 use Amp\Cancellation;
+use Amp\CompositeCancellation;
 use Amp\Socket\Socket as SocketInterface;
+use Amp\TimeoutCancellation;
 use Ndrstmr\Icap\Config;
 
 /**
@@ -43,7 +45,8 @@ final class AmpTransportSession implements TransportSession
     public function __construct(
         private readonly Config $config,
         private readonly SocketInterface $socket,
-        private readonly Cancellation $cancellation,
+        private readonly float $streamTimeout,
+        private readonly ?Cancellation $userCancellation,
         private readonly int $maxResponseSize,
         private readonly int $maxHeaderLineLength,
         private readonly ?ConnectionPoolInterface $pool,
@@ -69,9 +72,25 @@ final class AmpTransportSession implements TransportSession
             maxResponseSize: $this->maxResponseSize,
             maxHeaderLineLength: $this->maxHeaderLineLength,
         );
-        $cancellation = $this->cancellation;
+        $cancellation = $this->makeIoCancellation();
         $socket = $this->socket;
         return $reader->readFrom(static fn (): ?string => $socket->read($cancellation));
+    }
+
+    /**
+     * Creates a fresh TimeoutCancellation for a single IO phase,
+     * combined with the optional user-supplied Cancellation.
+     *
+     * Each call gets the full streamTimeout window — no session-lifetime
+     * timer that accumulates across multiple preview-continue round trips.
+     */
+    private function makeIoCancellation(): Cancellation
+    {
+        $timeout = new TimeoutCancellation($this->streamTimeout);
+        if ($this->userCancellation === null) {
+            return $timeout;
+        }
+        return new CompositeCancellation($this->userCancellation, $timeout);
     }
 
     #[\Override]

--- a/src/Transport/AsyncAmpTransport.php
+++ b/src/Transport/AsyncAmpTransport.php
@@ -108,17 +108,22 @@ final class AsyncAmpTransport implements SessionAwareTransport
     #[\Override]
     public function openSession(Config $config, ?Cancellation $cancellation = null): TransportSession
     {
-        $timeoutCancellation = new TimeoutCancellation($config->getStreamTimeout());
-        $effective = $cancellation === null
-            ? $timeoutCancellation
-            : new CompositeCancellation($cancellation, $timeoutCancellation);
+        // Use a one-shot timeout for socket acquisition only.
+        $acquireCancellation = new TimeoutCancellation($config->getStreamTimeout());
+        $effectiveAcquire = $cancellation === null
+            ? $acquireCancellation
+            : new CompositeCancellation($cancellation, $acquireCancellation);
 
-        $socket = $this->acquireSocket($config, $effective);
+        $socket = $this->acquireSocket($config, $effectiveAcquire);
 
+        // The session creates a fresh TimeoutCancellation per IO call
+        // (write / readResponse), so each individual operation gets
+        // the full streamTimeout window — no session-lifetime timer.
         return new AmpTransportSession(
             config: $config,
             socket: $socket,
-            cancellation: $effective,
+            streamTimeout: $config->getStreamTimeout(),
+            userCancellation: $cancellation,
             maxResponseSize: $config->getMaxResponseSize(),
             maxHeaderLineLength: $config->getMaxHeaderLineLength(),
             pool: $this->pool,

--- a/tests/Transport/PerIoTimeoutTest.php
+++ b/tests/Transport/PerIoTimeoutTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Amp\Socket;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Tests\AsyncTestCase;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+uses(AsyncTestCase::class);
+
+/**
+ * v2.2-P — per-IO timeout instead of session-lifetime timeout.
+ *
+ * The previous implementation created a single TimeoutCancellation when
+ * opening the session. For multi-round-trip flows (strict §4.5 preview-
+ * continue), the timer ran continuously across all IO phases — a server
+ * that legitimately takes longer than streamTimeout to scan a large file
+ * after the 100 Continue would trigger a spurious cancellation.
+ *
+ * The fix resets the timeout on each write() and readResponse() call,
+ * so each individual IO operation gets the full streamTimeout window.
+ */
+
+it('per-IO timeout resets between preview phases — slow server does not trigger spurious cancellation', function () {
+    [$serverEnd, $clientEnd] = Socket\createSocketPair();
+
+    $pool = new AmpConnectionPool(
+        maxConnectionsPerHost: 4,
+        connector: function () use ($clientEnd) {
+            return $clientEnd;
+        },
+    );
+
+    // streamTimeout = 2s — each IO phase gets 2 s, but the total
+    // session (~3.5 s) exceeds 2 s due to simulated server delays.
+    $config = new Config('icap.example', streamTimeout: 2.0);
+    $client = new IcapClient(
+        $config,
+        new AsyncAmpTransport($pool),
+        new RequestFormatter(),
+        new ResponseParser(),
+    );
+
+    $tmp = tempnam(sys_get_temp_dir(), 'icap');
+    file_put_contents($tmp, str_repeat('X', 200));
+
+    /** @var AsyncTestCase $this */
+    $this->runAsyncTest(function () use ($client, $tmp, $serverEnd) {
+        $server = \Amp\async(static function () use ($serverEnd): void {
+            // Phase 1 — read preview, answer 100 Continue.
+            $buf = '';
+            while (!str_contains($buf, "0\r\n\r\n")) {
+                $chunk = $serverEnd->read();
+                if ($chunk === null) {
+                    return;
+                }
+                $buf .= $chunk;
+            }
+            // Simulate a slow 100 Continue — 1.5s delay before answering.
+            // Each delay is within the 2s per-IO window, but the two
+            // delays combined (3s) exceed the 2s session-lifetime.
+            \Amp\delay(1.5);
+            $serverEnd->write("ICAP/1.0 100 Continue\r\n\r\n");
+
+            // Phase 2 — read remainder.
+            $buf = '';
+            while (!str_contains($buf, "0\r\n\r\n")) {
+                $chunk = $serverEnd->read();
+                if ($chunk === null) {
+                    return;
+                }
+                $buf .= $chunk;
+            }
+
+            // Simulate a slow ClamAV scan — another 1.5s delay.
+            \Amp\delay(1.5);
+
+            $serverEnd->write("ICAP/1.0 204 No Content\r\nEncapsulated: null-body=0\r\n\r\n");
+            $serverEnd->close();
+        });
+
+        // This must NOT throw CancelledException — the 0.8s delay is
+        // within the per-IO 1s window, even though the total session
+        // exceeds 1s when all phases are summed.
+        $result = $client->scanFileWithPreview('/svc', $tmp, 32)->await();
+        $server->await();
+
+        expect($result->isInfected())->toBeFalse();
+    });
+
+    unlink($tmp);
+});


### PR DESCRIPTION
## Context

v2.2-P from `docs/review/review_v2-1/consolidated_v2.1_task-list.md` — Source: Claude audit.

`AsyncAmpTransport::openSession()` created a single `TimeoutCancellation` at
session start. For multi-round-trip flows (strict RFC 3507 §4.5 preview-continue),
this timer accumulated across all IO phases. A server that legitimately takes close
to `streamTimeout` per phase (e.g. ClamAV scanning a large file after `100 Continue`)
would trigger a spurious `CancelledException`, even though each individual IO
operation completed within the timeout window.

## API

Internal constructor change — no public API surface affected:
- `AmpTransportSession::__construct()` now takes `float $streamTimeout` and
  `?Cancellation $userCancellation` instead of a pre-built `Cancellation`.

## Behaviour

Each `readResponse()` call now gets a fresh `TimeoutCancellation` with the full
`streamTimeout` window. A two-phase preview-continue exchange where each phase
takes 1.5 s no longer fails with a 2 s `streamTimeout` (previously it would,
because 1.5 + 1.5 = 3.0 > 2.0 session-lifetime). User-supplied cancellations
are still honoured via `CompositeCancellation` on each IO call.

## Refactoring

- New private `AmpTransportSession::makeIoCancellation()` helper creates the
  per-IO composite cancellation.
- `AsyncAmpTransport::openSession()` creates a one-shot timeout for socket
  acquisition only, then passes `streamTimeout` + `userCancellation` to the
  session.

## Tests

- `tests/Transport/PerIoTimeoutTest.php` (Transport suite): socket-pair test
  with `streamTimeout: 2.0`, server-side delays of 1.5 s per phase (total 3 s).
  Confirms the operation succeeds with per-IO timeout but would fail under a
  session-lifetime timer.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 139 tests, 324 assertions, all green
- [x] `composer test:integration` — against `docker compose up -d`
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Status

v2.2-P marked complete in consolidated task list. No follow-up PR needed.