### PR TITLE
docs: v3.0.0 release sweep — migration guide, README, SECURITY, CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-05-01
+
+`v3.0.0` is a deliberately small breaking release. It carries no new features
+and no architectural rework — it is a cleanup pass that closes three known-stale
+corners of the v2 API so the surface can be frozen for the upcoming Symfony
+bundle (`ndrstmr/icap-flow-bundle`). Migration: see
+[`docs/migration-v2-to-v3.md`](docs/migration-v2-to-v3.md). For most call sites
+the upgrade is a no-op other than bumping the constraint to `^3.0`.
+
 ### Removed
 - **BREAKING (v3.0.0):** `Ndrstmr\Icap\Exception\IcapResponseException` is gone.
   The class was `@deprecated since 2.0` (with `#[\Deprecated]` since v2.2) and

--- a/README.md
+++ b/README.md
@@ -24,9 +24,19 @@ An async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.4+, 
 >
 > This software is provided AS IS under EUPL-1.2; the licence's "no warranty" clauses apply unconditionally.
 
+## What changed in v3
+
+`v3.0.0` is a small, deliberate breaking release. It carries no new features — it is a cleanup pass that closes three known-stale corners of the v2 API so the surface can be frozen for the upcoming Symfony bundle (`ndrstmr/icap-flow-bundle`):
+
+- **`IcapClient::executeRaw()` is now `protected`.** It was always meant as an internal seam for the preview flow and never appeared in `IcapClientInterface`. Keeping it public let external callers bypass the fail-secure status-code interpretation. External callers must use `request()`, `scanFile()`, `scanFileWithPreview()` or `options()`; subclasses keep raw access.
+- **`options()` returns `Future<IcapResponse>`** (was `Future<ScanResult>`). OPTIONS is capability discovery, not a virus verdict — callers want the headers (`Preview`, `Options-TTL`, `Methods`, `Allow`, `Service`, `ISTag`, `Max-Connections`) directly. Fail-secure is preserved: 4xx still throws `IcapClientException`, 5xx still throws `IcapServerException`, `100 Continue` still throws `IcapProtocolException` — extracted into a single `assertSuccessfulStatus()` helper shared between `interpretResponse()` and `options()`.
+- **`IcapResponseException` is removed.** Deprecated since v2.0 (`#[\Deprecated]` since v2.2). Both throw sites (`IcapClient::interpretResponse()` backstop, `DefaultPreviewStrategy::handlePreviewResponse()` `default` branch) now throw `IcapProtocolException`. Callers using `catch (IcapExceptionInterface $e)` are unaffected.
+
+Migration: [`docs/migration-v2-to-v3.md`](docs/migration-v2-to-v3.md). For most call sites the upgrade is a no-op other than bumping the constraint to `^3.0`.
+
 ## What changed in v2
 
-`v2.0.0` is a **breaking** release that fixes RFC-3507-blocking bugs in v1. The v1 line is **deprecated**. Highlights:
+`v2.0.0` was a **breaking** release that fixes RFC-3507-blocking bugs in v1. The v1 line is **deprecated**. Highlights:
 
 - **RFC-3507 wire format** is correct: real `Encapsulated` offsets, HTTP-in-ICAP nesting, chunked bodies for both string and stream payloads, `0; ieof` terminator on preview-complete.
 - **Streaming-safe preview** — `scanFileWithPreview()` no longer buffers the file; only the preview window is read.
@@ -46,12 +56,12 @@ An async-ready ICAP (Internet Content Adaptation Protocol) client for PHP 8.4+, 
 
 The migration guide is [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). The full per-finding closure list is in [`docs/review/consolidated_task-list.md`](docs/review/consolidated_task-list.md).
 
-> **v2.1.0** added keep-alive connection pooling and strict RFC 3507 §4.5 preview-continue (preview + continuation on the same socket). See [`CHANGELOG.md`](CHANGELOG.md).
+> **v2.1.0** added keep-alive connection pooling and strict RFC 3507 §4.5 preview-continue (preview + continuation on the same socket). **v2.2.0** added OPTIONS-driven pool tuning (`Max-Connections`), pool idle eviction, ISTag-based cache invalidation, PSR-6/PSR-16 OPTIONS-cache adapters and a per-IO timeout model. See [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Installation
 
 ```bash
-composer require ndrstmr/icap-flow:^2.0
+composer require ndrstmr/icap-flow:^3.0
 ```
 
 ## Quickstart — synchronous

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,18 +67,24 @@ The v2 line was reviewed against three independent due-diligence reports (`docs/
 - **Bounded reads.** `Config::withLimits(maxResponseSize, maxHeaderCount, maxHeaderLineLength)` caps every response. Defaults: 10 MB total, 100 headers, 8 KB per line.
 - **No fail-open on 5xx.** Server errors raise `IcapServerException`. Your application is responsible for blocking the upload — the library will never silently report it as clean.
 
-## What this library DOES provide (since v2.0 / v2.1)
+## What this library DOES provide (since v2.0 / v2.1 / v2.2 / v3.0)
 
 - **Automatic retry on 5xx** via `RetryingIcapClient` (decorator, exponential backoff, configurable attempts). Wraps `IcapClient`; no retry by default on the bare client.
 - **OPTIONS-response caching** via `InMemoryOptionsCache` (honours `Options-TTL`, RFC 3507 §4.10.2). Plug in via the `$optionsCache` constructor parameter.
-- **Keep-alive connection pooling** via `AmpConnectionPool` (LIFO per host:port:tls-context, configurable cap). Used automatically by `AsyncAmpTransport`.
-- **TLS pool-key isolation** (since v2.1.1): each distinct `ClientTlsContext` object gets its own idle-socket stack, preventing cross-tenant socket reuse in multi-tenant deployments. See [GHSA advisory](#) for the pre-2.1.1 risk.
+- **Cross-process OPTIONS caching** via `Psr6OptionsCache` (PSR-6) and `Psr16OptionsCache` (PSR-16) — since v2.2. Suitable for Redis, APCu, Memcached, Symfony Cache. Supports cross-process ISTag-based invalidation via meta-keys.
+- **ISTag-based cache invalidation** (since v2.2): a server config / signature reload (new `ISTag` header per RFC 3507 §4.10.2) flushes all cached OPTIONS entries.
+- **Keep-alive connection pooling** via `AmpConnectionPool` (LIFO per host:port:tls-context-fingerprint, configurable cap). Used automatically by `AsyncAmpTransport`. `NullConnectionPool` is available for stateless workers (since v2.2).
+- **TLS pool-key isolation** (since v2.1.1): each distinct `ClientTlsContext` object gets its own idle-socket stack, preventing cross-tenant socket reuse in multi-tenant deployments.
+- **Pool idle eviction** (since v2.2): `AmpConnectionPool` evicts sockets idle longer than `maxIdleSeconds` (default 30 s) on the next `acquire()`. Prevents stale-socket accumulation in long-running workers (RoadRunner, Swoole, ReactPHP).
+- **OPTIONS-driven pool tuning** (since v2.2): `AmpConnectionPool::tuneFromOptions(IcapResponse)` honours the server's `Max-Connections` header (RFC 3507 §4.10.2).
+- **Per-IO timeout** (since v2.2): each socket read / write builds a fresh `TimeoutCancellation` from `streamTimeout`, combined with the caller's `Cancellation` via `CompositeCancellation`. Prevents spurious cancellation on slow but legitimate scans, while keeping a hard per-IO ceiling.
+- **Streaming-safe Strict §4.5 continuation** (since v2.1.2): the body remainder is streamed via `ChunkedBodyEncoder::encodeRemainderFromStream()`, never buffered in memory.
 
 ## What this library does NOT guarantee
 
-- It does **not** authenticate the ICAP server beyond TLS hostname verification — if you need mutual TLS or pinning, configure the `ClientTlsContext` accordingly.
-- It does **not** persist the OPTIONS cache across process restarts — `InMemoryOptionsCache` is in-process only. Use a PSR-6/PSR-16 adapter (planned for v2.2) for distributed caching.
-- It does **not** auto-negotiate pool capacity from the server's `Max-Connections` OPTIONS header (planned for v2.2).
+- It does **not** authenticate the ICAP server beyond TLS hostname verification — if you need mutual TLS or pinning, configure the `ClientTlsContext` accordingly. See [`examples/cookbook/04-tls-mtls.php`](examples/cookbook/04-tls-mtls.php).
+- It does **not** persist the OPTIONS cache across process restarts when using `InMemoryOptionsCache`. For cross-process caching use `Psr6OptionsCache` or `Psr16OptionsCache` with a Redis / APCu / Memcached / Symfony Cache backend.
+- It does **not** ship OpenTelemetry traces or Prometheus metrics out of the box. An observability decorator is on the wishlist (`docs/review/review_v2-1/consolidated_v2.1_task-list.md`, item W-Y) and will land when there is concrete deployment demand.
 
 ## AI-assisted origin
 

--- a/docs/migration-v2-to-v3.md
+++ b/docs/migration-v2-to-v3.md
@@ -1,0 +1,220 @@
+# Migration guide: v2 → v3
+
+`v3.0.0` is a deliberately small breaking release. It carries no new features and no architectural rework — it is a cleanup release whose sole purpose is to remove three known-stale corners of the v2 API so the surface can be frozen for the upcoming Symfony bundle (`ndrstmr/icap-flow-bundle`).
+
+If you are on `^2.2` and not subclassing `IcapClient`, not catching `IcapResponseException` directly, and not consuming `options()` as a `ScanResult`, **the upgrade is a no-op other than bumping the constraint to `^3.0`**.
+
+The three BC-breaks below resolve the v3-V, v3-W and v3-F items from the consolidated v2.1 task list (`docs/review/review_v2-1/consolidated_v2.1_task-list.md`).
+
+---
+
+## TL;DR
+
+```diff
+ composer require ndrstmr/icap-flow:^3.0
+```
+
+```diff
+-$result = $client->options('/avscan')->await();
+-$preview = $result->getOriginalResponse()->headers['Preview'][0] ?? null;
++$result = $client->options('/avscan')->await();
++$preview = $result->headers['Preview'][0] ?? null;
+```
+
+```diff
+-try { ... }
+-catch (\Ndrstmr\Icap\Exception\IcapResponseException $e) { ... }
++try { ... }
++catch (\Ndrstmr\Icap\Exception\IcapProtocolException $e) { ... }
++// or, if you don't need to discriminate:
++// catch (\Ndrstmr\Icap\Exception\IcapExceptionInterface $e) { ... }
+```
+
+```diff
+-$client->executeRaw($req)->await();
++$client->request($req)->await();
++// or scanFile() / scanFileWithPreview() / options()
++// — executeRaw() is now protected and only callable from a subclass
+```
+
+---
+
+## 1. PHP version
+
+- **v2.2**: `php ^8.4`
+- **v3.0**: `php ^8.4`
+
+No PHP-version change. CI matrix continues to run 8.4 + 8.5.
+
+---
+
+## 2. `IcapClient::executeRaw()` is now `protected` (v3-V)
+
+`executeRaw()` was always intended as an internal seam for the preview flow, where `100 Continue` is a legitimate intermediate response. Keeping it `public` let external callers bypass the fail-secure status-code interpretation in `interpretResponse()` — silently turning an unexpected status into a clean verdict, which defeats the library's main safety guarantee. The method was never part of `IcapClientInterface`, so the public contract is unchanged.
+
+```diff
+-public function executeRaw(IcapRequest $request, ?Cancellation $cancellation = null): Future
++protected function executeRaw(IcapRequest $request, ?Cancellation $cancellation = null): Future
+```
+
+### Migration
+
+If you were calling `executeRaw()` directly from outside the class:
+
+```diff
+-$response = $client->executeRaw($req)->await();
+-if ($response->statusCode === 200) { ... }
++$result = $client->request($req)->await();
++// $result is a ScanResult; for the raw IcapResponse use ->getOriginalResponse()
+```
+
+For the high-level operations, use the dedicated methods:
+
+```diff
+-$client->executeRaw(new IcapRequest('OPTIONS', $uri))->await();
++$client->options('/avscan')->await();
+```
+
+If you genuinely need raw access (vendor-specific extensions, custom preview strategies), subclass `IcapClient` — `protected` lets you keep calling or overriding the method:
+
+```php
+final class MyVendorClient extends IcapClient
+{
+    public function customScan(IcapRequest $req): IcapResponse
+    {
+        return $this->executeRaw($req)->await();
+    }
+}
+```
+
+---
+
+## 3. `IcapClient::options()` returns `Future<IcapResponse>` (v3-W)
+
+OPTIONS is a capability-discovery method (RFC 3507 §4.10). Wrapping the response in `ScanResult` — which is modelled around `isInfected()` / `getVirusName()` — was always semantically wrong. Real callers reached for `$result->getOriginalResponse()->headers` to read the negotiated `Preview`, `Options-TTL`, `Methods`, `Allow`, `Service`, `ISTag`, `Max-Connections` values; the wrapper was friction, not safety.
+
+| Symbol | Before (v2.x) | After (v3.0) |
+|---|---|---|
+| `IcapClient::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |
+| `SynchronousIcapClient::options()` | `ScanResult` | `IcapResponse` |
+| `RetryingIcapClient::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |
+| `IcapClientInterface::options()` | `Future<ScanResult>` | `Future<IcapResponse>` |
+
+### Fail-secure semantics are unchanged
+
+`interpretResponse()` used to inline both the success-mapping (204/200/206 → `ScanResult`) and the failure-mapping (100/4xx/5xx → typed exception). The failure branches are now extracted into a dedicated `assertSuccessfulStatus()` helper that both `interpretResponse()` (for scans) and `options()` (for capability discovery) call:
+
+- 100 Continue outside the preview flow → `IcapProtocolException`
+- 4xx → `IcapClientException` (with the real status code)
+- 5xx → `IcapServerException` (with the real status code)
+- 200/204/206 OK → raw `IcapResponse` is returned to the caller
+
+The OPTIONS-cache contract (`OptionsCacheInterface`) is unchanged — it always stored `IcapResponse`. The cache-hit path now skips the `interpretResponse()` round-trip and applies `assertSuccessfulStatus()` directly.
+
+### Migration
+
+```diff
+-$result = $client->options('/avscan')->await();
+-$headers = $result->getOriginalResponse()->headers;
+-$preview = (int) ($headers['Preview'][0] ?? 1024);
++$result = $client->options('/avscan')->await();
++$preview = (int) ($result->headers['Preview'][0] ?? 1024);
+```
+
+If you were doing `$result->isInfected()` on an OPTIONS response: that never made sense — OPTIONS is not a scan. Remove the call. If you genuinely need a "is this a clean scan" check, send a `RESPMOD` via `request()` / `scanFile()` instead.
+
+The `RetryingIcapClient::withRetry()` helper was generalised with `@template T` so the same retry harness now carries both `ScanResult` (for `request`/`scanFile*`) and `IcapResponse` (for `options`) without losing its return-type generic.
+
+---
+
+## 4. `IcapResponseException` is removed (v3-F)
+
+`Ndrstmr\Icap\Exception\IcapResponseException` has been deprecated since v2.0 (with the PHP 8.4 `#[\Deprecated]` attribute since v2.2). It only ever served as a catch-all bucket for status codes outside the recognised taxonomy — that is exactly what `IcapProtocolException` represents.
+
+Both throw sites moved to `IcapProtocolException`:
+
+- **`IcapClient::interpretResponse()` fail-secure backstop.** The previous comment claimed `assertSuccessfulStatus()` always throws and the line was unreachable; that was wrong. `assertSuccessfulStatus()` only throws for 100/4xx/5xx, leaving 1xx-other-than-100, 3xx and 6xx+ as a real fall-through. The backstop is genuine fail-secure code.
+- **`DefaultPreviewStrategy::handlePreviewResponse()` `default` branch.** Same semantics as before; the new exception type carries the offending status code as `->getCode()`.
+
+### Migration
+
+If you catch the exception explicitly:
+
+```diff
+-try {
+-    $client->scanFile('/avscan', $path);
+-} catch (\Ndrstmr\Icap\Exception\IcapResponseException $e) {
+-    // ...
+-}
++try {
++    $client->scanFile('/avscan', $path);
++} catch (\Ndrstmr\Icap\Exception\IcapProtocolException $e) {
++    // ...
++}
+```
+
+If you catch via the marker interface (`IcapExceptionInterface`), no change is needed — `IcapProtocolException` already implements it, and so does every other concrete exception in the taxonomy.
+
+The full v3.0 exception taxonomy:
+
+| Status / failure | Exception |
+|---|---|
+| 100 outside preview flow | `IcapProtocolException` |
+| 4xx | `IcapClientException` |
+| 5xx | `IcapServerException` |
+| 1xx-other-than-100, 3xx, 6xx+ | `IcapProtocolException` (was `IcapResponseException`) |
+| malformed response bytes | `IcapMalformedResponseException extends IcapProtocolException` |
+| TCP / TLS / connect failure | `IcapConnectionException` |
+| stream cancellation timed out | `IcapTimeoutException` |
+
+All seven (six concrete + the marker) implement `IcapExceptionInterface`, so a single catch on the marker still captures everything.
+
+---
+
+## 5. What did *not* change
+
+To set expectations: the following all stay byte-compatible between v2.2 and v3.0.
+
+- ICAP wire format — same `RequestFormatter`, same `ResponseParser`, same chunked-body encoding, same `0; ieof` preview terminator.
+- Connection pool API (`ConnectionPoolInterface`, `AmpConnectionPool`, `NullConnectionPool`).
+- TLS/mTLS setup via `Config::withTlsContext()`.
+- Per-IO timeout model (introduced in v2.2).
+- OPTIONS cache contract (`OptionsCacheInterface`, `InMemoryOptionsCache`, `Psr6OptionsCache`, `Psr16OptionsCache`).
+- ISTag-based cache invalidation (introduced in v2.2).
+- Multi-vendor virus-header detection (`Config::withVirusFoundHeaders()`).
+- DoS limits (`Config::withLimits()`).
+- PSR-3 logger integration and the structured-logging schema.
+- DTO shapes (`IcapRequest`, `IcapResponse`, `HttpRequest`, `HttpResponse`, `ScanResult`).
+- `RetryingIcapClient` retry policy (5xx only, exponential backoff).
+- amphp v3 / Revolt event-loop integration.
+
+The `RetryingIcapClient::withRetry()` internal helper picked up an `@template T` so `options()` can return `IcapResponse` through it; the public `RetryingIcapClient::options()` signature inherits from `IcapClientInterface` and is correctly typed without explicit annotations.
+
+---
+
+## 6. Test impact
+
+If you vendor tests against the library:
+
+- Tests that asserted `$client->options(...)->isInfected()` — replace with raw-response inspection (`$response->statusCode`, `$response->headers[...]`) or move the scan-semantics assertion to `request()` / `scanFile()`.
+- Tests that asserted `IcapResponseException` — switch to `IcapProtocolException` (or the marker interface).
+- The deprecation-warning lines from v2.x (two per test run) are gone in v3 — your `phpunit.xml.dist` `failOnRisky` / `failOnDeprecation` settings may surface this as a behavioural change.
+
+---
+
+## 7. Provenance
+
+`docs/review/review_v2-1/consolidated_v2.1_task-list.md` lists the three v3 items (v3-V, v3-W, v3-F) with reviewer attribution (Claude, Codex, four independent audits). Each PR that closed an item is recorded against the corresponding line:
+
+- v3-V → PR #85 (`feat(IcapClient)!: make executeRaw() protected`)
+- v3-W → PR #86 (`feat(IcapClient)!: return IcapResponse from options()`)
+- v3-F → PR #87 (`refactor(exception)!: remove deprecated IcapResponseException`)
+
+The next deep-research audit cycle (Claude, Codex, Jules) runs against `v3.0.0` using the prompt at `docs/review/deep-research-prompt-icapflow_v3.0.md`.
+
+---
+
+## Need help?
+
+- The v1→v2 migration guide is at [`docs/migration-v1-to-v2.md`](migration-v1-to-v2.md).
+- Open an issue if you hit something not covered here — please include the v2.x code, the v3 migration target, and the exception class (if any) you're trying to catch.

--- a/docs/review/review_v2-1/consolidated_v2.1_task-list.md
+++ b/docs/review/review_v2-1/consolidated_v2.1_task-list.md
@@ -373,7 +373,7 @@ erzwungen werden.
   `src/SynchronousIcapClient.php` — Quelle: Claude, Codex*
 
 - [x] **v3-F** `IcapResponseException` entfernen (Deprecation einlösen).
-  ✅ PR (release/v3.0) — Klasse gelöscht, beide Throw-Sites
+  ✅ PR #87 (release/v3.0) — Klasse gelöscht, beide Throw-Sites
   (`IcapClient::interpretResponse()` Backstop, `DefaultPreviewStrategy`
   default-Branch) auf `IcapProtocolException` umgestellt.
   *Datei: `src/Exception/IcapResponseException.php` + alle Call-Sites — Quelle: Claude, Codex*


### PR DESCRIPTION
## Context

Documentation pass to bring all maintainer-facing surfaces in line with v3.0.0 before the `release/v3.0 -> main` release PR. Each piece follows directly from the three BC-break PRs (#85, #86, #87).

## API

none — pure documentation.

## Behaviour

- **`docs/migration-v2-to-v3.md`** (new): three-section migration guide modelled after the existing v1->v2 guide. One section per BC-break (v3-V, v3-W, v3-F) with Before/After diffs and a "what did not change" reference list. TL;DR up front.
- **`README.md`**: new "What changed in v3" section above the existing v2 block (three bullets, one per BC-break, plus a migration-guide link). Composer-require hint bumped to `^3.0`. v2.x highlight line extended with v2.2 features (OPTIONS-driven pool tuning, idle eviction, ISTag invalidation, PSR cache adapters, per-IO timeout) that were never reflected.
- **`SECURITY.md`**: rewritten "What this library DOES provide" to match v3.0 state. Three stale "planned for v2.2" claims removed (PSR-6/16 cache adapter, Max-Connections pool tuning, OTel/observability) since the first two shipped in v2.2 and the third moved to the wishlist. Eight new bullets covering v2.1.1 / v2.1.2 / v2.2 hardening.
- **`CHANGELOG.md`**: stamped `[3.0.0] - 2026-05-01` between `[Unreleased]` and the existing BC-break entries that have been accumulating since PR #85. New empty `[Unreleased]` kept on top per Keep-a-Changelog convention. Added a one-paragraph summary above the Removed/Changed sections.
- **`consolidated_v2.1_task-list.md`**: backfilled PR #87 reference on the v3-F item (was a `(release/v3.0)` placeholder before the PR existed). v3-V / v3-W already carried PR #85 / #86.

## Refactoring

none.

## Tests

n/a (docs only). Quality gates re-run as a smoke check:

- `composer cs-fix` — no-op
- `composer stan` — no errors
- `composer test` — 159 passed (363 assertions), unchanged from PR #87

## Verification

- [x] composer cs-fix
- [x] composer stan
- [x] composer test
- [x] CI matrix (PHP 8.4 + 8.5) — wird durch GitHub Actions geprüft

## Closes

Refs v3-V / v3-W / v3-F (Release-Sweep — die Items selbst sind durch #85/#86/#87 geschlossen).

## Status

Letzter Doku-PR vor dem Release-Cut. Nach Merge:

1. Release-PR `release/v3.0 -> main` (PR D) — bündelt #85, #86, #87, #88 und diesen Doku-Sweep.
2. Tag `v3.0.0` auf den Release-Merge-Commit.
3. Drei unabhängige Deep-Research-Audits gegen `v3.0.0` mit dem Prompt aus PR #88.

Provenance-Hinweis: Ab dieser PR wieder mit Claude-Attribution (`Co-Authored-By: Claude Opus 4.7`) — der Maintainer macht die v3-Linie bewusst transparent, wer welche Commits geschrieben hat. Die v3-Code-PRs (#85, #86, #87) und der Audit-Prompt (#88) tragen die Attribution rückwirkend nicht; alle künftigen v3-Commits werden sie tragen.