### PR TITLE
docs: v2.2 documentation epic — cookbook, README, compliance, contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,64 @@ below before opening an issue or submitting a pull request.
 ## Pull Request Process
 
 1. Fork the repository and create a branch for your changes.
-2. Implement your code and run `composer test`.
-3. Apply the coding style with `composer cs-fix`.
-4. Open a pull request against the `main` branch and reference any related issues.
+2. Implement your code and run all quality gates:
+   ```bash
+   composer cs-fix             # apply PSR-12 formatting
+   composer stan               # PHPStan Level 9 + bleedingEdge — must be clean
+   composer test               # Pest unit suite — must be green
+   ```
+3. Open a pull request against the `main` branch and reference any related issues.
+
+## Commit Convention
+
+This repository follows [Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+### Format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Types
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` — do not invent custom types.
+
+### Scopes
+
+Use when it adds clarity. Common scopes: `transport`, `wire`, `preview`, `pool`, `cache`, `security`, `IcapClient`.
+
+### Rules
+
+- **Subject:** imperative mood, lowercase, no trailing period, max ~70 characters.
+- **Body:** mandatory. Explain *why*, not *what* — the diff shows the what.
+- **Footer:** use `Closes #XX` (not `Refs`) to auto-close GitHub issues. `BREAKING CHANGE:` for any BC-break.
+
+### Examples
+
+```
+feat(cache): add PSR-16 OPTIONS-cache adapter
+
+Production deployments with Redis or APCu can now plug their existing
+PSR-16 CacheInterface into the OPTIONS cache without implementing
+OptionsCacheInterface from scratch.
+
+Closes #81
+```
+
+```
+fix(transport): use per-IO timeout instead of session-lifetime timer
+
+The session-lifetime timer accumulated across preview-continue phases,
+causing spurious CancelledException on slow but legitimate scans.
+```
 
 ## Coding Standards
 
-The source code follows the [PSR-12](https://www.php-fig.org/psr/psr-12/) standard.
-
+- [PSR-12](https://www.php-fig.org/psr/psr-12/) enforced via `composer cs-fix` (php-cs-fixer).
+- PHP 8.4 minimum. `final class` on all classes in `src/`. `#[\Override]` on every interface implementation.
+- PHPStan Level 9 + bleedingEdge — no baseline, no `@phpstan-ignore`.
+- EUPL-1.2 license header required in every PHP file (applied automatically by cs-fix).

--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ $client = new IcapClient(
 );
 ```
 
+### Connection pool
+
+For long-running workers (RoadRunner, Swoole, ReactPHP) the async transport can reuse sockets via a connection pool:
+
+```php
+use Ndrstmr\Icap\Cache\InMemoryOptionsCache;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+$pool = new AmpConnectionPool(
+    maxConnectionsPerHost: 8,    // idle-socket cap per host:port:tls
+    maxIdleSeconds: 30.0,        // evict sockets idle longer than 30 s
+);
+
+$transport = new AsyncAmpTransport($pool);
+
+// Optional: pass an OPTIONS cache so the client auto-negotiates
+// preview size and honours Options-TTL / ISTag invalidation.
+$cache = new InMemoryOptionsCache();
+// For cross-process caching (Redis, APCu) use Psr16OptionsCache
+// or Psr6OptionsCache instead.
+
+$client = new IcapClient($config, $transport, new RequestFormatter(), new ResponseParser(), optionsCache: $cache);
+```
+
 ## Custom request headers
 
 ```php
@@ -162,6 +187,10 @@ The `examples/` directory has runnable demos, including a full Symfony-ready asy
 - `examples/cookbook/01-custom-headers.php` — `X-Client-IP`, `X-Authenticated-User`
 - `examples/cookbook/02-custom-preview-strategy.php` — vendor-specific preview interpretation
 - `examples/cookbook/03-options-request.php` — capability discovery via OPTIONS
+- `examples/cookbook/04-tls-mtls.php` — TLS and mutual TLS (mTLS) setup
+- `examples/cookbook/05-retry-decorator.php` — exponential-backoff retry on 5xx
+- `examples/cookbook/06-pool-tuning.php` — connection-pool idle eviction and Max-Connections
+- `examples/cookbook/07-cancellation-from-upload.php` — timeout and user-initiated cancellation
 
 ## Integration tests
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,56 @@
+# Compliance Mapping
+
+This document maps `ndrstmr/icap-flow` capabilities to common regulatory and
+security frameworks relevant for European public-sector deployments.
+
+> **Disclaimer.** This mapping is informational — it does not constitute a
+> certification or formal compliance statement. Large parts of this library
+> were authored with AI assistance (see the [AI-assisted development
+> disclaimer](../README.md) and `docs/review/`). Deployers must conduct
+> their own independent review and integration testing before production use.
+
+## BSI IT-Grundschutz
+
+### OPS.1.1.4 — Schutz vor Schadprogrammen
+
+| Requirement | Coverage |
+|---|---|
+| Malware scanning of uploaded content | Core purpose — `scanFile()` / `scanFileWithPreview()` via ICAP (RFC 3507) |
+| Support for multiple AV engines | `Config::withVirusFoundHeaders()` supports ClamAV, Symantec, Trend Micro, Sophos, McAfee, Kaspersky header conventions |
+| Fail-secure on unknown status codes | `IcapClient::interpretResponse()` throws typed exceptions for anything that is not a clear clean signal (204 / 200 without virus header) |
+| Logging of scan results | PSR-3 structured logging with `method`, `uri`, `host`, `port`, `statusCode`, `infected` context keys |
+| Retry on transient failures | `RetryingIcapClient` decorator with exponential backoff on 5xx |
+
+### APP.4.4 — Webanwendungen und Webservices (excerpt)
+
+| Requirement | Coverage |
+|---|---|
+| Input validation on external data | Header-name validation (RFC 7230 §3.2.6 tchar whitelist), URI path validation (no CRLF/NUL injection), DoS limits on response size / header count / header line length |
+| TLS for inter-service communication | `Config::withTlsContext()` — TLS 1.2/1.3 via `amphp/socket`, mTLS supported |
+| Connection management | `AmpConnectionPool` with idle eviction, per-host caps, server-side `Max-Connections` awareness, TLS-context-isolated pool keys |
+
+## DSGVO / GDPR — Art. 32 (Security of Processing)
+
+| Measure | Coverage |
+|---|---|
+| Encryption in transit | TLS/mTLS support for ICAP connections (see `examples/cookbook/04-tls-mtls.php`) |
+| Minimisation of data exposure | File contents are streamed, not buffered in memory; `RequestFormatter::format()` emits chunked-transfer encoding. Response headers are not logged (regression-tested in `tests/LoggerIntegrationTest.php`) |
+| Resilience | Connection pooling with idle eviction, retry decorator, per-IO timeouts (no session-lifetime accumulation) |
+| Auditability | PSR-3 structured log events at request start and completion; EUPL-1.2 license ensures source availability |
+
+## EUPL-1.2 License
+
+The library is licensed under EUPL-1.2, which is:
+- Recognised by the European Commission as an open-source licence for public-sector software.
+- Listed on [OpenCoDE](https://opencode.de/) as a compatible licence.
+- Compatible with GPL-2.0, GPL-3.0, LGPL, AGPL, MPL, EUPL, and other licences listed in the EUPL Appendix.
+
+## AI-Assisted Development
+
+This library was developed with significant AI assistance. Four independent
+deep-research audits (Claude, Codex ×2, Jules) are documented in
+`docs/review/review_v2-1/` with a consolidated task list that tracks every
+finding to resolution. The audit consensus is TRL-7 (system prototype
+demonstration in operational environment) with scores of 74–77/100.
+
+See the [README disclaimer](../README.md) for the full statement.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -275,21 +275,25 @@ Alle Items additiv; kein BC-Break.
 
 ### Doku & Tooling
 
-- [ ] **v2.2-cookbook** 4 neue Cookbook-Files:
+- [x] **v2.2-cookbook** 4 neue Cookbook-Files:
   `04-tls-mtls.php`, `05-retry-decorator.php`,
   `06-pool-tuning.php`, `07-cancellation-from-upload.php`.
+  ✅ PR #84.
   *Dateien: `examples/cookbook/` — Quelle: Claude, Codex*
 
-- [ ] **v2.2-readme** Connection-Pool-Konfiguration im README-Config-Block
+- [x] **v2.2-readme** Connection-Pool-Konfiguration im README-Config-Block
   dokumentieren.
+  ✅ PR #84.
   *Datei: `README.md:89-129` — Quelle: Claude*
 
-- [ ] **v2.2-compliance** `docs/compliance.md` mit BSI OPS.1.1.4 / APP.4.4 /
+- [x] **v2.2-compliance** `docs/compliance.md` mit BSI OPS.1.1.4 / APP.4.4 /
   DSGVO Art. 32-Mapping + AI-Disclaimer-Verlinkung.
+  ✅ PR #84.
   *Datei: `docs/compliance.md` (neu) — Quelle: Claude*
 
-- [ ] **v2.2-contrib** CONTRIBUTING.md um Conventional-Commits-Konvention
+- [x] **v2.2-contrib** CONTRIBUTING.md um Conventional-Commits-Konvention
   ergänzen (Typen, Scopes, Body-Pflicht).
+  ✅ PR #84.
   *Datei: `CONTRIBUTING.md` — Quelle: Claude*
 
 - [x] **v2.2-F** `IcapResponseException`: PHP 8.4 `#[\Deprecated]` mit

--- a/examples/cookbook/04-tls-mtls.php
+++ b/examples/cookbook/04-tls-mtls.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Amp\Socket\ClientTlsContext;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+/*
+ * TLS / mTLS — connect to an ICAP server that requires encrypted
+ * transport (icaps://). Most enterprise appliances (Symantec, Trend
+ * Micro, Sophos) expose their ICAP interface on port 11344 with TLS.
+ *
+ * For mTLS (mutual TLS) the client presents its own certificate,
+ * which the appliance verifies against a trusted CA. This is typical
+ * in zero-trust or BSI-Grundschutz-aligned environments.
+ */
+
+// --- Plain TLS (server-only verification) ---
+
+$config = (new Config(
+    host: 'icap.example.com',
+    port: 11344,
+))
+    ->withTlsContext(
+        (new ClientTlsContext('icap.example.com'))
+            ->withCaFile('/etc/ssl/certs/ca-certificates.crt'),
+    );
+
+$client = new IcapClient(
+    $config,
+    new AsyncAmpTransport(new AmpConnectionPool()),
+    new RequestFormatter(),
+    new ResponseParser(),
+);
+
+// --- mTLS (client certificate) ---
+
+$mtlsConfig = (new Config(
+    host: 'icap-secure.internal',
+    port: 11344,
+))
+    ->withTlsContext(
+        (new ClientTlsContext('icap-secure.internal'))
+            ->withCaFile('/etc/pki/tls/certs/corporate-ca.pem')
+            ->withCertificate(new \Amp\Socket\Certificate(
+                '/etc/pki/tls/certs/client.pem',
+                '/etc/pki/tls/private/client.key',
+            )),
+    );
+
+$mtlsClient = new IcapClient(
+    $mtlsConfig,
+    new AsyncAmpTransport(new AmpConnectionPool()),
+    new RequestFormatter(),
+    new ResponseParser(),
+);
+
+// Both clients work identically from here:
+\Amp\async(function () use ($client) {
+    $result = $client->scanFile('/avscan', __DIR__ . '/../eicar.com')->await();
+    echo $result->isInfected()
+        ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+        : 'Clean' . PHP_EOL;
+});
+
+\Revolt\EventLoop::run();

--- a/examples/cookbook/05-retry-decorator.php
+++ b/examples/cookbook/05-retry-decorator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\RetryingIcapClient;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+/*
+ * RetryingIcapClient — automatic exponential-backoff retries for
+ * transient ICAP 5xx server errors.
+ *
+ * The decorator wraps any IcapClientInterface and replays the request
+ * on IcapServerException (503 Service Unavailable, 500 Internal Error,
+ * etc.). Client errors (4xx) are NOT retried — those indicate a caller
+ * mistake.
+ *
+ * Typical use case: ClamAV reloading signatures (returns 503 for a
+ * few seconds), brief network blips behind a load balancer, or a
+ * vendor appliance under heavy load.
+ */
+
+$config = new Config('icap.example.com');
+
+$inner = new IcapClient(
+    $config,
+    new AsyncAmpTransport(new AmpConnectionPool()),
+    new RequestFormatter(),
+    new ResponseParser(),
+);
+
+$client = new RetryingIcapClient(
+    inner: $inner,
+    maxAttempts: 3,              // give up after 3 tries
+    baseDelaySeconds: 0.5,       // first retry after 0.5 s
+    backoffMultiplier: 2.0,      // 0.5 → 1.0 → 2.0 s
+    maxDelaySeconds: 5.0,        // cap at 5 s between retries
+);
+
+// Use $client exactly like a regular IcapClient:
+\Amp\async(function () use ($client) {
+    $result = $client->scanFile('/avscan', __DIR__ . '/../eicar.com')->await();
+
+    echo $result->isInfected()
+        ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+        : 'Clean' . PHP_EOL;
+});
+
+\Revolt\EventLoop::run();

--- a/examples/cookbook/06-pool-tuning.php
+++ b/examples/cookbook/06-pool-tuning.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Ndrstmr\Icap\Cache\InMemoryOptionsCache;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+/*
+ * Connection-pool tuning — configure idle socket eviction, per-host
+ * connection caps, and server-side Max-Connections awareness.
+ *
+ * Important for long-running workers (RoadRunner, Swoole, ReactPHP)
+ * that keep connections alive across requests. Without tuning, idle
+ * sockets accumulate; with it, the pool automatically evicts stale
+ * entries and respects the server's connection budget.
+ */
+
+$pool = new AmpConnectionPool(
+    maxConnectionsPerHost: 8,     // local idle-socket cap (per host:port:tls)
+    maxIdleSeconds: 30.0,         // evict sockets idle longer than 30 s
+);
+
+// Optional: inform the pool about the server's Max-Connections header.
+// Typically done after the first OPTIONS round trip.
+$cache = new InMemoryOptionsCache();
+
+$config = new Config('icap.example.com');
+
+$client = new IcapClient(
+    $config,
+    new AsyncAmpTransport($pool),
+    new RequestFormatter(),
+    new ResponseParser(),
+    optionsCache: $cache,
+);
+
+\Amp\async(function () use ($client, $pool) {
+    // The first OPTIONS response tells us the server's connection limit.
+    $options = $client->options('/avscan')->await();
+    $headers = $options->getOriginalResponse()->headers;
+
+    // Tune the pool to respect the server's advertised limit.
+    $pool->tuneFromOptions($options->getOriginalResponse());
+
+    echo 'Max-Connections: ' . ($headers['Max-Connections'][0] ?? 'not advertised') . PHP_EOL;
+
+    // Now scan — the pool will reuse sockets, evict stale ones,
+    // and cap at min(localCap, serverMax).
+    $result = $client->scanFile('/avscan', __DIR__ . '/../eicar.com')->await();
+
+    echo $result->isInfected()
+        ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+        : 'Clean' . PHP_EOL;
+});
+
+\Revolt\EventLoop::run();

--- a/examples/cookbook/07-cancellation-from-upload.php
+++ b/examples/cookbook/07-cancellation-from-upload.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Amp\DeferredCancellation;
+use Amp\TimeoutCancellation;
+use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\IcapClient;
+use Ndrstmr\Icap\RequestFormatter;
+use Ndrstmr\Icap\ResponseParser;
+use Ndrstmr\Icap\Transport\AmpConnectionPool;
+use Ndrstmr\Icap\Transport\AsyncAmpTransport;
+
+/*
+ * Cancellation — abort an in-flight ICAP scan from the outside.
+ *
+ * Two common scenarios:
+ *   1. Timeout-based: kill the scan after N seconds regardless of
+ *      what the server is doing (e.g. for upload APIs with SLAs).
+ *   2. User-initiated: the HTTP client cancelled the upload, so
+ *      there's no point continuing the scan.
+ *
+ * Both use amphp's Cancellation hierarchy. The library combines the
+ * user-supplied Cancellation with its own per-IO TimeoutCancellation
+ * via CompositeCancellation — whichever fires first wins.
+ */
+
+$config = new Config('icap.example.com');
+$client = new IcapClient(
+    $config,
+    new AsyncAmpTransport(new AmpConnectionPool()),
+    new RequestFormatter(),
+    new ResponseParser(),
+);
+
+// --- Scenario 1: Hard timeout ---
+
+\Amp\async(function () use ($client) {
+    $timeout = new TimeoutCancellation(5.0); // 5 seconds max
+
+    try {
+        $result = $client->scanFile(
+            '/avscan',
+            __DIR__ . '/../eicar.com',
+            cancellation: $timeout,
+        )->await();
+
+        echo $result->isInfected()
+            ? 'Virus: ' . $result->getVirusName() . PHP_EOL
+            : 'Clean' . PHP_EOL;
+    } catch (\Amp\CancelledException) {
+        echo 'Scan timed out after 5 seconds' . PHP_EOL;
+    }
+});
+
+// --- Scenario 2: User-initiated cancellation ---
+
+\Amp\async(function () use ($client) {
+    $deferred = new DeferredCancellation();
+
+    $scanFuture = $client->scanFile(
+        '/avscan',
+        __DIR__ . '/../eicar.com',
+        cancellation: $deferred->getCancellation(),
+    );
+
+    // Simulate: user cancels the upload after 2 seconds.
+    \Amp\delay(2.0);
+    $deferred->cancel();
+
+    try {
+        $result = $scanFuture->await();
+        echo $result->isInfected() ? 'Infected' : 'Clean';
+        echo PHP_EOL;
+    } catch (\Amp\CancelledException) {
+        echo 'Scan cancelled by user' . PHP_EOL;
+    }
+});
+
+\Revolt\EventLoop::run();


### PR DESCRIPTION
## Context

Bundles the four remaining v2.2 documentation items into a single PR:
**v2.2-cookbook**, **v2.2-readme**, **v2.2-compliance**, **v2.2-contrib**
from `docs/review/review_v2-1/consolidated_v2.1_task-list.md`.

## API

none — documentation only

## Behaviour

none — no production code changed

## Refactoring

none

## Tests

n/a — no code changes. All existing quality gates pass (`cs-check`, `stan`, `test`).

## Verification

- [x] `composer cs-check`
- [x] `composer stan` — PHPStan Level 9 + bleedingEdge clean
- [x] `composer test` — 157 tests, 367 assertions, all green

## Details

### v2.2-cookbook — 4 new cookbook examples

- `04-tls-mtls.php` — TLS and mutual TLS (client certificate) setup
- `05-retry-decorator.php` — `RetryingIcapClient` with exponential backoff
- `06-pool-tuning.php` — `AmpConnectionPool` idle eviction, `Max-Connections`, `tuneFromOptions()`
- `07-cancellation-from-upload.php` — `TimeoutCancellation` and `DeferredCancellation` patterns

### v2.2-readme — Connection pool section

New "Connection pool" subsection in the Configuration block showing
`AmpConnectionPool` setup with `maxConnectionsPerHost`, `maxIdleSeconds`,
and `InMemoryOptionsCache` / PSR-16 adapter. Examples list updated.

### v2.2-compliance — docs/compliance.md

Maps library capabilities to BSI IT-Grundschutz (OPS.1.1.4 malware
scanning, APP.4.4 input validation / TLS / connection management),
DSGVO Art. 32 (encryption, minimisation, resilience, auditability),
and EUPL-1.2 licence context. Cross-references the AI disclaimer.

### v2.2-contrib — CONTRIBUTING.md

Expanded with Conventional Commits 1.0 convention (types, scopes,
subject/body/footer rules, two concrete examples), quality gate
commands, and coding standard expectations.

## Status

All four documentation items marked complete in the consolidated task list.
This closes the v2.2 documentation epic.