### PR TITLE
feat(cache): add PSR-6 and PSR-16 OPTIONS-cache adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **PSR-6 and PSR-16 OPTIONS-cache adapters** (v2.2-X): `Psr6OptionsCache` and
+  `Psr16OptionsCache` delegate to any PSR-6 `CacheItemPoolInterface` or PSR-16
+  `CacheInterface` implementation (Redis, APCu, Memcached, …). Both support key
+  prefixing, ISTag-based flush-on-change, and TTL pass-through. The PSR interfaces
+  are listed as `suggest` in composer.json — no hard dependency added.
 - **OPTIONS-cache ISTag invalidation** (v2.2-T): `OptionsCacheInterface::set()`
   accepts an optional `?string $istag` parameter. `InMemoryOptionsCache` tracks
   the last known ISTag and flushes all cached entries when it changes (RFC 3507

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,13 @@
     "pestphp/pest": "^3.8",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.2",
+    "psr/cache": "^3.0",
+    "psr/simple-cache": "^3.0",
     "roave/security-advisories": "dev-latest"
+  },
+  "suggest": {
+    "psr/cache": "Required for Psr6OptionsCache adapter (PSR-6 CacheItemPoolInterface)",
+    "psr/simple-cache": "Required for Psr16OptionsCache adapter (PSR-16 CacheInterface)"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6bc1a54bda805fe479693ffb87d2c24c",
+    "content-hash": "73643c1ccbf5063debbc0c04993d7be6",
     "packages": [
         {
             "name": "amphp/amp",
@@ -3703,6 +3703,55 @@
                 }
             ],
             "time": "2026-01-27T05:59:18+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -213,8 +213,9 @@ Alle Items additiv; kein BC-Break.
   *Datei: `src/Transport/NullConnectionPool.php` (neu) — Quelle: Codex*
   ✅ PR #71, Closes #57.
 
-- [ ] **v2.2-X** PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps:
+- [x] **v2.2-X** PSR-6/16 OPTIONS-Cache-Adapter als Optional-Deps:
   `Cache/Psr16OptionsCache.php`, `Cache/Psr6OptionsCache.php`.
+  ✅ PR #81.
   *Quelle: 3/4*
 
 ### CI-Härtung & Test-Reife

--- a/src/Cache/Psr16OptionsCache.php
+++ b/src/Cache/Psr16OptionsCache.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Cache;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Psr\SimpleCache\CacheInterface;
+
+/**
+ * OPTIONS-cache adapter that delegates to any PSR-16 (Simple Cache)
+ * implementation.
+ *
+ * The adapter stores each {@see IcapResponse} as a serializable array
+ * in the backing store. ISTag tracking uses a dedicated meta-key so
+ * the flush-on-change behaviour works across processes (unlike
+ * {@see InMemoryOptionsCache}, which is process-local).
+ *
+ * Requires `psr/simple-cache` ^3.0 — listed in composer.json `suggest`.
+ */
+final class Psr16OptionsCache implements OptionsCacheInterface
+{
+    private const string ISTAG_META_KEY = '__icap_istag';
+    private const string KEYS_META_KEY = '__icap_keys';
+
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly string $prefix = '',
+    ) {
+    }
+
+    #[\Override]
+    public function get(string $key): ?IcapResponse
+    {
+        /** @var array{statusCode: int, headers: array<string, list<string>>, body: string}|null $data */
+        $data = $this->cache->get($this->prefix . $key);
+        if ($data === null) {
+            return null;
+        }
+
+        return new IcapResponse(
+            $data['statusCode'],
+            $data['headers'],
+            $data['body'],
+        );
+    }
+
+    #[\Override]
+    public function set(string $key, IcapResponse $response, int $ttlSeconds, ?string $istag = null): void
+    {
+        if ($ttlSeconds <= 0) {
+            return;
+        }
+
+        if ($istag !== null) {
+            $this->handleIstagChange($istag);
+        }
+
+        $data = [
+            'statusCode' => $response->statusCode,
+            'headers'    => $response->headers,
+            'body'       => $response->body,
+        ];
+
+        $this->cache->set($this->prefix . $key, $data, $ttlSeconds);
+        $this->trackKey($key);
+    }
+
+    #[\Override]
+    public function delete(string $key): void
+    {
+        $this->cache->delete($this->prefix . $key);
+        $this->untrackKey($key);
+    }
+
+    /**
+     * When the ISTag changes, flush all previously tracked entries.
+     */
+    private function handleIstagChange(string $istag): void
+    {
+        /** @var string|null $stored */
+        $stored = $this->cache->get($this->prefix . self::ISTAG_META_KEY);
+
+        if ($stored !== null && $stored !== $istag) {
+            // ISTag changed — flush all tracked entries.
+            /** @var list<string> $keys */
+            $keys = $this->cache->get($this->prefix . self::KEYS_META_KEY) ?? [];
+            foreach ($keys as $trackedKey) {
+                $this->cache->delete($this->prefix . $trackedKey);
+            }
+            $this->cache->delete($this->prefix . self::KEYS_META_KEY);
+        }
+
+        // Always update to the latest ISTag (no TTL — lives as long as
+        // the cache backend keeps it, which is fine because we only use
+        // it for comparison).
+        $this->cache->set($this->prefix . self::ISTAG_META_KEY, $istag);
+    }
+
+    private function trackKey(string $key): void
+    {
+        /** @var list<string> $keys */
+        $keys = $this->cache->get($this->prefix . self::KEYS_META_KEY) ?? [];
+        if (!in_array($key, $keys, true)) {
+            $keys[] = $key;
+            $this->cache->set($this->prefix . self::KEYS_META_KEY, $keys);
+        }
+    }
+
+    private function untrackKey(string $key): void
+    {
+        /** @var list<string> $keys */
+        $keys = $this->cache->get($this->prefix . self::KEYS_META_KEY) ?? [];
+        $keys = array_values(array_filter($keys, static fn (string $k): bool => $k !== $key));
+        $this->cache->set($this->prefix . self::KEYS_META_KEY, $keys);
+    }
+}

--- a/src/Cache/Psr6OptionsCache.php
+++ b/src/Cache/Psr6OptionsCache.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+namespace Ndrstmr\Icap\Cache;
+
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * OPTIONS-cache adapter that delegates to any PSR-6
+ * (Cache Item Pool) implementation.
+ *
+ * The adapter stores each {@see IcapResponse} as a serializable array
+ * in the backing pool. ISTag tracking uses a dedicated meta-key so
+ * the flush-on-change behaviour works across processes (unlike
+ * {@see InMemoryOptionsCache}, which is process-local).
+ *
+ * Requires `psr/cache` ^3.0 — listed in composer.json `suggest`.
+ */
+final class Psr6OptionsCache implements OptionsCacheInterface
+{
+    private const string ISTAG_META_KEY = '__icap_istag';
+    private const string KEYS_META_KEY = '__icap_keys';
+
+    public function __construct(
+        private readonly CacheItemPoolInterface $pool,
+        private readonly string $prefix = '',
+    ) {
+    }
+
+    #[\Override]
+    public function get(string $key): ?IcapResponse
+    {
+        $item = $this->pool->getItem($this->prefix . $key);
+        if (!$item->isHit()) {
+            return null;
+        }
+
+        /** @var array{statusCode: int, headers: array<string, list<string>>, body: string} $data */
+        $data = $item->get();
+
+        return new IcapResponse(
+            $data['statusCode'],
+            $data['headers'],
+            $data['body'],
+        );
+    }
+
+    #[\Override]
+    public function set(string $key, IcapResponse $response, int $ttlSeconds, ?string $istag = null): void
+    {
+        if ($ttlSeconds <= 0) {
+            return;
+        }
+
+        if ($istag !== null) {
+            $this->handleIstagChange($istag);
+        }
+
+        $data = [
+            'statusCode' => $response->statusCode,
+            'headers'    => $response->headers,
+            'body'       => $response->body,
+        ];
+
+        $item = $this->pool->getItem($this->prefix . $key);
+        $item->set($data);
+        $item->expiresAfter($ttlSeconds);
+        $this->pool->save($item);
+
+        $this->trackKey($key);
+    }
+
+    #[\Override]
+    public function delete(string $key): void
+    {
+        $this->pool->deleteItem($this->prefix . $key);
+        $this->untrackKey($key);
+    }
+
+    /**
+     * When the ISTag changes, flush all previously tracked entries.
+     */
+    private function handleIstagChange(string $istag): void
+    {
+        $istagItem = $this->pool->getItem($this->prefix . self::ISTAG_META_KEY);
+
+        if ($istagItem->isHit()) {
+            /** @var string $stored */
+            $stored = $istagItem->get();
+            if ($stored !== $istag) {
+                // ISTag changed — flush all tracked entries.
+                $keysItem = $this->pool->getItem($this->prefix . self::KEYS_META_KEY);
+                /** @var list<string> $keys */
+                $keys = $keysItem->isHit() ? $keysItem->get() : [];
+                foreach ($keys as $trackedKey) {
+                    $this->pool->deleteItem($this->prefix . $trackedKey);
+                }
+                $this->pool->deleteItem($this->prefix . self::KEYS_META_KEY);
+            }
+        }
+
+        // Always update to the latest ISTag.
+        $item = $this->pool->getItem($this->prefix . self::ISTAG_META_KEY);
+        $item->set($istag);
+        $this->pool->save($item);
+    }
+
+    private function trackKey(string $key): void
+    {
+        $keysItem = $this->pool->getItem($this->prefix . self::KEYS_META_KEY);
+        /** @var list<string> $keys */
+        $keys = $keysItem->isHit() ? $keysItem->get() : [];
+        if (!in_array($key, $keys, true)) {
+            $keys[] = $key;
+            $newItem = $this->pool->getItem($this->prefix . self::KEYS_META_KEY);
+            $newItem->set($keys);
+            $this->pool->save($newItem);
+        }
+    }
+
+    private function untrackKey(string $key): void
+    {
+        $keysItem = $this->pool->getItem($this->prefix . self::KEYS_META_KEY);
+        /** @var list<string> $keys */
+        $keys = $keysItem->isHit() ? $keysItem->get() : [];
+        $keys = array_values(array_filter($keys, static fn (string $k): bool => $k !== $key));
+        $newItem = $this->pool->getItem($this->prefix . self::KEYS_META_KEY);
+        $newItem->set($keys);
+        $this->pool->save($newItem);
+    }
+}

--- a/tests/Cache/Psr16OptionsCacheTest.php
+++ b/tests/Cache/Psr16OptionsCacheTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Ndrstmr\Icap\Cache\Psr16OptionsCache;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Psr\SimpleCache\CacheInterface;
+
+it('delegates get to PSR-16 and reconstructs IcapResponse', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'icap.');
+
+    $response = new IcapResponse(200, ['Preview' => ['1024']]);
+    $cache->set('host:1344/svc', $response, 60);
+
+    $result = $cache->get('host:1344/svc');
+    expect($result)->not->toBeNull()
+        ->and($result?->statusCode)->toBe(200)
+        ->and($result?->headers['Preview'])->toBe(['1024']);
+});
+
+it('returns null on cache miss', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'icap.');
+
+    expect($cache->get('nonexistent'))->toBeNull();
+});
+
+it('delegates delete to PSR-16', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'icap.');
+
+    $cache->set('k', new IcapResponse(200), 60);
+    expect($cache->get('k'))->not->toBeNull();
+
+    $cache->delete('k');
+    expect($cache->get('k'))->toBeNull();
+});
+
+it('flushes all entries when ISTag changes', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'icap.');
+
+    $cache->set('svc1', new IcapResponse(200), 60, 'istag-v1');
+    $cache->set('svc2', new IcapResponse(204), 60, 'istag-v1');
+    expect($cache->get('svc1'))->not->toBeNull();
+    expect($cache->get('svc2'))->not->toBeNull();
+
+    // New ISTag → both entries should be flushed.
+    $cache->set('svc3', new IcapResponse(200), 60, 'istag-v2');
+    expect($cache->get('svc1'))->toBeNull();
+    expect($cache->get('svc2'))->toBeNull();
+    expect($cache->get('svc3'))->not->toBeNull();
+});
+
+it('does not cache when TTL is zero or negative', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'icap.');
+
+    $cache->set('k', new IcapResponse(200), 0);
+    expect($cache->get('k'))->toBeNull();
+
+    $cache->set('k', new IcapResponse(200), -5);
+    expect($cache->get('k'))->toBeNull();
+});
+
+it('uses key prefix to namespace entries in the backing store', function () {
+    $inner = new ArraySimpleCache();
+    $cache = new Psr16OptionsCache($inner, 'myapp.');
+
+    $cache->set('svc', new IcapResponse(200), 60);
+
+    // The inner store should have the prefixed key.
+    expect($inner->has('myapp.svc'))->toBeTrue();
+    expect($inner->has('svc'))->toBeFalse();
+});
+
+// --- In-memory PSR-16 implementation for testing ---
+
+/**
+ * Minimal PSR-16 implementation backed by an array. TTL is ignored
+ * (entries never expire) — sufficient for unit tests.
+ */
+final class ArraySimpleCache implements CacheInterface
+{
+    /** @var array<string, mixed> */
+    private array $store = [];
+
+    #[\Override]
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->store[$key] ?? $default;
+    }
+
+    #[\Override]
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+    {
+        $this->store[$key] = $value;
+        return true;
+    }
+
+    #[\Override]
+    public function delete(string $key): bool
+    {
+        unset($this->store[$key]);
+        return true;
+    }
+
+    #[\Override]
+    public function clear(): bool
+    {
+        $this->store = [];
+        return true;
+    }
+
+    #[\Override]
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->store[$key] ?? $default;
+        }
+        return $result;
+    }
+
+    /**
+     * @param iterable<string, mixed> $values
+     */
+    #[\Override]
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->store[$key] = $value;
+        }
+        return true;
+    }
+
+    #[\Override]
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            unset($this->store[$key]);
+        }
+        return true;
+    }
+
+    #[\Override]
+    public function has(string $key): bool
+    {
+        return array_key_exists($key, $this->store);
+    }
+}

--- a/tests/Cache/Psr6OptionsCacheTest.php
+++ b/tests/Cache/Psr6OptionsCacheTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/**
+ * SPDX-License-Identifier: EUPL-1.2
+ *
+ * This file is part of icap-flow.
+ *
+ * Licensed under the EUPL, Version 1.2 only (the "Licence");
+ * you may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ *     https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+declare(strict_types=1);
+
+use Ndrstmr\Icap\Cache\Psr6OptionsCache;
+use Ndrstmr\Icap\DTO\IcapResponse;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+it('delegates get to PSR-6 and reconstructs IcapResponse', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'icap.');
+
+    $response = new IcapResponse(200, ['Preview' => ['1024']]);
+    $cache->set('host:1344/svc', $response, 60);
+
+    $result = $cache->get('host:1344/svc');
+    expect($result)->not->toBeNull()
+        ->and($result?->statusCode)->toBe(200)
+        ->and($result?->headers['Preview'])->toBe(['1024']);
+});
+
+it('returns null on cache miss', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'icap.');
+
+    expect($cache->get('nonexistent'))->toBeNull();
+});
+
+it('delegates delete to PSR-6', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'icap.');
+
+    $cache->set('k', new IcapResponse(200), 60);
+    expect($cache->get('k'))->not->toBeNull();
+
+    $cache->delete('k');
+    expect($cache->get('k'))->toBeNull();
+});
+
+it('flushes all tracked entries when ISTag changes', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'icap.');
+
+    $cache->set('svc1', new IcapResponse(200), 60, 'istag-v1');
+    $cache->set('svc2', new IcapResponse(204), 60, 'istag-v1');
+    expect($cache->get('svc1'))->not->toBeNull();
+    expect($cache->get('svc2'))->not->toBeNull();
+
+    // New ISTag → both entries should be flushed.
+    $cache->set('svc3', new IcapResponse(200), 60, 'istag-v2');
+    expect($cache->get('svc1'))->toBeNull();
+    expect($cache->get('svc2'))->toBeNull();
+    expect($cache->get('svc3'))->not->toBeNull();
+});
+
+it('does not cache when TTL is zero or negative', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'icap.');
+
+    $cache->set('k', new IcapResponse(200), 0);
+    expect($cache->get('k'))->toBeNull();
+
+    $cache->set('k', new IcapResponse(200), -5);
+    expect($cache->get('k'))->toBeNull();
+});
+
+it('uses key prefix to namespace entries in the backing pool', function () {
+    $pool = new ArrayCacheItemPool();
+    $cache = new Psr6OptionsCache($pool, 'myapp.');
+
+    $cache->set('svc', new IcapResponse(200), 60);
+
+    expect($pool->hasItem('myapp.svc'))->toBeTrue();
+    expect($pool->hasItem('svc'))->toBeFalse();
+});
+
+// --- In-memory PSR-6 implementation for testing ---
+
+final class ArrayCacheItem implements CacheItemInterface
+{
+    private mixed $value = null;
+    private bool $isHit;
+    private ?int $ttl = null;
+
+    public function __construct(
+        private readonly string $key,
+        mixed $value = null,
+        bool $isHit = false,
+    ) {
+        $this->value = $value;
+        $this->isHit = $isHit;
+    }
+
+    #[\Override]
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    #[\Override]
+    public function get(): mixed
+    {
+        return $this->value;
+    }
+
+    #[\Override]
+    public function isHit(): bool
+    {
+        return $this->isHit;
+    }
+
+    #[\Override]
+    public function set(mixed $value): static
+    {
+        $this->value = $value;
+        $this->isHit = true;
+        return $this;
+    }
+
+    #[\Override]
+    public function expiresAt(?\DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    #[\Override]
+    public function expiresAfter(int|\DateInterval|null $time): static
+    {
+        if ($time instanceof \DateInterval) {
+            $this->ttl = (int) (new \DateTime())->add($time)->getTimestamp() - time();
+        } else {
+            $this->ttl = $time;
+        }
+        return $this;
+    }
+
+    public function getTtl(): ?int
+    {
+        return $this->ttl;
+    }
+}
+
+final class ArrayCacheItemPool implements CacheItemPoolInterface
+{
+    /** @var array<string, ArrayCacheItem> */
+    private array $items = [];
+
+    /** @var list<ArrayCacheItem> */
+    private array $deferred = [];
+
+    #[\Override]
+    public function getItem(string $key): CacheItemInterface
+    {
+        if (isset($this->items[$key])) {
+            return new ArrayCacheItem($key, $this->items[$key]->get(), true);
+        }
+        return new ArrayCacheItem($key);
+    }
+
+    /**
+     * @return iterable<string, CacheItemInterface>
+     */
+    #[\Override]
+    public function getItems(array $keys = []): iterable
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->getItem($key);
+        }
+        return $result;
+    }
+
+    #[\Override]
+    public function hasItem(string $key): bool
+    {
+        return isset($this->items[$key]);
+    }
+
+    #[\Override]
+    public function clear(): bool
+    {
+        $this->items = [];
+        $this->deferred = [];
+        return true;
+    }
+
+    #[\Override]
+    public function deleteItem(string $key): bool
+    {
+        unset($this->items[$key]);
+        return true;
+    }
+
+    #[\Override]
+    public function deleteItems(array $keys): bool
+    {
+        foreach ($keys as $key) {
+            unset($this->items[$key]);
+        }
+        return true;
+    }
+
+    #[\Override]
+    public function save(CacheItemInterface $item): bool
+    {
+        /** @var ArrayCacheItem $item */
+        $this->items[$item->getKey()] = $item;
+        return true;
+    }
+
+    #[\Override]
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        /** @var ArrayCacheItem $item */
+        $this->deferred[] = $item;
+        return true;
+    }
+
+    #[\Override]
+    public function commit(): bool
+    {
+        foreach ($this->deferred as $item) {
+            $this->save($item);
+        }
+        $this->deferred = [];
+        return true;
+    }
+}


### PR DESCRIPTION
## Context

v2.2-X from `docs/review/review_v2-1/consolidated_v2.1_task-list.md` — Source: 3/4 reviewers.

Production deployments that need cross-process OPTIONS caching (Redis, APCu,
Memcached, …) previously had to implement `OptionsCacheInterface` from scratch.
The new adapters bridge to PSR-6 / PSR-16 implementations, removing that
boilerplate.

## API

Two new classes, both `final class` implementing `OptionsCacheInterface`:

- `Psr16OptionsCache(CacheInterface $cache, string $prefix = '')`
- `Psr6OptionsCache(CacheItemPoolInterface $pool, string $prefix = '')`

`psr/cache` and `psr/simple-cache` are listed in composer.json `suggest`
(not `require`) — no hard dependency added. They are in `require-dev` for
the test doubles.

## Behaviour

Both adapters:
- Serialize `IcapResponse` as `array{statusCode, headers, body}` into the
  backing store (fully serializable, works with any PSR cache backend).
- Support configurable key prefix for namespace isolation in shared cache
  pools.
- Track ISTag via a dedicated meta-key in the backing store. When the ISTag
  changes, all previously tracked entries are flushed — cross-process safe,
  unlike `InMemoryOptionsCache`.
- TTL is passed through to the backing store. TTL <= 0 is a no-op.

## Refactoring

none

## Tests

- `tests/Cache/Psr16OptionsCacheTest.php` (Cache suite, 6 tests): get/set/
  delete delegation, cache miss, ISTag flush, TTL <= 0 no-op, key prefix.
  Includes `ArraySimpleCache` — minimal PSR-16 test double.
- `tests/Cache/Psr6OptionsCacheTest.php` (Cache suite, 6 tests): same
  coverage via PSR-6 path. Includes `ArrayCacheItem` + `ArrayCacheItemPool`
  test doubles.

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 151 tests, 354 assertions, all green
- [x] `composer test:integration` — against `docker compose up -d`
- [x] CI-Matrix (PHP 8.4 + 8.5)

## Status

v2.2-X marked complete in consolidated task list.