### PR TITLE
feat(IcapClient)!: return IcapResponse from options()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `request()`, `scanFile()`, `scanFileWithPreview()` or `options()` instead;
   subclasses that need raw access can still invoke or override the method.
   *(v3-V — Quelle: Claude, Codex)*
+- **BREAKING (v3.0.0):** `IcapClient::options()` and
+  `SynchronousIcapClient::options()` now return `Future<IcapResponse>` /
+  `IcapResponse` instead of `Future<ScanResult>` / `ScanResult`. OPTIONS is a
+  capability-discovery method (RFC 3507 §4.10), so a virus-verdict wrapper was
+  always semantically wrong — callers want the raw headers (`Preview`,
+  `Options-TTL`, `Methods`, `Allow`, `Service`, `ISTag`, `Max-Connections`).
+  Fail-secure semantics are preserved: 4xx still throws `IcapClientException`,
+  5xx throws `IcapServerException`, `100 Continue` throws
+  `IcapProtocolException`. The pre-existing `assertSuccessfulStatus()` helper
+  (extracted from `interpretResponse()`) is the single source of truth for the
+  failure branches. Migration: replace `$result->isInfected()` /
+  `$result->getOriginalResponse()->headers` with `$result->headers` directly.
+  *(v3-W — Quelle: Claude, Codex)*
 
 ## [2.2.0] - 2026-04-30
 

--- a/examples/cookbook/03-options-request.php
+++ b/examples/cookbook/03-options-request.php
@@ -16,7 +16,7 @@ use Ndrstmr\Icap\SynchronousIcapClient;
 $icap = SynchronousIcapClient::create();
 
 $options = $icap->options('/avscan');
-$headers = $options->getOriginalResponse()->headers;
+$headers = $options->headers;
 
 $previewSize = (int) ($headers['Preview'][0] ?? 1024);
 

--- a/examples/cookbook/06-pool-tuning.php
+++ b/examples/cookbook/06-pool-tuning.php
@@ -44,10 +44,10 @@ $client = new IcapClient(
 \Amp\async(function () use ($client, $pool) {
     // The first OPTIONS response tells us the server's connection limit.
     $options = $client->options('/avscan')->await();
-    $headers = $options->getOriginalResponse()->headers;
+    $headers = $options->headers;
 
     // Tune the pool to respect the server's advertised limit.
-    $pool->tuneFromOptions($options->getOriginalResponse());
+    $pool->tuneFromOptions($options);
 
     echo 'Max-Connections: ' . ($headers['Max-Connections'][0] ?? 'not advertised') . PHP_EOL;
 

--- a/src/IcapClient.php
+++ b/src/IcapClient.php
@@ -175,12 +175,13 @@ final class IcapClient implements IcapClientInterface
         if ($this->optionsCache !== null) {
             $cached = $this->optionsCache->get($cacheKey);
             if ($cached !== null) {
-                return Future::complete($this->interpretResponse($cached, $this->config));
+                $this->assertSuccessfulStatus($cached->statusCode);
+                return Future::complete($cached);
             }
         }
 
-        /** @var Future<ScanResult> $future */
-        $future = \Amp\async(function () use ($uri, $cacheKey, $cancellation): ScanResult {
+        /** @var Future<IcapResponse> $future */
+        $future = \Amp\async(function () use ($uri, $cacheKey, $cancellation): IcapResponse {
             $request = new IcapRequest('OPTIONS', $uri);
             $context = [
                 'method' => $request->method,
@@ -193,7 +194,7 @@ final class IcapClient implements IcapClientInterface
             $response = null;
             try {
                 $response = $this->executeRaw($request, $cancellation)->await();
-                $result = $this->interpretResponse($response, $this->config);
+                $this->assertSuccessfulStatus($response->statusCode);
             } catch (\Throwable $e) {
                 $this->logger->warning('ICAP request failed', $context + [
                     'statusCode' => $response?->statusCode,
@@ -205,7 +206,6 @@ final class IcapClient implements IcapClientInterface
 
             $this->logger->info('ICAP request completed', $context + [
                 'statusCode' => $response->statusCode,
-                'infected'   => $result->isInfected(),
             ]);
 
             // Cache the parsed IcapResponse, keyed by host:port + service.
@@ -218,7 +218,7 @@ final class IcapClient implements IcapClientInterface
                 $this->optionsCache->set($cacheKey, $response, $ttl, $istag);
             }
 
-            return $result;
+            return $response;
         });
 
         return $future;
@@ -600,6 +600,26 @@ final class IcapClient implements IcapClientInterface
             return new ScanResult(false, null, $response);
         }
 
+        $this->assertSuccessfulStatus($code);
+
+        // assertSuccessfulStatus() always throws for non-success codes;
+        // the throw below is unreachable but keeps PHPStan happy.
+        throw new IcapResponseException('Unexpected ICAP status: ' . $code, $code);
+    }
+
+    /**
+     * Apply the fail-secure verdict for status codes that do not signal a
+     * successful exchange. Used by {@see interpretResponse()} for scans and
+     * directly by {@see options()}, which returns the raw {@see IcapResponse}
+     * on success but must still treat 4xx/5xx/100 as exceptions.
+     *
+     * @throws IcapProtocolException When the response is `100 Continue`
+     *         outside the preview flow
+     * @throws IcapClientException   When the status is in the 4xx range
+     * @throws IcapServerException   When the status is in the 5xx range
+     */
+    private function assertSuccessfulStatus(int $code): void
+    {
         if ($code === 100) {
             throw new IcapProtocolException(
                 'ICAP 100 Continue is only valid during a preview exchange; received outside preview flow.',
@@ -620,8 +640,6 @@ final class IcapClient implements IcapClientInterface
                 $code,
             );
         }
-
-        throw new IcapResponseException('Unexpected ICAP status: ' . $code, $code);
     }
 
     private function extractVirusName(IcapResponse $response, Config $config): ?string

--- a/src/IcapClientInterface.php
+++ b/src/IcapClientInterface.php
@@ -23,6 +23,7 @@ namespace Ndrstmr\Icap;
 use Amp\Cancellation;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\DTO\ScanResult;
 
 /**
@@ -48,9 +49,15 @@ interface IcapClientInterface
     public function request(IcapRequest $request, ?Cancellation $cancellation = null): Future;
 
     /**
-     * Issue an OPTIONS request against the given service.
+     * Issue an OPTIONS request against the given service. Returns the raw
+     * {@see IcapResponse} on success so callers can inspect capability
+     * headers (`Preview`, `Options-TTL`, `Methods`, `Allow`, `Service`,
+     * `ISTag`, …) directly. The fail-secure status-code interpretation
+     * still applies — 4xx throws {@see IcapClientException}, 5xx throws
+     * {@see IcapServerException}, `100 Continue` throws
+     * {@see IcapProtocolException}.
      *
-     * @return Future<ScanResult>
+     * @return Future<IcapResponse>
      */
     public function options(string $service, ?Cancellation $cancellation = null): Future;
 

--- a/src/RetryingIcapClient.php
+++ b/src/RetryingIcapClient.php
@@ -24,7 +24,6 @@ use Amp\Cancellation;
 use Amp\Future;
 use Closure;
 use Ndrstmr\Icap\DTO\IcapRequest;
-use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\Exception\IcapServerException;
 
 use function Amp\delay;
@@ -134,13 +133,16 @@ final class RetryingIcapClient implements IcapClientInterface
     }
 
     /**
-     * @param Closure(): Future<ScanResult> $operation
-     * @return Future<ScanResult>
+     * @template T
+     *
+     * @param Closure(): Future<T> $operation
+     *
+     * @return Future<T>
      */
     private function withRetry(Closure $operation): Future
     {
-        /** @var Future<ScanResult> $future */
-        $future = \Amp\async(function () use ($operation): ScanResult {
+        /** @var Future<T> $future */
+        $future = \Amp\async(function () use ($operation): mixed {
             // The loop runs at least once because maxAttempts >= 1 is
             // enforced in the ctor, so the final throw always has a
             // captured exception to re-raise.

--- a/src/SynchronousIcapClient.php
+++ b/src/SynchronousIcapClient.php
@@ -23,6 +23,7 @@ namespace Ndrstmr\Icap;
 use Amp\Cancellation;
 use Amp\Future;
 use Ndrstmr\Icap\DTO\IcapRequest;
+use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\Transport\SynchronousStreamTransport;
@@ -66,7 +67,7 @@ final class SynchronousIcapClient
         return $this->asyncClient->request($request, $cancellation)->await();
     }
 
-    public function options(string $service, ?Cancellation $cancellation = null): ScanResult
+    public function options(string $service, ?Cancellation $cancellation = null): IcapResponse
     {
         return $this->asyncClient->options($service, $cancellation)->await();
     }

--- a/tests/IcapClientTest.php
+++ b/tests/IcapClientTest.php
@@ -22,7 +22,6 @@ use Mockery as m;
 use Ndrstmr\Icap\Config;
 use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
-use Ndrstmr\Icap\DTO\ScanResult;
 use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\PreviewDecision;
 use Ndrstmr\Icap\PreviewStrategyInterface;
@@ -79,8 +78,7 @@ it('OPTIONS: orchestrates formatter → transport → parser', function () {
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client, $resp) {
         $res = $client->options('/service')->await();
-        expect($res)->toBeInstanceOf(ScanResult::class)
-            ->and($res->getOriginalResponse())->toBe($resp);
+        expect($res)->toBe($resp);
     });
 
     m::close();

--- a/tests/Integration/IcapServerSmokeTest.php
+++ b/tests/Integration/IcapServerSmokeTest.php
@@ -19,7 +19,7 @@
 declare(strict_types=1);
 
 use Ndrstmr\Icap\Config;
-use Ndrstmr\Icap\DTO\ScanResult;
+use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\Tests\AsyncTestCase;
 
@@ -74,8 +74,8 @@ it('performs an OPTIONS round-trip against the configured echo service', functio
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client, $service) {
         $result = $client->options($service)->await();
-        expect($result)->toBeInstanceOf(ScanResult::class)
-            ->and($result->getOriginalResponse()->statusCode)->toBe(200);
+        expect($result)->toBeInstanceOf(IcapResponse::class)
+            ->and($result->statusCode)->toBe(200);
     });
 });
 

--- a/tests/MultiVendorVirusHeadersTest.php
+++ b/tests/MultiVendorVirusHeadersTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use Mockery as m;
 use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\IcapClient;
 use Ndrstmr\Icap\RequestFormatterInterface;
@@ -83,7 +84,7 @@ it('detects a virus via the first vendor header that is present', function () {
 
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client) {
-        $res = $client->options('/svc')->await();
+        $res = $client->request(new IcapRequest('RESPMOD', 'icap://h/svc'))->await();
         expect($res->isInfected())->toBeTrue()
             ->and($res->getVirusName())->toBe('Type=0; Resolution=2; Threat=EICAR;');
     });
@@ -99,7 +100,7 @@ it('returns clean when none of the configured virus headers is present', functio
 
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client) {
-        $res = $client->options('/svc')->await();
+        $res = $client->request(new IcapRequest('RESPMOD', 'icap://h/svc'))->await();
         expect($res->isInfected())->toBeFalse();
     });
 
@@ -117,7 +118,7 @@ it('picks the first header in the configured order when multiple are present', f
 
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client) {
-        $res = $client->options('/svc')->await();
+        $res = $client->request(new IcapRequest('RESPMOD', 'icap://h/svc'))->await();
         expect($res->getVirusName())->toBe('Eicar-Test');
     });
 

--- a/tests/Security/FailSecureAndValidationTest.php
+++ b/tests/Security/FailSecureAndValidationTest.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 use Mockery as m;
 use Ndrstmr\Icap\Config;
+use Ndrstmr\Icap\DTO\IcapRequest;
 use Ndrstmr\Icap\DTO\IcapResponse;
 use Ndrstmr\Icap\Exception\IcapClientException;
 use Ndrstmr\Icap\Exception\IcapProtocolException;
@@ -116,7 +117,7 @@ it('treats a 200 response with no virus header as clean', function () {
 
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client) {
-        $res = $client->options('/svc')->await();
+        $res = $client->request(new IcapRequest('RESPMOD', 'icap://h/svc'))->await();
         expect($res->isInfected())->toBeFalse();
     });
 
@@ -130,7 +131,7 @@ it('treats a 200 response carrying a virus header as infected', function () {
 
     /** @var AsyncTestCase $this */
     $this->runAsyncTest(function () use ($client) {
-        $res = $client->options('/svc')->await();
+        $res = $client->request(new IcapRequest('RESPMOD', 'icap://h/svc'))->await();
         expect($res->isInfected())->toBeTrue()
             ->and($res->getVirusName())->toBe('Eicar-Test-Signature');
     });

--- a/tests/SynchronousIcapClientTest.php
+++ b/tests/SynchronousIcapClientTest.php
@@ -64,8 +64,7 @@ it('delegates calls to the async client and blocks for results', function () {
 
     $res = $client->options('/service');
 
-    expect($res)->toBeInstanceOf(ScanResult::class)
-        ->and($res->getOriginalResponse())->toBe($responseObj);
+    expect($res)->toBe($responseObj);
 
     m::close();
 });


### PR DESCRIPTION
## Context

Second of three v3.0.0 BC-break PRs against the `release/v3.0` integration branch (after #85).

`IcapClient::options()` returned `Future<ScanResult>`. `ScanResult` is modelled around `isInfected()` / `getVirusName()` — a virus verdict on a capability-discovery response is semantically wrong. Real callers always reached for `$result->getOriginalResponse()->headers` to read the negotiated `Preview`, `Options-TTL`, `Methods`, `Allow`, `Service`, `ISTag`, `Max-Connections` values; the wrapper was friction, not safety.

This PR closes **v3-W** from the consolidated v2.1 task list (`docs/review/review_v2-1/consolidated_v2.1_task-list.md`, Reviewer-Quellen: Claude, Codex).

## API

**BREAKING:** Return-type changes on the OPTIONS path:

| Symbol | Before | After |
|---|---|---|
| `IcapClient::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |
| `SynchronousIcapClient::options()` | `ScanResult` | `IcapResponse` |
| `RetryingIcapClient::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |
| `IcapClientInterface::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |

## Behaviour

Fail-secure semantics are unchanged. Previously, `interpretResponse()` inlined both the success-mapping (204/200/206 -> `ScanResult`) and the failure-mapping (100/4xx/5xx -> typed exception). The failure branches are now extracted into a dedicated `assertSuccessfulStatus()` helper that both `interpretResponse()` (for scans) and `options()` (for capability discovery) call:

- 100 Continue outside the preview flow -> `IcapProtocolException`
- 4xx -> `IcapClientException` (with the real status code)
- 5xx -> `IcapServerException` (with the real status code)
- 204 / 200 / 206 -> raw `IcapResponse` is returned to the caller

The OPTIONS-cache contract (`OptionsCacheInterface`) is unchanged — it always stored `IcapResponse`. The cache hit path now skips the `interpretResponse()` round-trip and applies `assertSuccessfulStatus()` directly.

Migration:
```php
// before (v2.x)
$result = $client->options('/svc')->await();
$preview = $result->getOriginalResponse()->headers['Preview'][0] ?? null;

// after (v3.0)
$result = $client->options('/svc')->await();
$preview = $result->headers['Preview'][0] ?? null;
```

## Refactoring

- Extract `assertSuccessfulStatus(int \$code): void` from `interpretResponse()` so the fail-secure failure branches live in exactly one place.
- Generalise `RetryingIcapClient::withRetry()` with `@template T` so it can carry both `ScanResult` (for `request`/`scanFile*`) and `IcapResponse` (for `options`) without losing its return-type generic.
- Boy-scout: drop now-unused `ScanResult` imports from `RetryingIcapClient`, `IcapClientTest`, `IcapServerSmokeTest`.

## Tests

All 157 unit tests pass after migration. Test changes:
- `IcapClientTest::OPTIONS orchestrates ...` — assert the returned `IcapResponse` matches the parser output directly (no more `getOriginalResponse()` indirection).
- `MultiVendorVirusHeadersTest` — these tests were piggy-backing on `options()` to exercise virus-header detection; switched to `request(new IcapRequest('RESPMOD', ...))` which is the correct path. The Vendor-header detection logic is unchanged.
- `FailSecureAndValidationTest` — the 4xx/5xx/100 fail-secure assertions stay on `options()` (that is exactly the contract being tested). The two "200 with virus header is infected" assertions moved to `request()`, mirroring the MultiVendorVirusHeaders fix.
- `SynchronousIcapClientTest` — assert the returned `IcapResponse` directly.
- `Integration/IcapServerSmokeTest` — `expect(...)->toBeInstanceOf(IcapResponse::class)` and read `->statusCode` directly.
- `cookbook/03-options-request.php` and `cookbook/06-pool-tuning.php` cleaned up to read `$options->headers` instead of `$options->getOriginalResponse()->headers`.

## Verification

- [x] composer cs-check — clean
- [x] composer stan — PHPStan Level 9 + bleedingEdge: no errors
- [x] composer test — 157 passed (365 assertions)
- [x] CI-Matrix (PHP 8.4 + 8.5) — wird durch GitHub Actions geprüft (Trigger seit #85 auf release/**)

## Closes

Refs v3-W — docs/review/review_v2-1/consolidated_v2.1_task-list.md

## Status

Zweiter von drei BC-Break-PRs gegen release/v3.0:
1. PR A (#85, merged) — executeRaw() protected
2. **PR B (this) — options() returns Future<IcapResponse>**
3. PR C — remove deprecated IcapResponseException

Final release-PR release/v3.0 -> main mit CHANGELOG-Stempel + docs/migration-v2-to-v3.md + Tag v3.0.0 folgt nach Merge der drei PRs.