### PR TITLE
docs(claude): allow AI-attribution trailers, forbid maintainer co-author

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,10 +119,22 @@ Diese Repo folgt **strikt** [Conventional Commits 1.0](https://www.conventionalc
   - `BREAKING CHANGE: <Beschreibung>` für jeden BC-Break (gehören in den v3.0.0-Bucket, nicht in Patch/Minor).
   - `Closes #<issue>` wenn der Commit/PR das Issue schließen soll. `Refs #<issue>` nur für Verweise ohne Schließen. **Wichtig:** GitHub Auto-Close braucht exakt `Closes #XX` / `Fixes #XX` / `Resolves #XX` — `Refs` verlinkt nur, schließt nicht. Bei mehreren Issues jedes einzeln auflisten (`Closes #53`, `Closes #54`), nicht komma-separiert.
 
-### Was nicht in Commits / PRs gehört
+### AI-Attribution in Commits / PRs
 
-- **Keine Co-Authored-By-Trailer für Claude / Anthropic / Generated-with-Claude-Code-Werbung.** Auch keine 🤖-Emoji-Footer. Commits sind authored vom Repo-Maintainer; Tooling-Provenance gehört nicht in die Git-Historie.
-- **Keine Werbe- oder Generator-Hinweise** in PR-Beschreibungen, Issue-Bodies oder Commit-Messages.
+Für die **v3-Linie und alles danach** ist die AI-Attribution explizit erwünscht. Die Repo-Politik dazu wurde vom Maintainer am 01.05.2026 umgestellt: nicht mehr verstecken, sondern transparent dokumentieren, wer welchen Commit geschrieben hat.
+
+**Erlaubt und erwünscht:**
+
+- `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (oder das jeweils aktuelle Modell) als Trailer auf Commits, die mit Claude-Code-Hilfe entstanden sind.
+- Optional auch der Generator-Hinweis `🤖 Generated with [Claude Code](https://claude.com/claude-code)` in der Commit-Body, **vor** dem Co-Author-Trailer. Das ist keine Werbung — es ist Provenance.
+
+**Nicht erlaubt:**
+
+- **Niemals einen `Co-authored-by`-Trailer auf den Repo-Maintainer setzen.** Der Maintainer ist sowieso der Git-`Author` jedes Commits — ein Co-Author-Trailer für ihn ist redundant und falsch.
+- Keine anderen Personen als Co-Author setzen, ohne dass diese tatsächlich am Commit mitgearbeitet haben.
+
+### Sonstige Commit-/PR-Regeln
+
 - **Keine `--no-verify`** — wenn pre-commit-Hooks fehlschlagen, Root-Cause fixen und neuen Commit anlegen (nicht amend).
 
 ### Pull Requests


### PR DESCRIPTION
## Context

Project policy update for the v3 line. The previous CLAUDE.md rule blanket-banned AI-attribution trailers ("keine Co-Authored-By-Trailer für Claude / Anthropic"). That fit v1/v2, where the goal was to make the git history read as if the maintainer authored everything personally.

For v3 the policy is reversed: AI-assisted commits should carry a `Co-Authored-By` trailer for the model that helped, optionally with the "Generated with Claude Code" hint. The reasoning is provenance, not marketing — the README disclaimer and the three independent deep-research audits already make AI authorship a public fact, and the git history should match.

## API

none — pure project-policy documentation.

## Behaviour

`CLAUDE.md` section "Was nicht in Commits / PRs gehört" replaced with two sections:

- **AI-Attribution in Commits / PRs** — explicitly allows and encourages `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (or current model) plus the optional `🤖 Generated with [Claude Code]` line.
- **Sonstige Commit-/PR-Regeln** — `--no-verify` ban kept; everything else moved to the new section.

Three things that stay forbidden:

- Adding the repo maintainer as `Co-authored-by`. He is already the git `Author` of every commit, so a Co-Author trailer for him is redundant and looks like a self-attribution.
- Adding other humans who did not actually contribute as `Co-authored-by`.
- `--no-verify` and other hook bypasses.

## Refactoring

none.

## Tests

n/a (pure policy doc). Quality gates run as a smoke check:

- `composer cs-fix` — no-op (no source touched)
- `composer stan` — no errors
- `composer test` — 159 passed (363 assertions)

## Verification

- [x] composer cs-fix
- [x] composer stan
- [x] composer test
- [x] CI matrix (PHP 8.4 + 8.5)

## Closes

none — this is project-policy plumbing, not a finding closure.

## Status

Mini-PR neben dem v3-Release-Sweep. Nicht in den Sweep gemergt, weil die Policy-Änderung projektweit wirkt und unabhängig vom Release-Inhalt diskutierbar sein sollte. Nach Merge gilt die Regel ab sofort für alle künftigen Commits — der bereits gemergte Doku-Sweep (PR #89) hat die Attribution bereits angewendet.