### PR TITLE
docs(claude): drop generator-advert clause from AI-attribution policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,11 +125,11 @@ Für die **v3-Linie und alles danach** ist die AI-Attribution explizit erwünsch
 
 **Erlaubt und erwünscht:**
 
-- `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (oder das jeweils aktuelle Modell) als Trailer auf Commits, die mit Claude-Code-Hilfe entstanden sind.
-- Optional auch der Generator-Hinweis `🤖 Generated with [Claude Code](https://claude.com/claude-code)` in der Commit-Body, **vor** dem Co-Author-Trailer. Das ist keine Werbung — es ist Provenance.
+- Genau **ein** `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (oder das jeweils aktuelle Modell) als Trailer auf Commits, die mit Claude-Code-Hilfe entstanden sind. Mehr nicht — das ist die Provenance.
 
 **Nicht erlaubt:**
 
+- **Kein `🤖 Generated with [Claude Code]`-Hinweis** oder andere Generator-Werbe-Footer im Commit-Body. Der `Co-Authored-By`-Trailer reicht — alles darüber hinaus ist Werbung.
 - **Niemals einen `Co-authored-by`-Trailer auf den Repo-Maintainer setzen.** Der Maintainer ist sowieso der Git-`Author` jedes Commits — ein Co-Author-Trailer für ihn ist redundant und falsch.
 - Keine anderen Personen als Co-Author setzen, ohne dass diese tatsächlich am Commit mitgearbeitet haben.
 


### PR DESCRIPTION
## Context

Follow-up to PR #90, same day. PR #90 merged a CLAUDE.md policy that allowed the "🤖 Generated with [Claude Code]" hint as an optional addition to the `Co-Authored-By` trailer. The maintainer rejected that wording on the same day: the trailer alone is the provenance; the generator hint is advertising.

This PR replaces the "Optional auch der Generator-Hinweis …" sentence with an explicit ban, so the policy reads unambiguously.

## API

none — pure project-policy documentation.

## Behaviour

`CLAUDE.md` "AI-Attribution in Commits / PRs" section, two diffs:

- The "Erlaubt und erwünscht" list now says: **genau ein** `Co-Authored-By: …` Trailer. Mehr nicht.
- The "Nicht erlaubt" list gains a new bullet: **Kein** `🤖 Generated with [Claude Code]`-Hinweis oder andere Generator-Werbe-Footer im Commit-Body.

Effect: maximum one line of attribution per commit, namely `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>` (or the current model). No `🤖`, no "Generated with", no link to claude.com.

## Refactoring

none.

## Tests

n/a (pure policy doc).

## Verification

- [x] `composer cs-fix` — no-op (CLAUDE.md only)
- [x] `composer stan` — no errors
- [x] `composer test` — 159 passed (363 assertions)

## Closes

none — same-day correction of PR #90.

## Status

Mini-PR, sollte vor dem Release-PR `release/v3.0 -> main` mergen, damit die korrekte Policy auch auf main landet (und nicht die zwischenzeitliche „Generator-Hinweis optional erwünscht"-Variante aus #90).