### PR TITLE
docs(review): v3.0.0 audit reports, task list, and bundle planning

### DIFF
--- a/docs/review/review_v3-0/claude_deep-research-audit-icap-flow-v3.0.0.md
+++ b/docs/review/review_v3-0/claude_deep-research-audit-icap-flow-v3.0.0.md
@@ -1,0 +1,470 @@
+# Code-Review: ndrstmr/icap-flow v3.0.0
+
+## 1. Executive Summary
+
+`ndrstmr/icap-flow v3.0.0` ist eine produktionsreife ICAP-Client-Library auf hohem Niveau. Die Code-Basis besteht den AAA-Anspruch in den meisten Dimensionen:
+
+- ✅ PHPStan Level 9 + bleedingEdge ohne Baseline läuft fehlerfrei
+- ✅ php-cs-fixer ohne Findings
+- ✅ 159 Tests / 363 Assertions grün
+- ✅ Gesamtcoverage 84,4 %
+- ✅ RFC-3507-Wire-Format mit Hand-Computed-Bytes-Tests verifiziert
+- ✅ Fail-secure-Statusinterpretation in `assertSuccessfulStatus()` als Single-Source-of-Truth
+- ✅ TLS-Pool-Key-Isolation sicher
+- ✅ Strict-§4.5-Same-Socket-Continuation streamt ohne RAM-Buffering
+- ✅ Per-IO-Timeout korrekt komponiert
+- ✅ Drei v3-BC-Breaks (v3-V/W/F) am Code sauber umgesetzt
+
+### Verifikation der drei v3-BC-Breaks
+
+Alle drei restlos geschlossen:
+- ✅ `executeRaw()` ist protected mit ausführlicher Phpdoc-Begründung
+- ✅ `options(): Future<IcapResponse>` über alle drei Implementierungen konsistent
+- ✅ `IcapResponseException` weder als Datei noch als Code-Referenz noch als Test-Erwartung vorhanden
+
+
+**Keine P0-Blocker für Produktion gefunden.** Es gibt aber vier P1-Findings, die für einen Class-AAA-Code-Review noch geschlossen werden sollten — vor allem für den geplanten Bundle-Stand:
+1. `IcapTimeoutException` ist toter Code *(P1, Diagnose-Kontrakt-Verletzung)*.
+2. Library-managed Header-Prinzip gilt nur für Encapsulated, nicht für Host/Connection — caller-supplied Host gewinnt im Formatter *(P1, semantischer Hijack möglich)*.
+3. PSR-Cache-Adapter haben Race-Conditions im `__icap_keys`-Tracking *(P1, Multi-Worker unter Last)*.
+4. Coverage-Hotspots in `SynchronousStreamTransport` (41 %), `AsyncAmpTransport` (64 %), `AmpConnectionPool` (71 %) — die im Audit-Prompt behaupteten ≥ 85/90 % aus v2.2 sind nicht erreicht, und kritische Cleanup-Pfade (`closeForced=true`, Strict-§4.5 catch-Block) sind ungetestet *(P1)*.
+
+**TRL-Einschätzung:** **TRL-7 → TRL-8** (System Complete & Qualified). Mit drei vorigen unabhängigen Audits + dem v3-Cleanup ist die Library jenseits des „Prototype in operational environment"-Stadiums. Für TRL-9 (System Proven in Operational Environment) fehlen multi-Vendor-Integration-Tests (Symantec/Sophos/Trend Micro/Kaspersky) und ein veröffentlichtes Begleit-Bundle in produktivem Einsatz.
+
+**Empfehlung für Produktion:**
+* **Interne Tools / Prototypen / öffentliche Verwaltung Symfony (TYPO3, Shopware) gegen c-icap+ClamAV:** JA mit Standard-Härtung (TLS, `RetryingIcapClient`, Logging-Pipeline, `Config::withLimits()`).
+* **Security-kritischer Upload-Scan-Gateway:** JA mit Einschränkungen — die vier P1-Findings vor Go-Live im eigenen Betriebskontext klären (insbes. P1-Finding #2 ist Konfigurationsfrage: keine User-Input-Header-Listen ohne Allowlist).
+* **Symfony-Bundle-Stufe:** API-Vertrag JETZT einfrierungsreif. Die drei v3-BC-Breaks haben alles geschlossen, was das verhindert hätte. Bundle als `^0.1`-Start, Aufstieg auf `^1.0` nach erstem Real-Deployment.
+
+**Vergleich v2.1 → v3.0:** v3.0 ist genau das, was es zu sein vorgibt — ein konservativer Cleanup-Release ohne neue Features. Die in der konsolidierten v2.1-Task-Liste (4 unabhängige Audits, Konsens TRL-7) als kritisch markierten Items A (TLS-Pool-Key), B (`DefaultPreviewStrategy` 200/206), F (`IcapResponseException`), G (Fail-Secure 100), H (CRLF-Guard), v3-V/W/F sind alle am Code verifiziert geschlossen. Die in v2.2 versprochene Coverage-Push (`AmpConnectionPool` ≥ 90 %, `SynchronousStreamTransport` ≥ 85 %) ist messbar nicht erreicht.
+
+---
+
+## 2. Repository-Inventar v3.0.0
+
+### 2.1 Verzeichnisstruktur und LOC
+
+```text
+src/   (39 PHP-Dateien, ~4.212 LOC)
+├── IcapClient.php                707  ← zentrale Facade (mit assertSuccessfulStatus())
+├── IcapClientInterface.php        99  ← Public Contract (4 Methoden + Cancellation)
+├── RetryingIcapClient.php        175  ← Decorator (generisch via @template T)
+├── SynchronousIcapClient.php     101  ← Sync-Wrapper
+├── Config.php                    203  ← final readonly + Wither-Pattern
+├── RequestFormatter.php          213  ← iterable<string> Streaming
+├── ResponseParser.php            239  ← RFC 7230 §3.2.4 obs-fold + DoS-Limits
+├── ChunkedBodyEncoder.php        100  ← Streaming + encodeRemainderFromStream()
+├── DefaultPreviewStrategy.php     93  ← 100/204/200/206-Matrix
+├── PreviewDecision.php            31  ← Enum
+├── PreviewStrategyInterface.php   34
+├── (Interfaces: 41+34+99=174 LOC)
+├── DTO/                          286  ← 5 final readonly Klassen
+├── Exception/                    216  ← Marker + 6 konkrete Typen
+├── Cache/                        456  ← InMemory + PSR-6 + PSR-16 + Interface
+└── Transport/                  1.179  ← Pool + Session + Frame-Reader + Async + Sync
+
+tests/ (38 PHP-Dateien, ~5.122 LOC)
+├── Wire/        — Hand-Computed-Bytes (Formatter + Parser + ChunkedEncoder)
+├── Security/    — Fail-Secure + DoS-Limits
+├── Transport/   — Pool (Default/Idle/MaxConn/TLS), Frame-Reader, Per-IO-Timeout
+├── Cache/       — InMemory + PSR-6 + PSR-16
+├── DTO/         — Value-Object-Tests
+├── Exception/   — Hierarchie + Marker
+├── Integration/ — c-icap + ClamAV (skip-by-default)
+└── (Top-level: IcapClient, Cancellation, MultiVendorVirusHeaders, Logger, …)
+```
+
+**Test-zu-Code-Ratio:** 5.122 / 4.212 ≈ 1,22. Branchenüblich für Security-kritische Libraries: 1,5–2,5. Die Ratio ist niedrig, was sich in den Coverage-Hotspots (Phase 5) widerspiegelt.
+
+### 2.2 Public-API-Oberfläche (für SemVer-Disziplin)
+
+| Symbol | Sichtbarkeit | Status v3.0 | BC seit v2.2 |
+| :--- | :--- | :--- | :--- |
+| `IcapClientInterface::request/options/scanFile/scanFileWithPreview` | public | stabil | — |
+| `IcapClient::executeRaw` | protected | v3-V BREAK | ja |
+| `IcapClient::options(): Future<IcapResponse>` | public | v3-W BREAK | ja |
+| `Exception\IcapResponseException` | — | v3-F removed | ja |
+| `Cache\Psr6OptionsCache`, `Psr16OptionsCache` | public final | stabil seit v2.2 | — |
+| `Transport\NullConnectionPool` | public final | stabil seit v2.2 | — |
+| `OptionsCacheInterface::set(?string $istag)` | public | erweitert seit v2.2 | additiv-OK |
+| `RetryingIcapClient::withRetry()` mit `@template T` | private | stabil v3.0 | nur intern |
+| Marker `IcapExceptionInterface` | public interface | stabil | — |
+| Konkrete Exceptions | 6 final + 1 nicht-final (`IcapProtocolException`) | stabil v3.0 | — |
+
+### 2.3 Dependency-Graph
+
+* **runtime:** `php^8.4`, `amphp/socket^2.3`, `psr/log^3.0`, `revolt/event-loop^1.0`
+* **suggest:** `psr/cache^3.0`, `psr/simple-cache^3.0` (soft, NOT hard deps — sauber)
+* **dev:** `pest^3.8`, `phpstan^2.1`, `php-cs-fixer^3.75`, `mockery^1.6`, `phpunit^11.2`, `roave/security-advisories:dev-latest`
+
+**Bewertung:** runtime-deps minimalistisch und hochqualitativ (`amphp`/`Revolt` sind die Standard-Async-Stacks für PHP 8.4+). PSR-Cache-Pakete bewusst als suggest — vermeidet harte Dependencies für Caller, die `InMemoryOptionsCache` ausreichend finden. Sehr gut.
+
+---
+
+## 3. v3.0-BC-Break-Verifikation
+
+* **Item: v3-V `executeRaw()` protected**
+    * **Code-Ref:** `src/IcapClient.php:154`
+    * **Status:** ✅ verifiziert geschlossen
+    * **Begründung:** Sichtbarkeit protected, Phpdoc Z. 137-153 dokumentiert die Security-Rationale ausführlich. Methode bleibt für Subklassen nutzbar. Direkter Test-Zugriff ist nicht mehr möglich, was die Test-Suite akzeptiert (ein Mock-Pfad, kein Reflection-Aufruf).
+* **Item: v3-W `options(): Future<IcapResponse>`**
+    * **Code-Ref:** `src/IcapClient.php:167`, `src/IcapClientInterface.php:62`, `src/SynchronousIcapClient.php:70`
+    * **Status:** ✅ verifiziert geschlossen
+    * **Begründung:** Signatur über alle drei Implementierungen konsistent. `assertSuccessfulStatus()` (Z. 624) ist Single-Source-of-Truth; wird von `interpretResponse()` Z. 602 und `options()` Z. 196 + Z. 177 (Cache-Hit) gemeinsam genutzt. Cookbook `03-options-request.php` und `06-pool-tuning.php` reflektieren die neue API korrekt (`$options->headers`, nicht `$result->getOriginalResponse()->headers`).
+* **Item: v3-F `IcapResponseException` removed**
+    * **Code-Ref:** `src/Exception/` (7 Dateien, kein `IcapResponseException.php`); `grep -rn "IcapResponseException" src/ tests/` liefert null Treffer
+    * **Status:** ✅ verifiziert geschlossen
+    * **Begründung:** Beide Throw-Sites werfen `IcapProtocolException`: `IcapClient.php:607` (Backstop für 1xx-other-than-100, 3xx, 6xx+) und `DefaultPreviewStrategy.php:70` (default-Branch der Status-Match). `tests/Exception/ExceptionHierarchyTest.php` enthält keinen Eintrag. Marker-Catch-Pfad via `IcapExceptionInterface` weiter intakt.
+
+### 3.1 Spot-Check der v2.2-Closures
+
+| Item | Code-Ref | Status |
+| :--- | :--- | :--- |
+| **v2.1.1-A TLS-Pool-Key-Isolation** | `AmpConnectionPool.php:194-211` | ✅ Security geschlossen (per `spl_object_hash`) — aber: explizit als „transitional" markiert, deterministischer SHA-256-Hash für v2.2 versprochen, nicht geliefert (siehe Finding #1). Test 'isolates idle sockets...' in `AmpConnectionPoolTest.php:201-235` greift. |
+| **v2.1.1-B DefaultPreviewStrategy 200/206** | `DefaultPreviewStrategy.php:62-92` | ✅ verifiziert geschlossen — `match (true)`-Branch deckt 200/206 → `classifyBodyResponse()` → `ABORT_INFECTED`/`ABORT_CLEAN` ab. |
+| **v2.1.2 Strict-§4.5 Streaming** | `IcapClient.php:414` + `ChunkedBodyEncoder.php:83-99` | ✅ verifiziert geschlossen — kein `stream_get_contents()` mehr. Test in `PreviewContinueStrictTest.php:139-241` belegt mit 128 KiB Payload. |
+| **v2.2-K OPTIONS-driven Preview-Size** | `IcapClient.php:520-540` | ✅ verifiziert geschlossen — Test in `tests/OptionsDrivenPreviewSizeTest.php` vorhanden. |
+| **v2.2-L Pool-Tuning aus OPTIONS** | `AmpConnectionPool.php:173-179` | ✅ verifiziert geschlossen — Test in `AmpConnectionPoolMaxConnectionsTest.php` vorhanden. |
+| **v2.2-Q Pool-Idle-Eviction** | `AmpConnectionPool.php:107-121` | ✅ verifiziert geschlossen — Test in `AmpConnectionPoolIdleEvictionTest.php`. |
+| **v2.2-P Per-IO-Timeout** | `AmpTransportSession.php:87-94` | ✅ verifiziert geschlossen — Test in `PerIoTimeoutTest.php`, läuft 3,74 s mit Socket-Pair und gestaffelten Server-Delays. |
+| **v2.2-T/U ISTag-Invalidation + Clock** | `InMemoryOptionsCache.php:43-107` | ✅ verifiziert geschlossen, aber im PSR-Adapter-Pfad mit Race-Conditions (siehe Finding #3). |
+| **v2.2-X PSR-6/PSR-16-Adapter** | `Psr6OptionsCache.php`, `Psr16OptionsCache.php` | ✅ verifiziert geschlossen, aber mit P1-/P2-Issues (siehe Findings #3, #6, #7). |
+
+### 3.2 Wunschliste-Check
+
+| Item | Status | Bewertung |
+| :--- | :--- | :--- |
+| **W-Y OpenTelemetry-Decorator** | aufgeschoben | Verschiebung gerechtfertigt — kein Public-Sector-OTel-Mandat 2026 sichtbar. Empfehlung in v3.1.0 zu eröffnen, sobald erstes Bundle-Deployment OTel verlangt. |
+| **W-Z PHPBench-Suite** | aufgeschoben | Verschiebung gerechtfertigt — keine bekannten Performance-Probleme; Library ist I/O-bound, nicht CPU-bound. Mutation-Tests reichen für Korrektheit. |
+| **W-sbom SBOM-Workflow (CycloneDX/SPDX)** | aufgeschoben | Verschiebung kritisch zu prüfen. Ab BSI TR-03183 (Stand 2026) wird SBOM für öffentliche Verwaltungssoftware Pflicht. Empfehlung: in v3.0.x oder v3.1.0 hochziehen. |
+
+---
+
+## 4. Findings nach Dimension
+
+### 4.1 Sprachmoderne / Typsystem
+
+**Stärken:**
+* `final readonly class` durchgängig auf DTOs, Config, Cache-Adapter — sauber.
+* Konstruktor-Property-Promotion durchgängig.
+* `#[\Override]` auf jeder Interface-Implementierung — PHPStan-Level-9-konform.
+* `@template T` auf `RetryingIcapClient::withRetry()` ist sauber definiert.
+* `int<1, max>`-Phpdoc auf `resolvePreviewSize()` — Level-9-Niveau.
+* `final` auf allen konkreten Klassen außer `IcapProtocolException` (bewusst nicht-final).
+
+**Beobachtungen (informativ):**
+* Property hooks (PHP 8.4) und asymmetric visibility werden nicht genutzt. Kein Schaden.
+* `mixed $body: string|resource|null` in HttpRequest/HttpResponse ist korrekt (kein `resource`-Typ in PHP).
+
+*(Kein Finding)*
+
+### 4.2 SOLID / Architektur
+
+**Stärken (im AAA-Niveau):**
+* SRP sauber durchgezogen (Reader, Parser, Encoder, Session, Pool isoliert).
+* Decorator (`RetryingIcapClient`) retried nur `IcapServerException` (5xx).
+* Strategy (`PreviewStrategyInterface`) sauber entkoppelt.
+* Pool-Pattern mit LIFO-Stack, Idle-Eviction und OPTIONS-Tuning sehr gut.
+* `assertSuccessfulStatus()`-Extraktion ist der richtige SRP-Schnitt.
+
+#### F-2-1 (P1) — Library-managed Headers gewinnen nur teilweise (Header-Hijack möglich)
+**Code-Ref:** `src/RequestFormatter.php:152-154`
+```php
+if (!isset($headers['Host'])) {
+    $headers['Host'] = [$host];
+}
+```
+**Problem:** Caller-gelieferter `Host` über `scanFile(..., $extraHeaders)` gewinnt. CLAUDE.md fordert, dass Library-verwaltete Header gewinnen. Ein Caller könnte via `'Host' => 'evil-routing-target'` das Routing manipulieren.
+**Severity:** P1 (Semantischer Hijack möglich).
+**Fix-Vorschlag:** Unbedingtes Setzen und explizites Blocken in der Allowlist:
+```php
+$headers['Host'] = [$host]; 
+unset($headers['Connection']); 
+$headers['Encapsulated'] = [$encapsulated];
+```
+
+#### F-2-2 (P2) — IcapClient::options() Cache-Hit-Pfad inkonsistent zur API-Form
+**Code-Ref:** `src/IcapClient.php:174-180`
+**Problem:** Gespeicherter 5xx-Fehler wirft synchrone Exception vor der Rückgabe des Future. Caller mit `try { ...->await(); }` fängt hier nichts.
+**Fix-Vorschlag:**
+```php
+return \Amp\async(function () use ($cached): IcapResponse {
+    $this->assertSuccessfulStatus($cached->statusCode);    
+    return $cached;
+});
+```
+
+#### F-2-3 (P2) — Cache-Hit-Pfad logged nicht
+**Problem:** Keine `info()`-Logs bei Cache-Hits. Observability-Lücke.
+**Fix-Vorschlag:** `$this->logger->info('ICAP options served from cache', [...]);` ergänzen.
+
+### 4.3 PSR-Compliance
+
+**Stärken:**
+* PSR-3 (Logger) strukturiert, optional.
+* PSR-4 sauber.
+* PSR-6 + PSR-16 als suggest — richtig.
+* PSR-20 (Clock) als `Closure(): int` trade-off OK.
+
+#### F-3-1 (P1) — PSR-Cache-Adapter haben Race-Conditions im Key-Tracking
+**Code-Ref:** `src/Cache/Psr6OptionsCache.php:126-148`, `src/Cache/Psr16OptionsCache.php:116-132`
+**Problem:** `trackKey()` macht read-modify-write auf `__icap_keys` ohne atomare Operation. Unter Last überschreiben sich Worker, Keys gehen verloren und stale ISTags bleiben hängen.
+**Fix-Vorschlag:** Option 3 (Minimal-invasiv & race-frei): `__icap_keys` entfernen und ISTag direkt im Eintrag speichern, beim `get()` validieren.
+
+#### F-3-2 (P2) — ISTag-Meta-Key ohne TTL
+**Code-Ref:** `src/Cache/Psr6OptionsCache.php:121-123`
+```php
+$item = $this->pool->getItem($this->prefix . self::ISTAG_META_KEY);
+$item->set($istag);
+$this->pool->save($item); // ohne expiresAfter()
+```
+**Problem:** Bei LRU-Eviction (z. B. Memcached) fliegt der Meta-Key weg, während Service-Einträge bleiben → stale Cache.
+**Fix-Vorschlag:** `expiresAfter(86400)` hinzufügen.
+
+### 4.4 Fehlerbehandlung & Exceptions
+
+#### F-4-1 (P1) — IcapTimeoutException ist toter Code
+**Code-Ref:** `src/Exception/IcapTimeoutException.php:27`
+**Problem:** Die typisierte Exception wird definiert, aber nirgends geworfen. Es fliegen stattdessen `Amp\CancelledException` oder `IcapConnectionException`.
+**Fix-Vorschlag:** Internen Timeout in `AsyncAmpTransport` und `SynchronousStreamTransport` abfangen und korrekt wrappen.
+
+#### F-4-2 (P2) — Sync-Read-Timeout-Cast verliert Sub-Sekunden-Präzision
+**Code-Ref:** `src/Transport/SynchronousStreamTransport.php:81`
+**Problem:** `stream_set_timeout` mit `(int)` schneidet Nachkommastellen ab. Timeout 0.5s wird zu 0s (Kein Timeout).
+**Fix-Vorschlag:** Sekunden und Mikrosekunden getrennt übergeben.
+
+#### F-4-3 (P3) — Null-Body-Response ohne Encapsulated-Header silent best-effort
+**Problem:** RFC verlangt Encapsulated-Header. Aktuell wird bei Fehlen tolerant ein leeres Array zurückgegeben.
+
+### 4.5 Ressourcen-Management & Connection-Handling
+
+#### F-5-1 (P1) — AmpConnectionPool::key() nutzt spl_object_hash als „transitional"
+**Code-Ref:** `src/Transport/AmpConnectionPool.php:194-211`
+**Problem:** Code-Kommentar kündigt für v2.2 Wechsel auf deterministischen Hash an, in v3.0 immer noch `spl_object_hash`. Führt bei strukturell identischen TLS-Kontexten zu ineffektiven Pools.
+**Fix-Vorschlag:** Deterministischen SHA-256 Hash aus Peer, Cert, CA etc. implementieren:
+```php
+private function key(Config $config): string {
+    // ...
+    return $key . ':tls:' . $this->fingerprintTls($tls);
+}
+```
+
+#### F-5-2 (P2) — Per-IO-Timeout ohne harten Session-Cap
+**Problem:** Slow-Loris-Gefahr durch kumulativ langsame Reads unterhalb des IO-Timeouts.
+**Fix-Vorschlag:** `maxRequestDurationSeconds` in Config einführen.
+
+#### F-5-3 (P2) — Config Konstruktor ohne Validation
+**Problem:** Ungültige Parameter (z. B. leere Hosts, negative Ports) werfen erst im Connect.
+**Fix-Vorschlag:** Explizite Validation im Konstruktor einbauen.
+
+### 4.6 Async-Implementierung
+
+*(Kein Finding, sauber umgesetzt)*
+
+### 4.7 RFC 3507 Compliance (Phase 3)
+
+| Status | Pfad | Behandlung | Test |
+| :--- | :--- | :--- | :--- |
+| **100 (außerhalb Preview)** | `assertSuccessfulStatus()` Z. 626 | `IcapProtocolException` (fail-secure) ✓ | `FailSecureAndValidationTest.php:71-81` |
+| **100 (im Preview)** | `DefaultPreviewStrategy` Z. 65 | `CONTINUE_SENDING` ✓ | `PreviewContinueStrictTest.php` |
+| **200 (Scan, virus header)** | `interpretResponse` Z. 591-598 | `ScanResult(infected=true)` ✓ | `FailSecureAndValidationTest.php:127-140` |
+| **200 (Scan, kein virus)** | `interpretResponse` Z. 599 | `ScanResult(clean)` ✓ | `FailSecureAndValidationTest.php:115-125` |
+| **204** | `interpretResponse` Z. 587 | `ScanResult(clean)` ✓ | mehrere |
+| **200 (OPTIONS)** | `assertSuccessfulStatus` ohne Throw | Raw `IcapResponse` ✓ | `OptionsCacheTest.php:80-116` |
+| **4xx** | `assertSuccessfulStatus` Z. 633 | `IcapClientException(code)` ✓ | `FailSecureAndValidationTest.php:83-97` |
+| **5xx** | `assertSuccessfulStatus` Z. 640 | `IcapServerException(code)` ✓ | `FailSecureAndValidationTest.php:99-113` |
+| **1xx/3xx/6xx+** | Backstop Z. 607 | `IcapProtocolException` ✓ | **Nicht direkt getestet (F-7-1)** |
+
+#### F-7-1 (P2) — Status-Matrix-Backstop ungetestet
+**Problem:** Der Fall-back Catch in Z. 607 ist durch keinen Test abgedeckt.
+**Fix-Vorschlag:** Test für z.B. 301 oder 102 simulieren, um Fail-Secure sicherzustellen.
+
+### 4.8 Security-Posture v3.0 (Phase 4)
+
+#### F-8-1 (P3) — Body von OPTIONS-Antworten wird ungeprüft cached
+**Problem:** OPTIONS hat typischerweise keinen Body, hostiler Server könnte bis zu 10 MiB liefern und den Cache sprengen.
+**Fix-Vorschlag:** Body vor dem Caching explizit auf `''` setzen.
+
+#### F-8-2 (P3) — Config::withTlsContext(null) deaktiviert TLS still
+**Problem:** Versehentliche Null-Übergabe schaltet geräuschlos auf Klartext um.
+**Fix-Vorschlag:** Explizite `withoutTls()` Methode.
+
+### 4.9 Tests & QA (Phase 5)
+
+#### F-9-1 (P1) — Coverage-Hotspots aus v2.2 nicht erreicht
+**Problem:** Versprochene Testabdeckung in kritischen Klassen nicht erfüllt (`SynchronousStreamTransport` 41%, `AsyncAmpTransport` 64%, `AmpConnectionPool` 71%). Ungetestete sicherheitskritische Catch-Blöcke (z.B. in `scanFileWithPreviewStrict`).
+**Fix-Vorschlag:** Prio-Tests für Mid-Continuation-Disconnects, Throw-Pfade und Sync-Loops schreiben.
+
+#### F-9-2 (P2) — Mutation-Threshold global 65 % zu lasch
+**Fix-Vorschlag:** Security-relevante Klassen mit `--min=85` in einem separaten CI-Job testen.
+
+#### F-9-3 (P2) — PSR-Cache-Tests ohne Cross-Process-Backing-Store
+**Fix-Vorschlag:** Echter Integration-Test mit Redis-Backend für Parallelitätsprüfungen.
+
+### 4.10 Symfony-Integration & Ökosystem-Fit (Phase 6)
+
+API-Vertrag ist bereit für ein Bundle. *(Kein library-internes Finding)*.
+
+---
+
+## 5. ICAP RFC 3507 Compliance-Checkliste v3.0
+
+| RFC-§ | Funktion | Status | Code-Ref |
+| :--- | :--- | :--- | :--- |
+| §4.2 | `abs_path`-Subset | ✅ | `validateServicePath` Z. 563 |
+| §4.3.3 | 204/200/206 Verdict-Mapping | ✅ | `interpretResponse` Z. 583 |
+| §4.4.1 | Encapsulated-Header verpflichtend | ✅ | `RequestFormatter::buildEncapsulatedHeader` |
+| §4.4.1 | null-body-Modus | ✅ | `ResponseParser::extractDecodedBody` Z. 173 |
+| §4.5 | Preview Continue (legacy 2-Request-Approx) | ✅ | `scanFileWithPreviewLegacy` |
+| §4.5 | Strict same-socket Preview-Continue | ✅ | `scanFileWithPreviewStrict` + Test |
+| §4.5 | `0; ieof`-Terminator bei `previewIsComplete` | ✅ | `ChunkedBodyEncoder.php:44` |
+| §4.7 | OPTIONS Methods + Allow Header | ✅ | Test 'parses an OPTIONS response...' |
+| §4.8 | REQMOD | ✅ Wire-Test | `RequestFormatterWireTest.php:101` |
+| §4.9 | RESPMOD | ✅ | mehrere Tests |
+| §4.10 | OPTIONS Capability Discovery | ✅ | `options(): Future<IcapResponse>` |
+| §4.10.2 | Options-TTL / Pool-Tuning / Preview | ✅ | `OptionsCacheInterface`, `tuneFromOptions`, `resolvePreviewSize` |
+| §4.10.2 | ISTag (Cache-Invalidation) | ✅ / ⚠ | InMem OK, PSR hat Race (F-3-1) |
+| §5.5 | Connection-Persistence (Keep-Alive) | ✅ | `AsyncAmpTransport` + `ResponseFrameReader` |
+| RFC 7230 | obs-fold / tchar-Whitelist / Chunked / Connection-close | ✅ | Vollständig umgesetzt und getestet |
+
+---
+
+## 6. OWASP Top 10 (2021/2025) Mapping
+
+| OWASP | Library-Mechanismus | Status |
+| :--- | :--- | :--- |
+| A01 Broken Access Control | nicht library-relevant | N/A |
+| A02 Cryptographic Failures | TLS via amphp, Hostname-Verification On, mTLS via Cookbook | ✅ Mitigated (mit P3 F-8-2) |
+| A03 Injection | Guard auf `$service` und Header-Werte, tchar-Whitelist | ✅ Mitigated (mit P1-Lücke F-2-1) |
+| A04 Insecure Design | Fail-Secure auf 100/4xx/5xx, DoS-Limits | ✅ Mitigated |
+| A05 Misconfiguration | Config-Wither + Compliance-Doku | ✅ Mitigated |
+| A06 Vulnerable Components | `composer audit` + roave/security-advisories | ✅ Mitigated (SBOM offen) |
+| A07 Auth Failures | nicht library-relevant | N/A |
+| A08 Data Integrity | EUPL-1.2, Packagist-PGP | ⚠ Partial (SBOM/Signature outstanding) |
+| A09 Logging Failures | PSR-3 strukturiert, kein PII | ✅ Mitigated |
+| A10 SSRF | Config::host aus Caller, kein User-Input | ✅ Mitigated |
+
+---
+
+## 7. Pool / Session-Lifecycle / Cache Threat-Analyse
+
+* **7.1 TLS-Pool-Isolation:** Sicher, aber Ineffizienz-Gap bei identischen Kontexten (siehe F-5-1).
+* **7.2 Idle-Eviction:** Lazy Eviction ohne Background-Tasks. Atomar sicher.
+* **7.3 OPTIONS-driven Pool-Tuning:** Caller muss dynamisch nachtunen, Cookbook ergänzen.
+* **7.4 Per-IO-Timeout:** Sauber implementiert, aber harter Session-Cap (`maxRequestDurationSeconds`) empfohlen (P2).
+* **7.5 Cache Race-Conditions:** ISTag-Race unter Last (siehe F-3-1, P1). Backing-Store-Tagging fehlt.
+* **7.6 Session-Lifecycle:** `Strict §4.5` Catch-Block sicherheitskritisch und korrekt, aber ungetestet.
+
+---
+
+## 8. Wettbewerbsvergleich
+
+### 8.1 PHP-Welt (Packagist 2026)
+
+| Paket | Aktualität | Pooling | TLS | Streaming | Strict §4.5 | Multi-Vendor | Aktiv? |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **ndrstmr/icap-flow** | v3.0 (2026-05) | ✓ | ✓ | ✓ | ✓ | ✓ | ja |
+| tomatonotomato/icap-php | ~2018 | — | — | — | — | nur ClamAV | nein |
+| aurora-pt/php-icap-client | ~2020 | — | Hack | — | — | nur ClamAV | nein |
+
+### 8.2 Andere Sprachen (Maßstab)
+
+| Stack | Lib | RFC-Coverage | Streaming | Pool | TLS | Strict §4.5 | Cancellation |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| Java | HttpComponents | hoch | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Go | egirna/icap-client | mittel | ✓ | nativ | ✓ | partiell | ✓ |
+| Python | pyicap | niedrig | partiell | — | — | — | — |
+| .NET | ICAPClient | mittel | ✓ | ✓ | ✓ | partiell | ✓ |
+
+*(icap-flow dominiert im PHP-Bereich und hält global im Feature-Set hervorragend mit).*
+
+---
+
+## 9. Bewertungsmatrix
+
+| Dimension | v1.0.0 | v2.1.0 | v3.0.0 | Begründung |
+| :--- | :--- | :--- | :--- | :--- |
+| Sprachmoderne | 5 | 9 | 9 | PHPStan L9+bleedingEdge ohne Baseline; `@template T` sauber |
+| Typsystem | 4 | 9 | 9 | `strict_types`, `int<1,max>`, `list` |
+| SOLID / Architektur | 5 | 9 | 9 | SRP-Schnitte sauber |
+| Exception-Design | 4 | 8 | 8 | -1 wegen toter `IcapTimeoutException` |
+| PSR-Konformität | 6 | 8 | 8 | Race in `__icap_keys` (F-3-1) zieht 1 Pkt ab |
+| Ressourcen/Mgmt | 4 | 8 | 9 | Per-IO-Timeout v2.2 + Idle-Eviction |
+| Pool-Korrektheit | n/a | 8 | 8 | `spl_object_hash` transitional (-1 Pkt) |
+| Async/Cancellation | 6 | 8/9 | 9 | Cancellation sauber durchgereicht |
+| RFC 3507 / §4.5 | 4 | 9 | 9 | Alle Methoden + dieselbe Socket Preview-Continue implementiert |
+| ICAP-Robustheit | 4 | 9 | 9 | obs-fold getestet; DoS-Limits enforced |
+| Security-Posture | 3 | 8 | 8 | Stark, aber P1-Lücke bei Host-Header (F-2-1) |
+| Test-Coverage | 4 | 8 | 7 | Hotspots aus v2.2 nicht erreicht (F-9-1) |
+| Wire-Format-Tests | 2 | 9 | 9 | Hand-Computed Bytes (Gold Standard) |
+| CI / Integration | 5 | 8 | 9 | Multi-PHP, c-icap+ClamAV, Nightly |
+| SemVer-Disziplin | 3 | 7 | 9 | v3.0 Cleanup isoliert |
+| Bundle-Readiness | 2 | 7 | 9 | API einfrierungsreif |
+| **Gesamt Score** | **86 (~31%)** | **207 (~74%)** | **227 (~81%)** | **TRL-7 → TRL-8** |
+
+---
+
+## 10. Produktionsreife-Gate-Entscheidung
+
+| Einsatzkontext | Empfehlung | Bedingungen |
+| :--- | :--- | :--- |
+| Interne Tools / Prototypen | ✅ Ja | ohne Einschränkungen |
+| Symfony Web-Portale (Public Sector) | ✅ Ja, mit Einschränkungen | F-2-1 via Allowlist blockieren; F-3-1 durch Single-Worker umgehen (oder InMemory Cache nutzen) |
+| Security-kritischer Upload-Gateway | ✅ Ja, mit Einschränkungen | Alle obigen + Coverage Push (F-9-1) + Vendor-Integration-Test im eigenen Lab |
+| Bundle-Stufe | ✅ API einfrierungsreif | Bundle als `^0.1`-Start mit `^3.0`-Library-Constraint |
+
+---
+
+## 11. Priorisierte Gap-Liste
+
+### P1 (Vor AAA-Class-Production-Use schließen)
+| # | Finding | Datei:Zeile | Aufwand |
+| :--- | :--- | :--- | :--- |
+| 1 | `IcapTimeoutException` ist toter Code (F-4-1) | `AsyncAmpTransport.php`, `SynchronousStreamTransport.php` | M (1-2 Tage) |
+| 2 | Host-Header-Gewinner via extraHeaders (F-2-1) | `RequestFormatter.php:152`, `IcapClient.php:665` | S (2-4 Std. + Test) |
+| 3 | PSR-Cache `__icap_keys`-Race (F-3-1) | `Psr6OptionsCache.php`, `Psr16OptionsCache.php` | M (1 Tag) |
+| 4 | Coverage-Hotspots aus v2.2 nicht erreicht (F-9-1)| `SynchronousStreamTransport.php`, `AsyncAmpTransport.php`, etc. | L (3-5 Tage) |
+
+### P2 (Nice to have für AAA-Class)
+| # | Finding | Aufwand |
+| :--- | :--- | :--- |
+| 5 | TLS-Pool-Key deterministisch machen (F-5-1) | S |
+| 6 | Mutation-Threshold auf >=85% (F-9-2) | S |
+| 7 | PSR-Cache Integration-Test (Redis) (F-9-3) | M |
+| 8 | Config Konstruktor-Validation (F-5-3) | XS |
+| 9 | Per-Session `maxRequestDurationSeconds`-Cap (F-5-2) | S |
+| 10 | `assertSuccessfulStatus()` Backstop-Test 301/102 (F-7-1) | XS |
+| 11 | `options()` Cache-Hit Logging & Consistency (F-2-2/3) | XS |
+| 12 | Psr*OptionsCache ISTag-Meta-Key TTL (F-3-2) | XS |
+| 13 | `stream_set_timeout` mit Microseconds (F-4-2) | XS |
+| 14 | OPTIONS-Body in Cache nullen (F-8-1) | XS |
+| 15 | `Config::withoutTls()` Methode (F-8-2) | XS |
+
+---
+
+## 12. Roadmap v3.0.x → v3.1 → v3.2 → v4.0
+
+* **v3.0.1 (Patch — reine Bugfixes)**
+    * *Schedule: 2-4 Wochen nach v3.0.0 (F-2-1 sicherheitsrelevant)*
+    * Fixes für P1 und P2 Bugs (Timeout Exceptions, Host Header Validation, Cache Future Konsistenz, etc.)
+* **v3.1.0 (Minor — additiv)**
+    * *Schedule: 2-3 Monate nach v3.0.1*
+    * Features wie neues ISTag-Caching (Race-Condition Fix), Deterministic TLS Fingerprint, Session Timeouts, und massive Coverage Pushes.
+* **v3.2.0 (Minor — Symfony-Bundle-Companion)**
+    * *Schedule: 6-9 Monate nach v3.0.0*
+    * Veröffentlichung des `ndrstmr/icap-flow-bundle:^0.1`.
+    * Integration von OpenTelemetry (falls Bedarf).
+* **v4.0.0 (Major — nur falls echte BC-Breaks erforderlich)**
+    * PHP 8.6+ Minimum oder tiefgreifende Architekturänderungen.
+
+---
+
+## 13. Quellenverzeichnis
+
+* **RFCs:** RFC 3507 (ICAP), RFC 7230 (HTTP/1.1), RFC 9110/7231
+* **PSR:** PSR-3, PSR-4, PSR-6, PSR-12, PSR-16, PSR-20
+* **Standards:** OWASP Top 10 (2021/2025), BSI IT-Grundschutz (OPS.1.1.4, APP.4.4), DSGVO Art. 32, EUPL-1.2
+* **Symfony 7.4 LTS:** HttpClient, Cache, Profiler
+* **Amp v3 / Revolt 1.x:** Socket\ClientTlsContext, Timeouts, EventLoop
+* **Vorgänger-Audits:** Diverses internes Review-Material (Claude, Codex, Jules, etc.)
+* **Reference-Implementations:** c-icap, egirna/icap-client (Go)

--- a/docs/review/review_v3-0/codex_technical-audit-v3.0.0.md
+++ b/docs/review/review_v3-0/codex_technical-audit-v3.0.0.md
@@ -1,0 +1,446 @@
+# Deep Review: ICapFlow v3.0.0 Production-Readiness & Technical Excellence Audit
+
+## Executive Summary
+
+ICapFlow v3.0.0 ist im Kern ein **konsequenter Cleanup-Major** ohne neue Feature-Fläche; die drei angekündigten BC-Breaks sind am Code nachvollziehbar umgesetzt: `executeRaw()` ist `protected`, `options()` liefert `IcapResponse`, und `IcapResponseException` ist entfernt. Die v2.2-Schließungen (Per-IO-Timeout, Pool-Idle-Eviction, OPTIONS-driven Pool-Tuning, ISTag-basierte Cache-Invalidation, PSR-6/16-Adapter) sind ebenfalls im Code und in dedizierten Tests sichtbar.
+
+Aus Security-/Korrektheitssicht ist die zentrale Fail-Secure-Matrix stabil: `100` außerhalb Preview, `4xx` und `5xx` werden als Exceptions erzwungen; Parser/Framer haben DoS-Grenzen und RFC-7230-obs-fold-Handhabung. Für den Einsatz als Upload-Malware-Gate in Symfony/TYPO3/Shopware lautet mein Urteil: **produktionsreif mit überschaubaren P1/P2-Aufgaben im Ökosystem (Bundle/Observability) statt im Core**.
+
+Haupt-Risiken liegen nicht mehr in offensichtlichen Protokollfehlern, sondern in Randbedingungen: (a) Cross-process-Race-Fenster der PSR-Cache-Meta-Key-Invalidation, (b) kein globales Hard-Deadline-Konzept über mehrere Per-IO-Zyklen, (c) fehlende First-Party-Symfony-Bundle-Schicht.
+
+**TRL-Einschätzung v3.0.0: 8/9** (v2.1-Konsens lag bei 7). Der Sprung ergibt sich aus geschlossenem Audit-Backlog, stabiler Test-/Mutation-Governance und klarer SemVer-Bereinigung vor Bundle-Start.
+
+## Repository-Inventar v3.0.0 (Phase 1)
+
+- PHP-Dateien gesamt: 78 (`src`: 39, `tests`: 39).
+- LOC: `src` 4212, `tests` 5122.
+- Test-zu-Code-Ratio (LOC): ~1.22.
+- Unit-Run lokal: 159 Tests, 363 Assertions.
+
+## v3.0-BC-Break-Verifikation
+
+| Item | Erwartung | Status | Evidenz |
+|---|---|---|---|
+| v3-V | `IcapClient::executeRaw()` ist `protected` inkl. Security-Rationale | Verifiziert geschlossen | `src/IcapClient.php` (Docblock + `protected function executeRaw`) |
+| v3-W | `options(): Future<IcapResponse>` + gemeinsame Failure-Single-Source (`assertSuccessfulStatus`) | Verifiziert geschlossen | `src/IcapClient.php`, `src/IcapClientInterface.php`, `src/SynchronousIcapClient.php` |
+| v3-F | `IcapResponseException` entfernt; Throw-Sites auf `IcapProtocolException` | Verifiziert geschlossen | `src/Exception/` ohne Datei, `src/DefaultPreviewStrategy.php`, `tests/Exception/ExceptionHierarchyTest.php` |
+
+### Spot-Check v2.2-Closures
+
+- Per-IO-Timeout umgesetzt in `AmpTransportSession::makeIoCancellation()` und per Test abgesichert.
+- Idle-Eviction (`maxIdleSeconds`) aktiv in `AmpConnectionPool` + eigene Testdatei.
+- OPTIONS-driven Pool-Tuning via `tuneFromOptions()` vorhanden + Tests für dynamische Updates.
+- PSR-6/16-Caches mit ISTag-Meta-Keys (`__icap_istag`, `__icap_keys`) vorhanden + dedizierte Tests.
+
+## Findings nach Dimension (Fakten vs Empfehlungen)
+
+### P1 — Cross-process Cache Race (PSR-6/16 Meta-Key Invalidation)
+
+**Fakt:** `Psr6OptionsCache` und `Psr16OptionsCache` implementieren ISTag-Flush über getrennte Writes auf Daten-Key + Meta-Keys (`__icap_istag`, `__icap_keys`), ohne atomare Transaktion.
+
+**Risiko:** In Redis/Memcached-Clustern können konkurrierende Worker inkonsistente Zwischenstände sehen (TOCTOU), insbesondere bei hoher OPTIONS-Schreibfrequenz.
+
+**Empfehlung:** Optionalen atomaren Backend-Mode ergänzen (z. B. CAS/Lua/transaction-capable adapter hook), mindestens dokumentierte Konsistenzgarantien + Lasttest-Szenario.
+
+### P2 — Kein globales Request-Deadline-Konzept
+
+**Fakt:** Per-IO-Timeout ist korrekt pro I/O neu zusammengesetzt; es existiert kein zusätzlicher harter Gesamt-Timeout über die komplette Session/Preview-Mehrphasen-Operation.
+
+**Risiko:** Bei „dauerhaft knapp unter Timeout“-I/O kann ein Request praktisch unbegrenzt laufen.
+
+**Empfehlung:** Optionalen `maxSessionDuration`/`hardDeadline` in `Config` ergänzen und in `AmpTransportSession` mit externer Cancellation kombinieren.
+
+### P1 — Ökosystem-Lücke: fehlendes offizielles Symfony-Bundle
+
+**Fakt:** Core ist DI-fähig, aber produktiver Symfony-Betrieb (multi-client config, cache wiring, retry policy, channelized logging, health-probes) erfordert derzeit Eigenbau.
+
+**Empfehlung:** `ndrstmr/icap-flow-bundle` zeitnah als Begleit-Repo (`^3.0`) starten; Fokus auf Configuration tree, service aliases, PSR-6 wiring, optional DataCollector.
+
+## Positiv verifiziert (erhalten)
+
+- Fail-secure Status-Mapping bleibt strikt und zentralisiert.
+- Strict preview-continue streamt Restdaten ohne Vollpufferung.
+- TLS-kontextbasierte Pool-Isolation gegen Cross-Tenant-Reuse vorhanden.
+- Tests decken Wire-Format, Pool-Lifecycle, Security-Guards und Cache-Adapter breit ab.
+
+## Roadmap
+
+- **v3.0.x:** Dokuhärtung zu Cache-Konsistenz + klare Guidance für OPTIONS-Cache in verteilten Setups.
+- **v3.1.0:** Hard-deadline-Feature, OTel-Decorator, offizielles Symfony-Bundle v0.1/1.0.
+- **v3.2.0:** Property-based Parser tests, optional fuzz harness, Symfony cookbook for `cache.app` + Messenger.
+- **v4.0.0:** Nur bei tatsächlichen API-Zwängen (derzeit nicht erforderlich).
+
+## Phase 2 — Code- & Architektur-Analyse
+
+### 2.1 Sprachmoderne & Typsystem (PHP 8.4/8.5)
+
+- `declare(strict_types=1)` und EUPL-Header sind im Core durchgängig umgesetzt.
+- `Config` ist `final readonly`; Wither (`with*`) liefern neue Instanzen statt Mutationen.
+- `#[\Override]` wird in den Interface-Implementierungen konsequent genutzt (`IcapClient`, `SynchronousIcapClient`, `RetryingIcapClient`).
+- `RetryingIcapClient::withRetry()` ist generisch (`@template T`) und wird sowohl für `Future<ScanResult>` als auch `Future<IcapResponse>` verwendet; das passt zur v3-`options()`-Semantik.
+- `IcapResponseException` ist in der Exception-Hierarchie nicht mehr vorhanden; Marker-Catch bleibt über `IcapExceptionInterface` konsistent.
+
+**Bewertung:** Typsystem-Strenge ist für eine Netzwerkbibliothek überdurchschnittlich gut; ein größeres Restrisiko liegt weniger in Typen als in verteilten Cache-Atomizitäten.
+
+### 2.2 Design, Pattern & SOLID
+
+- Core-Schnitt ist klar: Client orchestriert Formatter/Transport/Parser, Retry bleibt als separater Decorator.
+- `assertSuccessfulStatus()` entkoppelt Fail-Secure-Mapping sauber von der Scan-Interpretation; dadurch ist die `options()`-Semantik korrekt und konsistent.
+- Preview-Handling ist mit Strategy (`PreviewStrategyInterface`) gut kapsuliert; der Strict-Path bleibt in derselben Session (same-socket).
+- `executeRaw()` als `protected` verhindert, dass Consumer die Security-Interpretation im Normalfall umgehen.
+
+**Bewertung:** SRP/Decorator/Strategy sind stimmig umgesetzt; keine offensichtliche Architektur-Regression durch v3-Cleanup.
+
+### 2.3 PSR-Compliance
+
+- PSR-3: Logger optional, `NullLogger` default, keine Header-Payloads im Logging-Kontext.
+- PSR-4: Namespace/Verzeichnisstruktur ist konsistent.
+- PSR-6/PSR-16: Adapter vorhanden und getestet, aber mit Meta-Key-basiertem Invalidierungsdesign (Race-Fenster bleibt als bekannter Trade-off).
+- PSR-20: InMemory-Clock nutzt Closure statt `ClockInterface`; pragmatisch testbar, aber weniger interoperabel.
+
+**Empfehlung (P2):** Optionalen `ClockInterface`-Adapterpfad in v3.1 ergänzen (ohne Breaking Change).
+
+### 2.4 Fehlerbehandlung & Exception-Design
+
+- Status-Mapping bleibt fail-secure: `100` außerhalb Preview ist Protocol-Fehler; `4xx`/`5xx` sind typisiert.
+- Nach Entfernung von `IcapResponseException` ist `IcapProtocolException` jetzt der Catch-all für unerwartete/non-taxonomy Status.
+- Retry bleibt bewusst auf `IcapServerException` (5xx) begrenzt; das schützt vor Retry auf Protokoll- oder Client-Fehlern.
+
+**Bewertung:** Für Security-kritische Upload-Scans ist diese Trennung sinnvoll und defensiv.
+
+### 2.5 Ressourcen-Management & Connection-Handling
+
+- Pool-Key enthält TLS-Fingerprint-Kontext; reduziert Cross-Tenant-Reuse-Risiko.
+- Idle-Eviction ist lazy-on-acquire implementiert (performant, aber ohne Hintergrund-Reaper).
+- Bei Fehlern im Session-Flow wird Socket geschlossen statt zurück in den Pool gelegt (fail-safe Pool-Hygiene).
+- Per-IO-Timeout behebt das frühere Lifetime-Cancellation-Problem, aber ohne globale Hard-Deadline.
+
+**Empfehlung (P2):** Optionalen globalen Request-Timeout als zweite Schutzlinie einführen.
+
+### 2.6 Async-Implementierung
+
+- Amp-Futures/Cancellation werden End-to-End durchgereicht (Client → Transport → Session).
+- `CompositeCancellation` + frische `TimeoutCancellation` pro I/O ist korrekt für mehrphasige Preview-Flows.
+- Sync-Wrapper bleibt als klare Integrationsschicht für nicht-async Laufzeitkontexte vorhanden.
+
+**Bewertung:** Async-Design ist robust und praxistauglich; größte offene Lücke liegt eher bei Observability/Bundle-Fit als im Event-Loop-Handling selbst.
+
+## Phase 3 — ICAP-Protokoll-Compliance (RFC 3507)
+
+### 3.1 Methodenabdeckung
+
+- **OPTIONS** ist als Capability-Discovery korrekt modelliert (v3: raw `IcapResponse` statt `ScanResult`).
+- **RESPMOD** ist der primäre Scan-Pfad (`scanFile`, `scanFileWithPreview`).
+- **REQMOD** wird vom Formatter/Parser unterstützt und über `request(IcapRequest)` adressiert.
+
+**Verifikationsergebnis:** Methodenmatrix ist für den Library-Auftrag vollständig; v3-Semantik-Korrektur bei OPTIONS ist konsistent über Async- und Sync-Client.
+
+### 3.2 Nachrichtenformat (Wire)
+
+- Request-Line/Encapsulation wird im Formatter gebildet; die Wire-Tests prüfen Hand-Computed-Bytes für OPTIONS/RESPMOD/REQMOD.
+- Chunked-Encoding inklusive `0; ieof`-Pfad ist testseitig abgesichert.
+- Response-Framing arbeitet encapsulated-aware statt `Connection: close`-Heuristik.
+
+**Verifikationsergebnis:** RFC-nahe Wire-Disziplin ist vorhanden; die Test-Suite schützt die kritischen Byte-Pfade gut gegen Regression.
+
+### 3.3 Preview (§4.5)
+
+- Strict Preview-Continue läuft bei `SessionAwareTransport` auf **demselben Socket**.
+- Legacy-Fallback für nicht-sessionfähige Transports bleibt als bewusstes Kompatibilitätsverhalten erhalten.
+- Fortsetzungs-Streaming nutzt den Chunked-Encoder aus dem aktuellen Stream-Offset (kein Vollbuffer-Read des Restbodys).
+
+**Verifikationsergebnis:** Der v2.1.2-Fix gegen OOM-Risiko ist im Designpfad verankert und durch dedizierte Wire/Transport-Tests flankiert.
+
+### 3.4 Statuscode-Matrix (v3)
+
+- `204` → clean scan.
+- `200/206` → Header-basierte Virus-Interpretation.
+- `100` außerhalb Preview → `IcapProtocolException` (fail-secure).
+- `4xx` → `IcapClientException`, `5xx` → `IcapServerException`.
+- Nicht zuordenbare Codes außerhalb dieser Taxonomie laufen fail-secure als Protocol-Fehler.
+
+**Verifikationsergebnis:** v3-Extraktion `assertSuccessfulStatus()` reduziert Drift-Risiko zwischen `request()` und `options()`.
+
+### 3.5 Parser-Robustheit & Security
+
+- Parser verarbeitet RFC-7230-obsolete-folding (praktisch relevant für c-icap/Vendor-Header).
+- DoS-Limits (`maxResponseSize`, Headeranzahl, Headerzeilenlänge) sind konfigurierbar und testseitig abgesichert.
+- Malformed-Input wird in typisierte Protocol/Malformed-Exceptions überführt.
+
+**Verifikationsergebnis:** Robuste defensive Parsing-Strategie; kein Hinweis auf fail-open-Verhalten im Parserpfad.
+
+### 3.6 Interop-/Kompatibilitätsstand
+
+- CI-Integration gegen c-icap/ClamAV ist vorhanden.
+- Multi-Vendor-Header-Support ist im Core konfigurierbar und getestet.
+- Breite Hersteller-Interop (Symantec/Sophos/Trend/Kaspersky) ist nicht als First-Party-CI-Matrix abgedeckt.
+
+**Empfehlung (P2):** Interop-Matrix als optionales Nightly-Programm aufbauen (nicht als Hard-Gate für PRs).
+
+### RFC-3507-Checkliste (Phase-3 Snapshot)
+
+| Bereich | Status | Evidenz im Repo |
+|---|---|---|
+| OPTIONS Capability Discovery | Mitigated | `IcapClient::options()`, `OptionsCache*`, `OptionsCacheTest` |
+| REQMOD/RESPMOD Wire-Format | Mitigated | `RequestFormatter`, `Wire/RequestFormatterWireTest.php` |
+| Preview §4.5 Same-Socket (strict) | Mitigated | `scanFileWithPreviewStrict`, `PreviewContinueStrictTest.php` |
+| Preview fallback behavior | Partial (bewusst) | `scanFileWithPreviewLegacy` |
+| Encapsulated-aware response framing | Mitigated | `ResponseFrameReader`, `ResponseFrameReaderTest.php` |
+| Statuscode Fail-Secure-Mapping | Mitigated | `interpretResponse`, `assertSuccessfulStatus`, Security-Tests |
+| Header folding / malformed handling | Mitigated | `ResponseParser`, `Wire/ResponseParserWireTest.php` |
+| Vendor breadth CI coverage | Partial | Integration nur gegen c-icap/ClamAV |
+
+## Phase 4 — Security & Compliance Assessment
+
+### 4.1 Security Posture v3.0 (OWASP-orientiert)
+
+#### Fail-Secure-Verhalten
+
+- Der Core erzwingt fail-secure für `100` außerhalb Preview sowie für `4xx/5xx` via typed exceptions.
+- `options()` nutzt dieselbe Failure-Policy wie Scan-Pfade (keine semantische Sonderbehandlung als „clean“).
+- Unerwartete Statusbereiche außerhalb der bekannten Taxonomie landen ebenfalls als Protocol-Fehler.
+
+**Bewertung:** Für ein Upload-Security-Gateway ist dieses Fehlerverhalten angemessen defensiv.
+
+#### Input-/Header-Validierung (Injection)
+
+- Service-Path-Validierung blockiert Control-Characters, NUL und Whitespace zur Vermeidung von Request-Line/Header-Injection.
+- Header-Validierung prüft Namen gegen RFC-7230-tchar und validiert Werte inkl. Array-Mehrfachwerten auf CR/LF/NUL.
+- Damit ist der bekannte „nested header value“-Vorwurf aus früheren Reviews im v3-Codepfad faktisch nicht bestätigt.
+
+**Restrisiko:** `%0d%0a` wird nicht explizit decoded; im aktuellen Modell ist das vertretbar, da keine URI-Decodierung vor Wire-Emission erfolgt.
+
+#### TLS / Connection-Isolation
+
+- Pool-Key differenziert per TLS-Kontext-Fingerprint (host:port plus TLS-relevante Materialisierung), was Cross-Tenant-Reuse mit abweichender TLS-Konfiguration verhindert.
+- Fehlerpfade schließen Session-Sockets fail-safe statt potenziell desynchronisierte Streams in den Pool zurückzugeben.
+
+**Bewertung:** Die v2.1.1-Härtung gegen Cross-Tenant-Leaks ist in v3 intakt.
+
+#### Logging / Sensitive Data Exposure
+
+- Logging ist optional (PSR-3, `NullLogger` default).
+- Event-Kontext fokussiert auf Metadaten (`method`, `uri`, `host`, `port`, `statusCode`, bei Scan `infected`) statt Header-/Body-Inhalten.
+- Regressionstest schützt gegen Header-Leakage im Log-Kontext.
+
+**Bewertung:** DSGVO-relevante Minimierung ist im Library-Core sinnvoll umgesetzt; Betreiberverantwortung bleibt beim Logger-Backend.
+
+#### Dependency Security
+
+- Security-Guardrails via `composer audit` und `roave/security-advisories` sind im Projektprozess verankert.
+- Das senkt Lieferkettenrisiken, ersetzt aber keine SBOM-/Provenance-Transparenz für Public-Sector-Beschaffung.
+
+**Empfehlung (P2):** SBOM-Export (CycloneDX/SPDX) als CI-Artefakt optional in v3.1 einführen.
+
+### 4.2 PSR-Cache-Cross-Process-Analyse (vertieft)
+
+#### Beobachtung
+
+- PSR-6/16-Adapter nutzen Meta-Keys (`__icap_istag`, `__icap_keys`) für globale ISTag-Invalidation.
+- Der Ansatz ist pragmatisch und backend-agnostisch, aber nicht streng atomar in jedem Store.
+
+#### Risiko-Szenarien
+
+1. **TOCTOU beim ISTag-Switch:** Worker A schreibt neuen Response-Key, Worker B liest zwischen Daten- und Meta-Key-Update.
+2. **Key-Set-Wachstum:** `__icap_keys` kann in dynamischen Multi-Service/Multi-Tenant-Umgebungen wachsen.
+3. **Backend-Semantik-Divergenz:** Redis/Memcached/File-Adapter verhalten sich bzgl. Konsistenz/Race unterschiedlich.
+
+#### Präzise Empfehlung
+
+- v3.0.x: Dokumentation ergänzen (Konsistenzmodell + empfohlene Backend-Klassen).
+- v3.1: Optionaler „atomic invalidation strategy“-Hook (adapter- oder backend-spezifisch).
+- v3.1+: Last-/Race-Testprofil (parallelisierte Worker-Simulation) als nicht-blockender CI-Job.
+
+### 4.3 OWASP Top 10 (2021/2025) Mapping — Library-spezifisch
+
+| OWASP-Kategorie | Relevanter Mechanismus in icap-flow | Status |
+|---|---|---|
+| A01 Broken Access Control | Nicht primär Library-Scope (keine AuthZ-Engine) | N/A |
+| A02 Cryptographic Failures | TLS-Unterstützung + Pool-Isolation nach TLS-Kontext | Partial (Caller muss TLS policy sauber setzen) |
+| A03 Injection | Service-/Header-CRLF-Guards, Header-Name/Value-Validierung | Mitigated |
+| A04 Insecure Design | Fail-secure Status-Mapping, typed exception taxonomy | Mitigated |
+| A05 Security Misconfiguration | Sichere Defaults für Parser-/Response-Limits, aber TLS optional | Partial |
+| A06 Vulnerable Components | `composer audit` + roave advisories | Mitigated |
+| A07 Identification/Auth Failures | Nicht primärer Scope (abhängig von Upstream/ICAP-Infra) | N/A |
+| A08 Software/Data Integrity Failures | Keine Signatur-/attestation-Pipeline im Repo | Partial |
+| A09 Logging/Monitoring Failures | Minimaler Log-Context + Leak-Guard-Test | Mitigated |
+| A10 SSRF | Host/Port kommen aus App-Konfiguration; kein direkter User-Input-Pfad im Core | Partial (Betriebsrichtlinie nötig) |
+
+### 4.4 Public-Sector-Compliance (EUPL/BSI/DSGVO/OpenCoDE)
+
+#### EUPL / Lizenz
+
+- EUPL-1.2 ist konsistent im Repo verankert; Header-Disziplin in Source/Test-Dateien ist sichtbar.
+
+#### BSI-Grundschutz / Betriebskontext
+
+- Das vorhandene Compliance-Mapping ist für technische Orientierung nützlich, aber kein formaler Nachweis.
+- Für Behördenbetrieb bleibt die Betriebsdokumentation (Netzsegmentierung, Schlüsselmanagement, Incident-Prozesse) außerhalb der Library zwingend.
+
+#### DSGVO Art. 32
+
+- Logging-Minimierung im Core unterstützt Datenschutzprinzipien.
+- Der eigentliche Datenschutz-Impact entsteht durch Integrationsentscheidungen (welche Dateiinhalte/Metadaten geloggt oder gespeichert werden).
+
+#### Digitale Souveränität
+
+- OSS-Stack ohne SaaS-Zwang ist positiv; für Beschaffungspfade kann SBOM/Provenance mittelfristig relevant werden.
+
+### 4.5 Phase-4-Entscheidung (präzise)
+
+- **Keine neuen P0-Blocker** aus dem Core-Codepfad identifiziert.
+- **P1 bestätigt:** Cross-process Cache-Konsistenz ist die wichtigste verbleibende technische Unsicherheit.
+- **P2 bestätigt:** SBOM/Provenance, globales Deadline-Modell und erweiterte Interop-Matrix sind die sinnvollsten nächsten Schritte.
+
+## Phase 5 — Testing & Qualitätssicherung (Coverage/Mutation/CI-Gates)
+
+### 5.1 Unit-Test-Qualität & Suite-Disziplin
+
+- PHPUnit ist strikt konfiguriert (`beStrictAboutCoverageMetadata`, `beStrictAboutOutputDuringTests`, `failOnRisky=true`, `failOnWarning=true`).
+- Unit und Integration sind sauber getrennt (eigene Testsuites, Integration ausgeschlossen aus Unit-Run).
+- Die dokumentierte lokale Unit-Ausführung (159/363) passt zur erwarteten Größenordnung für den v3-Stand.
+
+**Bewertung:** Test-Hygiene ist überdurchschnittlich robust; „grün“ bedeutet hier mehr als nur „keine Assertion fehlgeschlagen“.
+
+### 5.2 Coverage-Gates
+
+- CI führt Unit-Tests mit Coverage auf **PHP 8.4 und 8.5** aus.
+- Coverage wird als Artifact persistiert und auf `gh-pages` für `main` veröffentlicht.
+- `includeUncoveredFiles=true` in der PHPUnit-Coverage-Konfiguration verhindert künstlich geschönte Coveragewerte.
+
+**Einschätzung:** Der Gate-Mechanismus ist sauber; die konkrete Prozentzahl muss aus dem jeweils aktuellen Coverage-Report gezogen werden (nicht statisch im Doc hardcoden).
+
+### 5.3 Mutation-Testing-Gate
+
+- Mutation-Job ist als eigener CI-Job mit MSI-Schwelle (`--min=65`) konfiguriert.
+- Mutation läuft auf PR-Events nach erfolgreichem Quality-Gate.
+
+**Bewertung:** Für eine Security-kritische Library ist 65% ein brauchbarer Einstieg, aber mittelfristig konservativ.
+
+**Empfehlung (P2):** MSI in Stufen anheben (z. B. 65 → 70 → 75), begleitet von gezielten Tests für überlebende Mutanten in Status-/Parser-/Cache-Pfaden.
+
+### 5.4 Integration-Tests & Intermittenz-Risiko
+
+- Integration läuft gegen echtes `c-icap + ClamAV` Setup via Docker Compose.
+- Readiness-Probe prüft nicht nur offenen Port, sondern erwartet echte ICAP-Antwort (`ICAP/1.x`) — wichtig gegen Freshclam-Cold-Start-Flakiness.
+- Integration wird auf `push`/`schedule` ausgeführt, nicht auf PRs.
+
+**Trade-off:** Schnellere PR-Zyklen vs. späteres Erkennen von Wire-Interop-Regressionen.
+
+**Empfehlung (P1/P2-Grenze):** Optionalen, lightweight PR-smoke für Integration (z. B. manuell auslösbar oder label-gesteuert) ergänzen, um kritische Wire-Änderungen früher zu validieren.
+
+### 5.5 Cache-/Timeout-spezifische Teststärke
+
+- Dedizierte Testdateien für `PerIoTimeout`, `AmpConnectionPool` (inkl. Idle-Eviction/Max-Connections) und PSR-6/16-Options-Cache-Adapter sind vorhanden.
+- Das reduziert das Risiko, dass regressionskritische v2.2/v3-Pfade unbemerkt aufweichen.
+
+**Restrisiko:** Cross-process-Races in echten verteilten Caches sind mit In-Memory/Test-Doubles nur begrenzt abbildbar.
+
+### 5.6 CI-Gate-Bewertung (Gesamt)
+
+| Gate | Status | Bewertung |
+|---|---|---|
+| Lint/Style (`cs-check`) | Aktiv | Gut |
+| Static Analysis (`stan`) | Aktiv | Gut |
+| Unit Tests (8.4/8.5) | Aktiv | Sehr gut |
+| Coverage Artifact/Deploy | Aktiv | Gut |
+| Integration c-icap/ClamAV | Aktiv (push/schedule) | Gut mit PR-Lücke |
+| Mutation (`min=65`) | Aktiv (PR) | Gut, steigerbar |
+| Dependency Audit | Aktiv | Gut |
+
+**Phase-5-Fazit:** Die QA-Kette ist für v3.0 stark. Die größten Hebel sind jetzt nicht „mehr von allem“, sondern **gezielte Härtung**: höhere Mutation-Schwelle, optionaler PR-Integration-Smoke und belastbarere Cache-Race-Validierung.
+
+## Phase 6 — Symfony-Integration & Ökosystem-Fit
+
+### 6.1 Bundle-Readiness (Core → `ndrstmr/icap-flow-bundle`)
+
+- Der Core bleibt framework-agnostisch und ist damit grundsätzlich bundle-freundlich.
+- `IcapClientInterface` plus `RetryingIcapClient`-Decorator passen gut zu Symfony-DI-Alias-Ketten.
+- Die v3-API-Bereinigung (`options(): IcapResponse`, `executeRaw()` geschützt) reduziert API-Ambiguitäten für spätere Bundle-Kontrakte.
+
+**Bewertung:** Der jetzige Core ist hinreichend stabil, um ein offizielles Bundle auf `^3.0` aufzusetzen.
+
+### 6.2 Minimal Viable Bundle (konkret)
+
+Empfohlene erste Version (v0.1 oder direkt v1.0, je nach Stabilitätsanspruch):
+
+1. `IcapFlowBundle` + `DependencyInjection/Configuration` mit Tree für:
+   - `host`, `port`, `socket_timeout`, `stream_timeout`
+   - `tls.*` (inkl. mTLS-Optionen)
+   - `virus_found_headers[]`
+   - `limits.max_response_size`, `limits.max_header_count`, `limits.max_header_line_length`
+   - `pool.max_connections_per_host`, `pool.max_idle_seconds`
+   - `retry.max_attempts`, `retry.initial_delay_ms`, `retry.max_delay_ms`
+   - `options_cache` (`in_memory` / `psr6` / `psr16`)
+2. Service-Wiring:
+   - `Config`
+   - `AmpConnectionPool` (optional `NullConnectionPool`)
+   - `AsyncAmpTransport`
+   - `IcapClient` (+ optional `RetryingIcapClient` als public alias auf `IcapClientInterface`)
+3. Multi-Client-Unterstützung (`icap_flow.clients.<name>`), damit Behörden-/Shop-Setups mehrere ICAP-Services sauber trennen können.
+
+### 6.3 Symfony-7.4-Fit (praktische Integrationspunkte)
+
+- **Monolog Channel**: `icap` (Bundle-seitig) für saubere Trennung operativer Scan-Logs.
+- **Cache-Integration**: PSR-6 Bridge zu `cache.app` als Default-OPTIONS-Cache mit klarer Doku zu Konsistenztrade-offs.
+- **Health/Readiness Probe**: `icap:options` oder interner Probe-Service für Operations.
+- **Messenger-Szenario**: Best-Practice-Recipe für Async-File-Scan-Pipelines ergänzen.
+
+**Bewertung:** Nicht-Core-Themen; sollten bewusst im Bundle statt in der Library selbst landen.
+
+### 6.4 Observability-Lage (OTel/Profiler/Metrics)
+
+- Aktuell ist PSR-3-Logging solide, aber Tracing/Metrics fehlen als First-Party-Bausteine.
+- Für öffentliche Träger mit wachsender OTel-Adoption wäre ein optionaler Decorator sinnvoll (`trace span per request`, `status/infected tags`, latency histograms).
+
+**Empfehlung (P1/P2):** In v3.1 zuerst einen kleinen Observability-Decorator liefern; Symfony-DataCollector kann danach im Bundle folgen.
+
+### 6.5 Ökosystem-Fit Entscheidung
+
+- **Stark:** Core-Design, DI-Tauglichkeit, Fehler-/Statusmodell, transportnahe Kapselung.
+- **Fehlt:** Offizielles Bundle, standardisierte Symfony-Recipes, OTel/Metrics-Erweiterung.
+- **Konsequenz:** Kein Core-Redesign nötig; der nächste Hebel ist klar **Produktisierung im Ökosystem**.
+
+## Phase 7 — Wettbewerbsvergleich / Benchmarking
+
+### 7.1 PHP-Landschaft (ICAP-bezogen)
+
+- Im PHP-Ökosystem ist die direkte ICAP-Client-Landschaft auf Packagist weiterhin dünn.
+- Als häufig referenzierter Vergleich taucht `nathan242/php-icap-client` auf (ältere API-/Runtime-Generation, deutlich geringere modern-typed/async Ausrichtung).
+- Ein dediziertes, modernes Symfony-First Bundle mit vergleichbarer Tiefe (Pool, Preview strictness, typed exception taxonomy, mutation-gated CI) ist in dieser Nische nicht klar als dominanter Standard sichtbar.
+
+**Einordnung:** `icap-flow` differenziert sich weniger über „es gibt gar keine Alternativen“ und mehr über **Engineering-Tiefe + QA-Governance**.
+
+### 7.2 Andere Sprachen (Referenzmuster)
+
+#### Go
+
+- `code.waarp.fr/lib/icap` betont explizit Streaming/TLS und adressiert Memory-Probleme älterer Bibliotheken als Designmotiv.
+- Ältere/fork-basierte Linien (`egirna`, `opencloud-eu`) zeigen, dass ICAP-Clients oft lange in „WIP/fork drift“-Zuständen bleiben.
+
+**Lernpunkt für icap-flow:** Die klare Positionierung auf Streaming- und Preview-Korrektheit ist im Sprachvergleich ein valides Qualitätsmerkmal.
+
+#### Python
+
+- PyPI-ICAP-Clients wirken fragmentiert; mehrere Pakete sind alt oder fork-basiert, was auf geringe Pflegefrequenz hindeutet.
+
+**Lernpunkt:** Ein stabiler Release-/Audit-Prozess ist ein echter Wettbewerbsvorteil gegenüber „funktioniert irgendwie“-Clientlibs.
+
+#### .NET
+
+- NuGet zeigt verfügbare ICAP-Client-Pakete, aber heterogene Reifegrade/Abdeckung.
+
+**Lernpunkt:** Auch hier ist weniger die Existenz eines Pakets entscheidend als die Tiefe bei Security/Fail-Secure/Interop.
+
+### 7.3 Benchmarking gegen Referenzimplementierungen
+
+- `c-icap` bleibt der praxisnahe Referenzanker für Interop-Validierung; die vorhandene Integration ist deshalb strategisch richtig.
+- Ein echter „Performance-Benchmark“ (Durchsatz/Latenz/Memory unter großen Dateien) ist im aktuellen Repo noch nicht als standardisierte Suite enthalten.
+
+**Empfehlung (P2):** In v3.1/v3.2 eine kleine, reproduzierbare Benchmark-Suite (z. B. phpbench + definierte Filegrößen/Preview-Profile) aufnehmen.
+
+### 7.4 Wettbewerbsfazit (Phase-7)
+
+- **Technisch:** `icap-flow` wirkt im Vergleich modern und sicherheitsbewusst.
+- **Produktseitig:** Größter Hebel ist nicht Core-Feature-Parität, sondern bessere Out-of-the-box Adoption (Bundle, Observability, Benchmarks, optional erweiterte Vendor-Interop).
+- **Strategisch:** Für Public-Sector-Nutzung ist nachvollziehbare QA-/Compliance-Story oft wichtiger als reine Feature-Anzahl — hier hat `icap-flow` eine gute Ausgangslage.

--- a/docs/review/review_v3-0/consolidated_v3.0_task-list.md
+++ b/docs/review/review_v3-0/consolidated_v3.0_task-list.md
@@ -1,0 +1,302 @@
+# Konsolidierte Task-Liste — v3.0.x / v3.1.0 Findings & Roadmap
+
+> **Basis:** Synthese der drei unabhängigen Audits zu v3.0.0
+> in `docs/review/review_v3-0/` (Codex, Jules, Claude),
+> verifiziert am `src/`-Stand bei Tag `v3.0.0`.
+>
+> **Scores:** Jules 265/280 (TRL-8), Codex TRL 8/9, Claude 227/280 (~81%, TRL-8).
+> Konsens: **TRL-8, produktionsreif mit P1-Code-Fixes.**
+>
+> v3.0.0 ist ein konsequenter Cleanup-Major: `executeRaw()` protected,
+> `options(): Future<IcapResponse>`, `IcapResponseException` entfernt.
+> Fail-Secure-Matrix, Parser-Limits, TLS-Pool-Isolation und
+> Injection-Guards sind intakt. **Vier P1-Findings** erfordern Patches
+> vor AAA-Class-Produktion: Statuscode-Backstop, Host-Header-Hijack,
+> IcapTimeoutException dead code, Coverage-Hotspots.
+
+---
+
+## Reviewer-Konsens-Matrix
+
+| Finding | Jules | Codex | Claude-Code | Claude-Audit | Konsens |
+|---|---|---|---|---|---|
+| `assertSuccessfulStatus()` Fail-Open für 1xx≠100/3xx/6xx im `options()`-Pfad | — | — | P1 | P2 (F-7-1) | **P1 (verifiziert)** |
+| `IcapTimeoutException` ist toter Code — wird nirgends geworfen | — | — | — | P1 (F-4-1) | **P1** |
+| Host-Header-Hijack via `extraHeaders` — Library-managed-Prinzip verletzt | — | — | — | P1 (F-2-1) | **P1** |
+| PSR-Cache `__icap_keys` Race-Condition (read-modify-write ohne Atomarität) | P2 | P1 | — | P1 (F-3-1) | **3/4 P1** |
+| Coverage-Hotspots nicht erreicht (SyncTransport 41%, AsyncTransport 64%) | — | — | P2 | P1 (F-9-1) | **P1** |
+| TLS-Fingerprint `spl_object_hash()` statt deterministischem Hash | — | — | P2 | P2 (F-5-1) | **2/4 P2** |
+| `tuneFromOptions()` nicht automatisch im `options()`-Hot-Path | — | — | P2 | — | 1/4 P2 |
+| Symfony-Bundle fehlt | P1 | P1 | — | — | **2/4 P1** |
+| PSR-Cache Key-Pruning (`__icap_keys` Wachstum) | P2 | P1 | — | — | **2/4 P1–P2** |
+| PSR-Cache Cross-Process Race-Doku | P2 (impl.) | P1 (doku) | — | P1 (F-3-1) | **3/4 P1** |
+| `options()` Cache-Hit: synchrone Exception + fehlendes Logging | — | — | — | P2 (F-2-2/3) | 1/4 P2 |
+| `stream_set_timeout` verliert Sub-Sekunden-Präzision (0.5→0) | — | — | — | P2 (F-4-2) | 1/4 P2 |
+| `Config` Konstruktor ohne Validation (leerer Host, negatives Port) | — | — | — | P2 (F-5-3) | 1/4 P2 |
+| ISTag-Meta-Key in PSR-Cache ohne TTL (LRU-Eviction-Problem) | — | — | — | P2 (F-3-2) | 1/4 P2 |
+| OTel-Decorator | P3 | P1/P2 | — | — | **2/4 P2** |
+| Globaler Request-Deadline (`maxSessionDuration`) | — | P2 | — | P2 (F-5-2) | **2/4 P2** |
+| MSI-Schwelle stufenweise erhöhen | — | P2 | — | P2 (F-9-2) | **2/4 P2** |
+| SBOM-Export (CycloneDX/SPDX) | — | P2 | — | — | 1/4 P2–P3 |
+| PR-Integration-Smoke (label-basiert) | — | P1/P2 | — | — | 1/4 P2 |
+| PHPBench-Suite | P3 | P2 | — | — | **2/4 P2–P3** |
+| OPTIONS-Body in Cache nullen (bis 10 MiB möglich) | — | — | — | P3 (F-8-1) | 1/4 P3 |
+| `Config::withTlsContext(null)` deaktiviert TLS geräuschlos | — | — | — | P3 (F-8-2) | 1/4 P3 |
+| PSR-20 `ClockInterface`-Adapter | — | P2 | — | — | 1/4 P3 |
+| Property Hooks in DTOs | P3 | — | — | — | 1/4 P3 |
+
+> **Korrektur / Nicht-Todos:**
+> - Cache-Race ist **kein Bug** — Fail-Secure-Verhalten fängt den Worst-Case.
+>   Lediglich Dokumentation fehlt.
+> - Vendor-Interop-CI-Matrix (Symantec/Sophos/Kaspersky) ist wünschenswert,
+>   aber ohne Zugang zu proprietären Appliances nicht umsetzbar.
+
+---
+
+## Verifizierte Findings
+
+| ID | Finding | Schweregrad | Evidenz | Quelle |
+|---|---|---|---|---|
+| A | PSR-Cache `__icap_keys` Meta-Array wächst unbegrenzt bei hochdynamischen Service-Pfaden | Robustheit P2 | `src/Cache/Psr6OptionsCache.php`, `Psr16OptionsCache.php` | 2/2 |
+| B | PSR-Cache Cross-Process-Konsistenzmodell undokumentiert (TOCTOU bei ISTag-Flush) | Doku P1 | `src/Cache/Psr6OptionsCache.php`, `Psr16OptionsCache.php` | 2/2 |
+| C | Kein globales Hard-Deadline über mehrphasige Preview-Operationen | Robustheit P2 | `src/Transport/AmpTransportSession.php` | Codex |
+| D | Kein OpenTelemetry-Decorator (Tracing/Metrics) | Observability P2 | — | 2/2 |
+| E | MSI-Schwelle bei 65% — konservativ für Security-kritische Lib | Testing P2 | `.github/workflows/ci.yml` | Codex |
+| F | Kein SBOM-Export für Public-Sector-Beschaffung | Compliance P3 | CI | Codex |
+| G | Integration-Tests nicht auf PRs (nur push/schedule) | CI P2 | `.github/workflows/ci.yml` | Codex |
+| H | PHPBench-Suite fehlt | Performance P3 | — | 2/2 |
+| I | Symfony-Bundle fehlt vollständig | Ökosystem P1 | — | 2/2 |
+| J | `assertSuccessfulStatus()` wirft nicht für 1xx≠100, 3xx, 6xx+ — im `options()`-Pfad fehlt Backstop → Response wird gecacht/zurückgegeben | **Fail-Secure P1** | `src/IcapClient.php:624-649` (Helper), Z. 197 (`options()`) | Claude-Code |
+| K | TLS-Pool-Key nutzt `spl_object_hash($tls)` — zwei äquivalente TLS-Contexts → getrennte Pool-Buckets → Pool-Reuse bricht im DI-Container | Performance P2 | `src/Transport/AmpConnectionPool.php:199-207` | Claude-Code |
+| L | `tuneFromOptions()` nur manuell aufrufbar — Default-Client mit Default-Pool braucht zwei OPTIONS-Round-Trips vor Tuning | Ergonomie P2 | `src/Transport/AmpConnectionPool.php:173-179` | Claude-Code |
+| M | 8 konkrete Test-Coverage-Lücken (Backstop-Codes, Legacy-Preview, Multi-Value-Header, Connection-close, Pre-fired-Cancellation, Cross-Process-Cache, maxHeaderCount, fragmentierte Reads) | Testing P2 | diverse | Claude-Code |
+| N | `AmpConnectionPool::tuneFromOptions()` Phpdoc-Beispiel zeigt `$result->originalResponse` (v2-API) — nach v3-W liefert `options()` direkt `IcapResponse`, `@see ScanResult::$originalResponse` ist stale | Doku P2 | `src/Transport/AmpConnectionPool.php:169-171` | Claude-Code |
+| O | `IcapTimeoutException` ist toter Code — wird nirgends geworfen, `Amp\CancelledException` (kein `IcapExceptionInterface`!) propagiert stattdessen | **API-Kontrakt P1** | `src/Exception/IcapTimeoutException.php`, `src/Transport/AsyncAmpTransport.php`, `SynchronousStreamTransport.php` | Claude-Audit F-4-1 |
+| P | `RequestFormatter.php:152` setzt Host nur per `if (!isset(...))` — Caller-supplied `Host` via `extraHeaders` gewinnt, CLAUDE.md-Designregel verletzt | **Security P1** | `src/RequestFormatter.php:152-154`, `src/IcapClient.php:696-706` | Claude-Audit F-2-1 |
+| Q | `stream_set_timeout($stream, (int) $timeout)` — Sub-Sekunden-Präzision geht verloren (0.5s → 0 = kein Timeout!) | Korrektheit P2 | `src/Transport/SynchronousStreamTransport.php:81` | Claude-Audit F-4-2 |
+| R | `options()` Cache-Hit: `assertSuccessfulStatus()` wirft synchron vor Future-Rückgabe — API-Inkonsistenz | API P2 | `src/IcapClient.php:174-180` | Claude-Audit F-2-2 |
+| S | `options()` Cache-Hit: kein `logger->info()` — Operator sieht nicht ob live oder Cache | Observability P2 | `src/IcapClient.php:174-180` | Claude-Audit F-2-3 |
+| T | `Config` Konstruktor ohne Validation — `new Config('')` oder `port: -1` knallt erst im Connect | Defensive P2 | `src/Config.php:53-66` | Claude-Audit F-5-3 |
+| U | ISTag-Meta-Key in PSR-Cache ohne `expiresAfter()` — bei LRU-Eviction (Memcached) fliegt Key weg, stale Cache bleibt | Cache-Konsistenz P2 | `src/Cache/Psr6OptionsCache.php:121-123` | Claude-Audit F-3-2 |
+
+---
+
+## Release-Plan
+
+```
+v3.0.1  Patch (Code + Doku)    kein BC    sofort     Findings B, J, N, O, P, Q, R, S, T, U
+v3.1.0  Minor (additiv)        kein BC    6–10 Wo.   Findings A, C, D, E, G, K, L, M
+v3.2.0  Minor (Tooling)        kein BC    danach     Findings F, H
+Bundle  icap-flow-bundle v1.0  neues Repo parallel   Finding I
+v4.0.0  nur bei echtem Bedarf  —          nicht absehbar
+```
+
+---
+
+## Milestone v3.0.1 — Patch (Code + Doku)
+
+**Scope:** Fail-Secure-Lücke im `options()`-Pfad schließen + Cache-Doku. Kein BC-Break.
+
+**PR-Vorschlag:** `fix(security): backstop for unhandled status codes in assertSuccessfulStatus()`
+
+- [ ] **v3.0.1-J** `assertSuccessfulStatus()` um Backstop-Throw erweitern:
+  Codes die weder 100, noch 2xx, noch 4xx, noch 5xx sind → `IcapProtocolException`.
+  Damit werden 1xx≠100 (z.B. 102), 3xx, 6xx+ im `options()`-Pfad
+  als Protokollfehler behandelt statt gecacht/zurückgegeben.
+  Der bestehende Backstop in `interpretResponse()` wird dann unreachable
+  (Defense-in-Depth, kann mit `@codeCoverageIgnore` annotiert bleiben).
+  **+ Test** in `tests/Security/`: Mock-Transport liefert 301/102/600 →
+  Exception auf `options()` UND `request()`.
+  *Datei: `src/IcapClient.php:624-649`*
+  *Quelle: Claude-Code P1 — am Code verifiziert*
+
+  ```php
+  // Am Ende von assertSuccessfulStatus(), nach dem 5xx-Block:
+  if ($code < 200 || $code >= 300) {
+      throw new IcapProtocolException(
+          sprintf('Unexpected ICAP status (%d) — neither success nor recognized failure.', $code),
+          $code,
+      );
+  }
+  ```
+
+- [ ] **v3.0.1-B** Konsistenzmodell für PSR-6/16-Cache-Adapter dokumentieren:
+  - Erwartetes Verhalten bei konkurrierenden Workern (TOCTOU-Fenster).
+  - Empfohlene Backend-Klassen (APCu für Single-Node, Redis mit Vorbehalt).
+  - Fail-Secure-Garantie: veraltete Capabilities führen schlimmstenfalls zu
+    4xx/Retry, nie zu falschem Clean-Verdict.
+  *Ziel: Absatz in README oder dediziertes `docs/cache-consistency.md`.*
+  *Quelle: Jules P2, Codex P1*
+
+- [ ] **v3.0.1-N** `AmpConnectionPool::tuneFromOptions()` Phpdoc korrigieren:
+  - Z. 169: `$result->originalResponse` → `$response` (nach v3-W ist `options()` direkt `Future<IcapResponse>`).
+  - Z. 171: `@see ScanResult::$originalResponse` entfernen (stale Referenz).
+  *Datei: `src/Transport/AmpConnectionPool.php:167-172`*
+  *Quelle: Claude-Code — am Code verifiziert*
+
+- [ ] **v3.0.1-O** `IcapTimeoutException` aktivieren: Interne Timeouts
+  (`Amp\CancelledException` aus `TimeoutCancellation` und
+  `stream_get_meta_data()['timed_out']`) abfangen und in
+  `IcapTimeoutException` wrappen. Nur interne Timeouts — User-supplied
+  `Cancellation` propagiert weiterhin als `CancelledException`.
+  **+ Test:** `expect(fn() => ...)->toThrow(IcapTimeoutException::class)`
+  mit Socket-Pair ohne Server-Antwort.
+  *Dateien: `src/Transport/AsyncAmpTransport.php`, `src/Transport/SynchronousStreamTransport.php`*
+  *Quelle: Claude-Audit F-4-1 — P1*
+
+- [ ] **v3.0.1-P** Host/Connection als Library-managed Headers erzwingen:
+  `RequestFormatter` setzt `$headers['Host'] = [$host]` unbedingt
+  (nicht nur `if (!isset(...)`).\
+  `IcapClient::validateIcapHeaders()` erweitern: Reserved-Names
+  (`Host`, `Encapsulated`, `Connection`) in `extraHeaders` ablehnen
+  via `\InvalidArgumentException`.
+  **+ Test:** `expect(fn() => $client->scanFile(..., ['Host' => 'evil']))->toThrow(InvalidArgumentException::class)`
+  *Dateien: `src/RequestFormatter.php:152-154`, `src/IcapClient.php:665-684`*
+  *Quelle: Claude-Audit F-2-1 — P1 (Security)*
+
+- [ ] **v3.0.1-Q** `stream_set_timeout` mit Mikrosekunden-Präzision:
+  ```php
+  $seconds = (int) $timeout;
+  $microseconds = (int) (($timeout - $seconds) * 1_000_000);
+  stream_set_timeout($stream, $seconds, $microseconds);
+  ```
+  *Datei: `src/Transport/SynchronousStreamTransport.php:81`*
+  *Quelle: Claude-Audit F-4-2 — P2*
+
+- [ ] **v3.0.1-R** `options()` Cache-Hit in Future wrappen für API-Konsistenz:
+  ```php
+  return \Amp\async(function () use ($cached): IcapResponse {
+      $this->assertSuccessfulStatus($cached->statusCode);
+      return $cached;
+  });
+  ```
+  *Datei: `src/IcapClient.php:174-180`*
+  *Quelle: Claude-Audit F-2-2 — P2*
+
+- [ ] **v3.0.1-S** `options()` Cache-Hit: Logger-Eintrag ergänzen:
+  `$this->logger->info('ICAP options served from cache', [...])`
+  *Datei: `src/IcapClient.php:174-180`*
+  *Quelle: Claude-Audit F-2-3 — P2*
+
+- [ ] **v3.0.1-T** `Config` Konstruktor-Validation:
+  Leerer Host, Port außerhalb 1–65535, negative Timeouts → `\InvalidArgumentException`.
+  *Datei: `src/Config.php:53-66`*
+  *Quelle: Claude-Audit F-5-3 — P2*
+
+- [ ] **v3.0.1-U** ISTag-Meta-Key mit TTL speichern:
+  `$item->expiresAfter(86400)` (24h) in `Psr6OptionsCache` und
+  `$this->cache->set($key, $istag, 86400)` in `Psr16OptionsCache`.
+  *Dateien: `src/Cache/Psr6OptionsCache.php:121-123`, `src/Cache/Psr16OptionsCache.php:113`*
+  *Quelle: Claude-Audit F-3-2 — P2*
+
+---
+
+## Milestone v3.1.0 — Minor (additiv)
+
+**Scope:** Robustheit, Observability, Testing-Governance. Kein BC-Break.
+
+- [ ] **v3.1-A** PSR-Cache Key-Pruning: `__icap_keys`-Array begrenzen.
+  Strategie: LRU oder TTL-basiertes Pruning bei `set()`. Maximale
+  Key-Anzahl als Config-Option (Default: 256).
+  *Dateien: `src/Cache/Psr6OptionsCache.php`, `src/Cache/Psr16OptionsCache.php`*
+  *Quelle: Jules P2, Codex P1*
+
+- [ ] **v3.1-C** Optionalen `maxSessionDuration` in `Config` ergänzen.
+  In `AmpTransportSession` als äußere Cancellation-Boundary neben Per-IO-Timeout.
+  Default: `null` (kein Limit, Rückwärtskompatibel).
+  *Dateien: `src/Config.php`, `src/Transport/AmpTransportSession.php`*
+  *Quelle: Codex P2*
+
+- [ ] **v3.1-D** OpenTelemetry-Decorator (`OtelTracingIcapClient`):
+  - Span pro `request()`/`scanFile*()`/`options()`.
+  - Attributes: `icap.method`, `icap.host`, `icap.status_code`, `icap.infected`.
+  - Optional, keine harte Abhängigkeit (suggest in `composer.json`).
+  *Ziel: `src/OtelTracingIcapClient.php` (Decorator, nicht Subklasse)*
+  *Quelle: 2/2*
+
+- [ ] **v3.1-E** MSI-Schwelle auf 70% anheben, gezielte Tests für
+  überlebende Mutanten in Status-/Parser-/Cache-Pfaden ergänzen.
+  *Datei: `composer.json` (mutation script), ggf. neue Testdateien*
+  *Quelle: Codex P2*
+
+- [ ] **v3.1-G** PR-Integration-Smoke: label-gesteuerter, optionaler
+  Integration-Workflow auf PRs (`integration-test`-Label triggert Job).
+  *Datei: `.github/workflows/ci.yml`*
+  *Quelle: Codex P2*
+
+- [ ] **v3.1-K** TLS-Pool-Key deterministisch machen: `spl_object_hash($tls)`
+  durch SHA-256 über stabile TLS-Felder ersetzen (`peerName`, `certFile`,
+  `caFile`, `cipherList`). Sicherheitsneutral (aktuelles Verhalten ist
+  fail-safe = mehr Sockets), aber Performance-relevant für DI-Container
+  die pro Request neue `ClientTlsContext`-Instanzen bauen.
+  *Datei: `src/Transport/AmpConnectionPool.php:199-207`*
+  *Quelle: Claude-Code P2*
+
+- [ ] **v3.1-L** Optional: `autoTuneFromOptions`-Parameter auf `IcapClient`
+  (Default `false`, BC-safe). Bei `true` wird nach `options()` automatisch
+  `pool->tuneFromOptions()` aufgerufen, wenn der Transport ein Pool-Object
+  exponiert. Alternative: als Bundle-Feature dokumentieren.
+  *Datei: `src/IcapClient.php`*
+  *Quelle: Claude-Code P2*
+
+- [ ] **v3.1-M** Gezielte Tests für 8 identifizierte Coverage-Lücken:
+  1. `interpretResponse()` Backstop (1xx≠100, 3xx, 6xx) — direkt testen
+  2. `scanFileWithPreviewLegacy()` Pfad (Non-SessionAware-Transport)
+  3. `validateIcapHeaders()` mit Multi-Value-Array inkl. Injection
+  4. `AmpConnectionPool` Server-`Connection: close`-Honor
+  5. `AmpTransportSession` Pre-fired external Cancellation
+  6. PSR-Cache-Adapter Cross-Process ISTag-Race
+  7. `ResponseParser` `maxHeaderCount`-Limit direkt
+  8. `ResponseFrameReader` fragmentierte 1-Byte-Server-Reads
+  *Dateien: `tests/Security/`, `tests/Transport/`, `tests/Wire/`, `tests/Cache/`*
+  *Quelle: Claude-Code P2*
+
+---
+
+## Milestone v3.2.0 — Tooling & Benchmarks
+
+- [ ] **v3.2-F** SBOM-Export (CycloneDX) als CI-Artefakt bei Release.
+  *Datei: `.github/workflows/ci.yml`*
+  *Quelle: Codex P2*
+
+- [ ] **v3.2-H** PHPBench-Suite: Definierte Filegrößen (1 KB, 1 MB, 100 MB),
+  Preview-Profile (mit/ohne), Pool-Szenarien (cold/warm).
+  *Ziel: `benchmarks/` Ordner*
+  *Quelle: 2/2*
+
+---
+
+## Begleit-Repo: `ndrstmr/icap-flow-bundle` v1.0.0
+
+**Scope:** Offizielles Symfony-Bundle auf `^3.0`. Höchste Ökosystem-Priorität.
+
+- [ ] **Bundle-I.1** `IcapFlowBundle` + Configuration Tree:
+  `host`, `port`, `tls.*`, `virus_found_headers[]`, `limits.*`,
+  `pool.*`, `retry.*`, `options_cache` (in_memory/psr6/psr16).
+
+- [ ] **Bundle-I.2** Service-Wiring:
+  `Config` → `AmpConnectionPool` → `AsyncAmpTransport` → `IcapClient`
+  (+ optional `RetryingIcapClient` als public alias).
+
+- [ ] **Bundle-I.3** Multi-Client-Support (`icap_flow.clients.<name>`).
+
+- [ ] **Bundle-I.4** Monolog-Channel `icap` + PSR-6-Bridge zu `cache.app`.
+
+- [ ] **Bundle-I.5** CLI Commands: `icap:options`, `icap:scan`.
+
+- [ ] **Bundle-I.6** Optional: `#[IcapClean]` Validator-Constraint.
+
+- [ ] **Bundle-I.7** Optional: Symfony DataCollector (nach OTel-Decorator).
+
+---
+
+## Nicht-Todos (bewusst ausgeschlossen)
+
+| Thema | Begründung |
+|---|---|
+| Core-Security-Fixes (außer J, O, P) | Bis auf Backstop, Timeout-Wrapping und Host-Header-Hijack keine gefunden — Parser-Limits, TLS-Isolation intakt |
+| Cache-Race „Fix" | Kein Bug, sondern dokumentierter Trade-off (fail-secure fängt Worst-Case) |
+| Vendor-Interop-CI (Symantec/Sophos etc.) | Kein Zugang zu proprietären Appliances |
+| Property Hooks in DTOs | Rein kosmetisch, kein Mehrwert |
+| `ClockInterface`-Adapter | Pragmatischer Closure-Ansatz reicht; kein externer Bedarf |
+| v4.0.0-Planung | Kein Designdruck; v3.0 hat alle Schulden abgebaut |

--- a/docs/review/review_v3-0/jules_deep-review-report-v3.0.0.md
+++ b/docs/review/review_v3-0/jules_deep-review-report-v3.0.0.md
@@ -1,0 +1,161 @@
+# Deep Review: ICapFlow v3.0.0 Production-Readiness & Technical Excellence Audit
+
+## 1. Executive Summary
+
+Das Repository `ndrstmr/icap-flow` liegt in der Version v3.0.0 vor und liefert einen extrem robusten, hochmodernen ICAP-Client (RFC 3507) für das asynchrone PHP-Ökosystem (amphp v3 / Revolt).
+
+Als Principal Engineer bescheinige ich dieser Bibliothek nach tiefgehender Prüfung der Major-Linie eine außerordentlich hohe Codequalität. v3.0.0 liefert erfolgreich den versprochenen API-Cleanup, entfernt Deprecations (wie `IcapResponseException`) und stellt die asynchronen Rückgabewerte auf streng typisierte DTOs um (`options()` liefert nun korrekt eine `IcapResponse`).
+
+Die Bibliothek nutzt Features aus PHP 8.4 wie das `#[\Override]`-Attribut sehr diszipliniert und unterhält einen sauberen PHPStan (Level 9) und Pest-Test-Stack. Besonders hervorzuheben sind das exzellent implementierte Connection-Pooling mit Idle Eviction und OPTIONS-basiertem Tuning (`AmpConnectionPool`), sowie der `ChunkedBodyEncoder`, der selbst gigantische Uploads memory-sicher durch den Same-Socket Continuation-Pfad streamt.
+
+**TRL-Score:** TRL-8 (System complete and qualified). Im Vergleich zu v2.1.0 (Audit-Snapshot TRL-7) hat v3.0.0 die Konsistenz und Typensicherheit für Endanwender massiv verbessert, ohne bestehende Mechanismen aufzubrechen.
+**Empfehlung:** Die Library ist für den produktiven Einsatz – auch in kritischen Security-Pfaden im öffentlichen Sektor (BSI-Grundschutz, DSGVO) – ohne Vorbehalte freigegeben. Ein offizielles Symfony-Bundle (`icap-flow-bundle`) stellt den logischen nächsten Schritt dar.
+
+---
+
+## 2. Repository-Inventar v3.0.0
+
+Das Repository ist übersichtlich und gut partitioniert. Alle wesentlichen Metriken bezeugen einen gesunden Codebase-Zustand.
+
+- **LOC:** ca. 4.2k in `src/`, 5.1k in `tests/`
+- **Dateien:** 77 PHP-Dateien (ohne vendor)
+- **CI & Tests:** 159 Unit-Tests (363 Assertions) - alle Tests durchlaufen lokal erfolgreich. PHPStan Level 9 wirft keine Fehler. Mutation Testing verlangt strikt ≥ 65% MSI und ist funktional über CI gekapselt.
+- **Dependency Graph:** Schlank. Nutzt `amphp/socket`, `revolt/event-loop` für Async-Operationen, `psr/log` (optional). Optional PSR-6/16 für Caching (`psr/cache`, `psr/simple-cache`).
+
+---
+
+## 3. v3.0-BC-Break-Verifikation
+
+Die drei wesentlichen v3.0 BC-Breaks wurden am Code geprüft:
+
+| Item | Status | Code-Ref | Begründung |
+|---|---|---|---|
+| **v3-V:** `executeRaw()` protected | **Verifiziert geschlossen** | `src/IcapClient.php:154` | Wurde zu `protected function executeRaw` umgewandelt. Ist im Interface nicht deklariert. Verhindert Umgehung von Statuscode-Checks für externe Aufrufer. |
+| **v3-W:** `options(): Future<IcapResponse>` | **Verifiziert geschlossen** | `src/IcapClient.php:182` <br> `src/IcapClientInterface.php:62` | `options()` returnt `Future<IcapResponse>`. Logik für Fehlerbehandlung (4xx, 5xx, 100) wurde korrekt in `assertSuccessfulStatus` gebündelt und wird dort verwendet. |
+| **v3-F:** `IcapResponseException` removed | **Verifiziert geschlossen** | `src/IcapClient.php:606` | Die Klasse existiert im `src/Exception/`-Verzeichnis nicht mehr. `tests/Exception/ExceptionHierarchyTest.php` referenziert sie nicht mehr. Catch-All ist jetzt `IcapProtocolException`. |
+
+### Stichprobenartige v2.2 Closure-Checks
+- **PSR-Cache Cross-Process:** `Psr16OptionsCache.php` implementiert dedizierte Meta-Keys (`__icap_istag`), um Cross-Process Invalidation zu gewährleisten.
+- **Pool-Idle-Eviction:** `AmpConnectionPool::acquire()` (Z. 115) evictet explizit veraltete Verbindungen bei jedem Zugriff.
+- **Per-IO-Timeout:** `AmpTransportSession::makeIoCancellation()` kombiniert Timeout mit User-Cancellation via `CompositeCancellation` korrekt pro Aufruf, was Spurious-Cancellations im Continuation-Path verhindert.
+
+---
+
+## 4. Findings nach Dimension
+
+### 4.1 Sprachmoderne & Typsystem (PHP 8.4/8.5)
+- **Positiv:** Die Codebase adaptiert moderne Konstrukte exzellent. `readonly` Properties und Konstruktor-Promotion werden konsequent genutzt. `#[\Override]` ist für alle implementierten Interfaces omnipräsent (u.A. `AmpConnectionPool.php:97`, `RetryingIcapClient.php:94`).
+- **Positiv:** In `RetryingIcapClient.php:136` wird `@template T` sauber verwendet, wodurch der Retry-Decorator sowohl `ScanResult` als auch `IcapResponse` typsicher durchleiten kann.
+- **Empfehlung (P3):** Prüfung, ob in Zukunft Property Hooks (`get`) in DTOs wie `ScanResult` den Boilerplate weiter reduzieren können.
+
+### 4.2 Design, Pattern & SOLID
+- **Positiv:** Die Aufspaltung in `TransportSession`, `RequestFormatter` und den neu überarbeiteten `IcapClient` ist vorbildlich. Das `assertSuccessfulStatus()`-Pattern (ausgelagert aus `interpretResponse`) verhindert Codeduplizierung und festigt die "Single-Source-of-Truth" für Statuscode-Policies.
+
+### 4.3 Ressourcen-Management & Connection-Handling
+- **Positiv:** Der `ChunkedBodyEncoder` (`src/ChunkedBodyEncoder.php:83`) puffert Streams nicht mehr in String-Variablen (`stream_get_contents()`), sondern nutzt Generatoren, um große Dateien speicherschonend zu iterieren (`encodeRemainderFromStream`).
+- **Beobachtung/Risiko (P2):** Beim PSR-6/16 Cache-Adapter (`Psr16OptionsCache.php`) kann durch das stetige Aufzeichnen von Cache-Keys unter `__icap_keys` bei Systemen mit hochdynamischen Service-Pfaden das Meta-Array unbegrenzt wachsen. Ein Pruning-Mechanismus fehlt hier.
+- **Positiv:** Cross-Tenant TLS Leakage wird durch den Hashen von TLS-Configs via `SplObjectStorage`-Keys (bzw. Hash-String) im `AmpConnectionPool` sauber abgewendet.
+
+---
+
+## 5. ICAP RFC 3507 Compliance-Checkliste v3.0
+
+| Feature | Status | Anmerkung / Code-Ref |
+|---|---|---|
+| **OPTIONS / Capability Discovery** | ✅ Mitigated | `IcapClient::resolvePreviewSize()` zieht `Preview` aus Cache. Pool zieht `Max-Connections` via `tuneFromOptions()`. |
+| **Strict §4.5 (Preview-Continue)** | ✅ Mitigated | `scanFileWithPreviewStrict` streamt Remainder nach 100 Continue exakt auf dem gleichen Socket, ohne Buffer. |
+| **`0; ieof` Terminator** | ✅ Mitigated | Falls Dateigröße <= Preview, wird im Encoder korrekt abgebrochen. |
+| **Encapsulated Header Offsets** | ✅ Mitigated | Native Berechnung in `RequestFormatter.php` für req-body/res-body/null-body. |
+| **RFC 7230 §3.2.4 Header Folding** | ✅ Mitigated | `ResponseParser::parseHeaderBlock()` (Z. 132) resolviert Spaces/Tabs als Fortsetzungszeilen korrekt. |
+
+---
+
+## 6. OWASP Top 10 (2021) Mapping
+
+| Kategorie | Mechanismen in icap-flow | Status |
+|---|---|---|
+| **A02: Cryptographic Failures** | Default-TLS Policy via `amphp/socket` und `Config::withTlsContext()`-Fingerprinting pro Pool-Eintrag. | Mitigated |
+| **A03: Injection** | Strict CRLF/NUL Check auf Service URI (`\r`, `\n`, `\0` werden in `IcapClient::validateIcapHeaders()` & URI-Builder geblockt). | Mitigated |
+| **A04: Insecure Design** | Fail-Secure Behavior: Unerwartete Codes (z.B. 100 außerhalb Preview) → `IcapProtocolException`. | Mitigated |
+| **A06: Vulnerable/Outdated Comps.** | Keine unsicheren Abhängigkeiten. `composer audit` & Roave Security Advisories aktiv in CI. | Mitigated |
+| **A10: SSRF** | `host`-Parameter in `Config` darf nicht aus User-Input gespeist werden. | N/A (Admin Duty) |
+
+---
+
+## 7. Pool / Session-Lifecycle / Cache Threat-Analyse
+
+Die Architektur rund um den Connection-Lifecycle ist das Herzstück des v3.0 Refactors:
+
+- **TLS-Pool-Isolation:** Vollständig gelöst. `AmpConnectionPool` separiert Sockets nicht nur nach Host:Port, sondern hash-verknüpft den TLS-Context in den Key ein. Kein Leakage.
+- **Idle-Eviction:** Lazy-Eviction beim `acquire()` (`AmpConnectionPool.php:115`) evaluiert Idle-Zeiten > `maxIdleSeconds` und dropt Verbindungen. Da PHP Single-Threaded Fiber-basiert ist, gibt es hier keine atomaren Race-Conditions bei Array-Operationen.
+- **Per-IO-Timeout:** Der Switch auf `TimeoutCancellation` pro I/O anstelle einer Lebenszeit-Cancellation löst alle False-Positive Abbrüche (beim Strict Streaming).
+- **Cache Race Condition (Risiko):** `Psr16OptionsCache` speichert einen Globalen ISTag Meta-Key. Zwischen Worker A, der das Meta-Feld schreibt, und Worker B, der liest, besteht ein Nano-Window, das potenziell veraltete Capabilities liefern könnte. Durch die Fail-Secure-Natur des Clients würde das schlimmstenfalls in einem 4xx enden → Unkritisch in der Praxis, aber architektonisch erwähnenswert.
+
+---
+
+## 8. Wettbewerbsvergleich
+
+| Library | Sprache | Streaming/§4.5 | Pool & Timeout-Control | Aktiv Gepflegt? |
+|---|---|---|---|---|
+| **ndrstmr/icap-flow (v3.0.0)** | PHP | ✅ Zero-copy chunking | ✅ Amp Pool + Idle Eviction | ✅ Sehr aktiv |
+| **nathan242/php-icap-client** | PHP | ❌ String-buffered | ❌ Sync `socket_create` | ❌ Verwaist |
+| **icap-client** | Go | ⚠️ Partiell | ✅ Go Contexts | ⚠️ Mittelmäßig |
+| **toolarium-icap-client** | Java | ✅ Java IO | ✅ Native Java Pooling | ⚠️ Legacy |
+
+*Fazit:* `icap-flow` dominiert im PHP-Ökosystem konkurrenzlos. Es gibt derzeit kein anderes Paket, das asynchrones I/O, strict §4.5 und ein vergleichbares Security-Posture vereint.
+
+---
+
+## 9. Bewertungsmatrix
+
+| Dimension | v1.0.0 | v2.1.0 | v3.0.0 (Score) | Begründung |
+|---|---|---|---|---|
+| Sprachmoderne (PHP 8.4) | 6/10 | 9/10 | **10/10** | DTOs, readonly, `#[\Override]`, `@template T`. Perfekt. |
+| SOLID / Architektur-Klarheit | 5/10 | 8/10 | **9/10** | Sehr saubere Wither-Patterns & Decorator (Retry). |
+| Exception-Design | 4/10 | 8/10 | **9/10** | 6 konkrete Typen + Marker. Altlast (`IcapResponseException`) weg. |
+| Connection-Pool-Korrektheit | n/a | 7/10 | **9/10** | TLS-Isolation + Eviction + Options Tuning sitzen. |
+| Strict Preview-Continue (§4.5) | n/a | 9/10 | **10/10** | Streaming via `ChunkedBodyEncoder` schützt vor OOM. |
+| Test-Coverage / Mutation | 6/10 | 8/10 | **9/10** | Pest MSI >= 65% hartes CI-Gate + 159 Tests. |
+| API-Stabilität / SemVer | n/a | 8/10 | **10/10** | Cleanup Release perfekt für Contract-Freezing ausgeführt. |
+| **Gesamt-Readiness-Score** | **~120** | **~225** | **265/280** | Exzellent vorbereitet für Enterprise Use. |
+
+---
+
+## 10. Produktionsreife-Gate-Entscheidung
+
+- **Für interne Tools / Prototypen:** Ja.
+- **Für Symfony-Applikationen im öffentlichen Sektor (TYPO3, Portale):** **Ja.** Das Compliance-Level (EUPL, BSI-Mapping, GDPR) und die Fail-Secure-Garantien erfüllen höchste Auflagen.
+- **Für den Einsatz als kritische Security-Komponente:** **Ja.** Der Code ist rigoros getypt, mutation-tested und schützt durch Streams vor OOM DoS-Szenarien.
+
+Das Bundle-Kontrakt (`ndrstmr/icap-flow-bundle`) kann exakt auf den Interfaces von `^3.0` aufgebaut werden. Es bestehen keine API-Flaws mehr, die ein baldiges `v4.0` erfordern würden.
+
+---
+
+## 11. Priorisierte Gap-Liste
+
+Was fehlt zum "technisch perfekten" Ökosystem-State?
+
+1. **P1 (Kritisch für Ökosystem-Fit):** Das geplante **Symfony-Bundle**. Die Dependency Injection, Autowiring und CLI Commands (`icap:options`, `icap:scan`) gehören in ein offizielles Symfony-Paket.
+2. **P2 (Nice-to-have):** PSR-Cache Key-Pruning. Ein Mechanismus zur Vermeidung des unendlichen Wachstums von `__icap_keys` in hochdynamischen Umgebungen im `Psr6OptionsCache` / `Psr16OptionsCache`.
+3. **P2 (Differenzierung):** Validator-Constraints (z.B. `#[IcapClean]`) für einfache `symfony/validator`-Integration. (Gehört ins Bundle).
+4. **P3 (Vision):** OpenTelemetry-Decorator (`W-Y`) für Tracing/Metrics. Fuzzing Suite für den Parser.
+
+---
+
+## 12. Roadmap v3.0.x → v3.1 → v4.0
+
+- **v3.0.x (Patches):** Bugfixes bei Bedarf. Keine Änderungen absehbar.
+- **Begleit-Repo (`icap-flow-bundle` v1.0.0):** Sollte jetzt sofort initiiert werden, referenziert auf `^3.0.0`. Beinhaltet `IcapFlowExtension`, Logger-Config, Autowiring, CLI Commands und das `#[IcapClean]` Validator-Constraint.
+- **v3.1.0 (Minor):** Einführung von OpenTelemetry (`OtelTracingIcapClient`) als Add-on sowie Property-Based Testing.
+- **v4.0.0:** Vorerst nicht absehbar und auf Jahre nicht nötig, da v3.0 alle Designschulden abgebaut hat.
+
+---
+
+## 13. Quellenverzeichnis
+
+- **RFC 3507:** ICAP Protocol Spezifikation (besonders §4.5, §4.10)
+- **RFC 7230 / 9110:** HTTP Semantics & Chunked Encoding
+- **OWASP Top 10 (2021/2025):** Security Mapping für Fail-Secure Design
+- **BSI IT-Grundschutz:** OPS.1.1.4 (Schadprogramme), APP.4.4 (Webanwendungen)
+- **PHPStan / Amp / Symfony 7.4 Docs**
+- **Repository Historie:** Review v1 & v2.1 Tasklisten (`docs/review/*`)

--- a/docs/todos/01-symfony-bundle/plan-to-symfony-bundle.md
+++ b/docs/todos/01-symfony-bundle/plan-to-symfony-bundle.md
@@ -1,0 +1,71 @@
+# Bundle-Strategie
+
+## Repo-Setup
+
+- Neues Repo `ndrstmr/icap-flow-bundle`, eigene Versionierung, Library als Hard-Dependency `"ndrstmr/icap-flow": "^3.0"`.
+- Symfony 7.4 LTS als Pflicht (Mai 2026 GA, nächste LTS bis November 2029) — kein 6.4-Backport, keine Multi-Major-Matrix. Eine LTS-Linie ist genug für Public-Sector-Adoption.
+- PHP 8.4+ identisch zur Library (kein Mehraufwand für die CI-Matrix).
+- Lizenz EUPL-1.2 identisch zur Library.
+- Bundle-Skelett: `AbstractBundle` (Symfony 6.1+ Style), nicht der alte Bundle+Extension+Configuration-Dreiklang. Das ist heute der idiomatische Weg und drückt die Konfiguration in eine einzige Klasse.
+
+## Lieferung in drei Stufen, nicht in einem Big-Bang
+
+Ich würde den 8-Item-Scope auf drei Releases verteilen, damit jeder Release einzeln review- und produktionsreif ist.
+
+### v0.1.0 — Minimum Viable Bundle (Ziel: 2-3 Sessions Arbeit)
+
+Das absolute Kern-Pattern, das einem Anwender erlaubt, in `config/packages/icap_flow.yaml` zu konfigurieren und dann `IcapClientInterface` per autowire zu injizieren:
+
+- `IcapFlowBundle` (AbstractBundle-Style) mit Configuration-Tree:
+    - `host`, `port`, `socket_timeout`, `stream_timeout`
+    - `tls.enabled`, `tls.peer_name`, `tls.ca_file`, `tls.client_cert`, `tls.client_key` (mTLS)
+    - `virus_found_headers` (List)
+    - `limits.max_response_size`, `limits.max_header_count`, `limits.max_header_line_length`
+    - `pool.enabled` (default `true`), `pool.max_connections_per_host`, `pool.max_idle_seconds`
+    - `retry.enabled` (default `true`), `retry.max_attempts`, `retry.base_delay_seconds`, `retry.max_delay_seconds`, `retry.backoff_factor`
+    - `options_cache.enabled` (default `true`), `options_cache.adapter` (in_memory | service-id für PSR-6/PSR-16)
+- Service-Definitionen für `Config`, `AmpConnectionPool` (oder `NullConnectionPool` wenn `pool.enabled=false`), `AsyncAmpTransport`, `RequestFormatter`, `ResponseParser`, `IcapClient`, `RetryingIcapClient` (wenn enabled), `InMemoryOptionsCache`.
+- Auto-DI-Aliase: `IcapClientInterface` → `RetryingIcapClient` → inner `IcapClient` (oder `IcapClient` direkt wenn `retry.enabled=false`).
+- PSR-3-Logger via `LoggerInterface` autowire (Standard-Symfony).
+- Functional Tests mit `KernelTestCase` gegen die Test-Suite des Library-Repos.
+- README mit Quickstart + Konfigurations-Referenz.
+
+Bewusst draußen in v0.1: Multi-Client-Support, Profiler-DataCollector, Console-Commands, Validator-Constraint, Vich/Oneup-Adapter, Flex-Recipe.
+
+### v0.2.0 — Symfony-DX
+
+- Symfony Profiler DataCollector für ICAP-Aufrufe (Zeitleiste mit Method/URI/Status/Duration, Header-Inspektion, Cache-Hit-Anzeige).
+- Monolog-Channel `icap` vorgemappt.
+- Console-Commands: `icap:scan <file> [--service=]`, `icap:options [--service=]`, `icap:health` (OPTIONS-Probe als Liveness-Check).
+- Tagged-Services für Multi-Client: mehrere `icap_flow.client.<name>`-Konfigurationen, jede mit eigener Config. Auto-Wiring auf benannte Argumente (`#[Target('avscan')]`).
+
+### v0.3.0 — Application-Hooks
+
+- Validator-Constraint `#[IcapClean]` für File-Upload-Validation. Funktioniert auf `UploadedFile`, `SplFileInfo`, string-Path.
+- Adapter für VichUploaderBundle und OneupUploaderBundle als opt-in (per `composer require` + Tagging).
+- Messenger-Integration: `ScanFileMessage` + `ScanFileHandler` als Templates für async Scanning.
+
+Nach v0.3.0 ginge es auf v1.0.0 mit eingefrorenem API. Davor sind 0.x-Releases als »experimental contract« deklariert (semver-konform: 0.x darf brechen).
+
+## Zeitplan-Empfehlung
+
+- v0.1.0 in den nächsten 1–2 Wochen — solange v3.0.0 frisch ist und der API-Vertrag hell vor Augen.
+- Nach v0.1.0 — drei Audit-Wochen warten, bis die Library-Reviews durch sind. Falls die Audits Findings für die Library bringen, kommen die in eine 3.0.x und das Bundle bleibt auf `^3.0` stehen ohne Bruch.
+- v0.2.0 und v0.3.0 dann nach Bedarf, abhängig davon, was Frühnutzer an Symfony-DX vermissen.
+
+## Tooling-Disziplin
+
+Identisch zur Library — keine Sonderwege:
+
+- PHPStan Level 9 + bleedingEdge, keine Baseline.
+- PHP-CS-Fixer mit dem gleichen `.php-cs-fixer.dist.php` wie die Library (EUPL-Header inkl.).
+- PHPUnit / Pest für Tests; `KernelTestCase` + Symfony's BrowserKit wo nötig.
+- CI-Matrix PHP 8.4 + 8.5, Symfony 7.4 (eine Spalte; LTS-only).
+- Keine Mutation-Tests im Bundle — die sind in der Library, das Bundle ist im Wesentlichen DI-Verdrahtung.
+- Conventional Commits, Keep-a-Changelog, dieselbe Commit-/PR-Disziplin (Memory-Items gelten genauso).
+
+## Was ich nicht machen würde
+
+- Kein »icap-flow-bundle als Monorepo-Subdirectory«. Library und Bundle haben unterschiedliche Release-Zyklen — Bundle bricht öfter, Library möglichst nie. Separates Repo, separate SemVer.
+- Keine vorzeitige Symfony-6.4-Unterstützung. Wenn ein Public-Sector-Anwender 6.4 braucht, kann er auf v0.x pinnen, das wird sowieso BC-stabil bleiben innerhalb der Linie. Die Wartungslast einer Multi-Major-Matrix ist es nicht wert, bevor Frühnutzer das aktiv anfragen.
+- Kein eigener Audit-Prompt für das Bundle in v0.1. Der Library-Prompt deckt die DI-Readiness der Library ab; das Bundle ist DI-Glue ohne neue Security-Properties. Audit-Würdigkeit kommt erst zu v1.0.


### PR DESCRIPTION
## Context

Three independent production-readiness audits for v3.0.0 (Claude, Codex, Jules) have been completed. This PR adds the raw audit reports, the consolidated task list synthesizing all findings into a prioritized roadmap, and the planning document for the upcoming `ndrstmr/icap-flow-bundle` repo.

Relates to the v3.0.x/v3.1.0 roadmap items defined in `docs/review/review_v2-1/consolidated_v2.1_task-list.md` (Milestone v3.0.0, Finding Z1 — Symfony-Bundle).

## API

none — documentation only.

## Behaviour

No runtime behaviour change. Establishes the v3.0.1 patch scope (4 P1 findings: status-backstop, IcapTimeoutException dead code, Host-header hijack, coverage hotspots) and confirms the bundle roadmap.

## Refactoring

none

## Tests

none — no code changes.

## Verification

- [x] `composer cs-check` — no PHP files added
- [x] `composer stan` — no PHP files added
- [x] `composer test` — no PHP files added
- [x] CI-Matrix (PHP 8.4 + 8.5) — docs-only, no test impact

## Status

After merge:
- v3.0.1 patch work begins (Findings J, O, P from consolidated task list)
- Bundle repo `ndrstmr/icap-flow-bundle` can be initialized against `^3.0`
- Remote audit branches (`codex/conduct-technical-audit-*`, `jules-*`) can be deleted